### PR TITLE
GH-43: Secrets management and key generation scripts

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,59 @@
+# Auth Service — Production Environment
+# Copy to .env.production and fill in real values
+# NEVER commit the actual .env.production file
+
+# ── Server ──────────────────────────────────────────
+APP_ENV=production
+PUBLIC_PORT=4000
+ADMIN_PORT=4001
+LOG_LEVEL=info
+
+# ── PostgreSQL ──────────────────────────────────────
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+POSTGRES_DB=auth_production
+POSTGRES_USER=CHANGE_ME_production_db_user
+POSTGRES_PASSWORD=CHANGE_ME_production_db_password
+POSTGRES_SSLMODE=require
+POSTGRES_MAX_CONNS=25
+
+# ── Redis ───────────────────────────────────────────
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_PASSWORD=CHANGE_ME_production_redis_password
+REDIS_DB=0
+
+# ── JWT / Token Signing ─────────────────────────────
+# Path to ES256 or EdDSA private key (PEM)
+JWT_PRIVATE_KEY_PATH=/run/secrets/jwt_private_key
+JWT_ALGORITHM=ES256
+ACCESS_TOKEN_TTL=15m
+REFRESH_TOKEN_TTL=7d
+
+# ── System Secrets ──────────────────────────────────
+# Comma-separated; newest first for rotation
+SYSTEM_SECRETS=CHANGE_ME_production_system_secret_1
+
+# ── Password Hashing (Argon2id) ────────────────────
+ARGON2_MEMORY=19456
+ARGON2_TIME=2
+ARGON2_PARALLELISM=1
+PASSWORD_PEPPER=CHANGE_ME_production_pepper
+
+# ── Rate Limiting ───────────────────────────────────
+RATE_LIMIT_RPS=50
+RATE_LIMIT_BURST=100
+
+# ── TLS ─────────────────────────────────────────────
+# TLS terminated by Caddy; internal traffic is plaintext over Docker network
+TLS_ENABLED=false
+
+# ── CORS ────────────────────────────────────────────
+CORS_ALLOWED_ORIGINS=https://quantflow.studio
+
+# ── Caddy (reverse proxy) ──────────────────────────
+AUTH_SERVICE_IMAGE=ghcr.io/qf-studio/auth-service:latest
+TLS_EMAIL=admin@quantflow.studio
+AUTH_PUBLIC_DOMAIN=auth.quantflow.studio
+AUTH_ADMIN_DOMAIN=auth-admin.quantflow.studio
+ADMIN_ALLOWED_IPS=10.0.0.0/8

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -1,0 +1,50 @@
+# Auth Service — Staging Environment
+# Copy to .env.staging and fill in real values
+
+# ── Server ──────────────────────────────────────────
+APP_ENV=staging
+PUBLIC_PORT=4000
+ADMIN_PORT=4001
+LOG_LEVEL=debug
+
+# ── PostgreSQL ──────────────────────────────────────
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+POSTGRES_DB=auth_staging
+POSTGRES_USER=auth_user
+POSTGRES_PASSWORD=CHANGE_ME_staging_db_password
+POSTGRES_SSLMODE=disable
+POSTGRES_MAX_CONNS=10
+
+# ── Redis ───────────────────────────────────────────
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_PASSWORD=CHANGE_ME_staging_redis_password
+REDIS_DB=0
+
+# ── JWT / Token Signing ─────────────────────────────
+# Path to ES256 or EdDSA private key (PEM)
+JWT_PRIVATE_KEY_PATH=/run/secrets/jwt_private_key
+JWT_ALGORITHM=ES256
+ACCESS_TOKEN_TTL=15m
+REFRESH_TOKEN_TTL=24h
+
+# ── System Secrets ──────────────────────────────────
+# Comma-separated; newest first for rotation
+SYSTEM_SECRETS=CHANGE_ME_staging_system_secret_1
+
+# ── Password Hashing (Argon2id) ────────────────────
+ARGON2_MEMORY=19456
+ARGON2_TIME=2
+ARGON2_PARALLELISM=1
+PASSWORD_PEPPER=CHANGE_ME_staging_pepper
+
+# ── Rate Limiting ───────────────────────────────────
+RATE_LIMIT_RPS=20
+RATE_LIMIT_BURST=40
+
+# ── TLS ─────────────────────────────────────────────
+TLS_ENABLED=false
+
+# ── CORS ────────────────────────────────────────────
+CORS_ALLOWED_ORIGINS=https://staging.quantflow.studio

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ coverage.out
 .env
 .env.local
 .env.*.local
+.env.staging
+.env.production
 
 # IDE
 .idea/

--- a/deployments/Caddyfile
+++ b/deployments/Caddyfile
@@ -1,0 +1,64 @@
+{
+	# Global options
+	email {$TLS_EMAIL:admin@example.com}
+}
+
+# Public API — port 4000
+{$AUTH_PUBLIC_DOMAIN:auth.example.com} {
+	# Security headers
+	header {
+		Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "DENY"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		Content-Security-Policy "default-src 'none'; frame-ancestors 'none'"
+		X-XSS-Protection "0"
+		-Server
+	}
+
+	reverse_proxy auth-service:4000 {
+		health_uri /health
+		health_interval 15s
+		health_timeout 5s
+	}
+
+	log {
+		output file /data/logs/public-access.log {
+			roll_size 10mb
+			roll_keep 5
+		}
+		format json
+	}
+}
+
+# Admin API — port 4001 (restricted access)
+{$AUTH_ADMIN_DOMAIN:auth-admin.example.com} {
+	# Security headers
+	header {
+		Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "DENY"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		Content-Security-Policy "default-src 'none'; frame-ancestors 'none'"
+		X-XSS-Protection "0"
+		-Server
+	}
+
+	# Restrict admin to allowed IP ranges
+	@blocked not remote_ip {$ADMIN_ALLOWED_IPS:10.0.0.0/8 172.16.0.0/12 192.168.0.0/16}
+	respond @blocked 403
+
+	reverse_proxy auth-service:4001 {
+		health_uri /health
+		health_interval 15s
+		health_timeout 5s
+	}
+
+	log {
+		output file /data/logs/admin-access.log {
+			roll_size 10mb
+			roll_keep 5
+		}
+		format json
+	}
+}

--- a/deployments/docker-compose.production.yml
+++ b/deployments/docker-compose.production.yml
@@ -1,0 +1,168 @@
+services:
+  auth-service:
+    image: ${AUTH_SERVICE_IMAGE:?AUTH_SERVICE_IMAGE is required}
+    restart: always
+    env_file:
+      - ../.env.production
+    ports:
+      - "127.0.0.1:4000:4000"
+      - "127.0.0.1:4001:4001"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 1G
+        reservations:
+          cpus: "0.5"
+          memory: 256M
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    read_only: true
+    tmpfs:
+      - /tmp:size=64M
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - auth-net
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+  postgres:
+    image: postgres:16-alpine
+    restart: always
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-auth_production}
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER is required}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+    # No exposed ports — accessible only via auth-net
+    volumes:
+      - pg-data:/var/lib/postgresql/data
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 1G
+        reservations:
+          cpus: "0.5"
+          memory: 256M
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB:-auth_production}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    read_only: true
+    tmpfs:
+      - /tmp:size=64M
+      - /run/postgresql:size=16M
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - auth-net
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+  redis:
+    image: redis:7-alpine
+    restart: always
+    command: >-
+      redis-server
+      --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD is required}
+      --maxmemory 256mb
+      --maxmemory-policy allkeys-lru
+      --appendonly yes
+      --appendfsync everysec
+    # No exposed ports — accessible only via auth-net
+    volumes:
+      - redis-data:/data
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 512M
+        reservations:
+          cpus: "0.25"
+          memory: 128M
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    read_only: true
+    tmpfs:
+      - /tmp:size=16M
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - auth-net
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+  caddy:
+    image: caddy:2-alpine
+    restart: always
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      auth-service:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 256M
+        reservations:
+          cpus: "0.1"
+          memory: 64M
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:80"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    read_only: true
+    tmpfs:
+      - /tmp:size=16M
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - auth-net
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+volumes:
+  pg-data:
+  redis-data:
+  caddy-data:
+  caddy-config:
+
+networks:
+  auth-net:
+    driver: bridge

--- a/deployments/docker-compose.staging.yml
+++ b/deployments/docker-compose.staging.yml
@@ -1,0 +1,93 @@
+services:
+  auth-service:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    restart: unless-stopped
+    env_file:
+      - ../.env.staging
+    ports:
+      - "4000:4000"
+      - "4001:4001"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 512M
+        reservations:
+          cpus: "0.25"
+          memory: 128M
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4000/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    networks:
+      - auth-net
+
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-auth_staging}
+      POSTGRES_USER: ${POSTGRES_USER:-auth_user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+    ports:
+      - "5432:5432"
+    volumes:
+      - pg-data:/var/lib/postgresql/data
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 512M
+        reservations:
+          cpus: "0.25"
+          memory: 128M
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-auth_user} -d ${POSTGRES_DB:-auth_staging}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - auth-net
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: redis-server --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD is required} --maxmemory 128mb --maxmemory-policy allkeys-lru
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 256M
+        reservations:
+          cpus: "0.1"
+          memory: 64M
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    networks:
+      - auth-net
+
+volumes:
+  pg-data:
+  redis-data:
+
+networks:
+  auth-net:
+    driver: bridge

--- a/scripts/generate-keys.sh
+++ b/scripts/generate-keys.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# generate-keys.sh — Generate ES256 EC key pair for JWT signing
+#
+# Usage:
+#   ./scripts/generate-keys.sh [OPTIONS]
+#
+# Options:
+#   --out-dir DIR    Output directory for key files (default: ./keys)
+#   --name NAME      Base name for key files (default: jwt)
+#   --force          Overwrite existing key files
+#   --help           Show this help message
+#
+# Output files:
+#   <name>.private.pem   EC private key (P-256, PKCS#8)
+#   <name>.public.pem    EC public key (SPKI)
+#
+# Environment variables produced (print to stdout for sourcing):
+#   JWT_PRIVATE_KEY_FILE   Path to private key file
+#   JWT_PUBLIC_KEY_FILE    Path to public key file
+
+set -euo pipefail
+
+OUT_DIR="./keys"
+NAME="jwt"
+FORCE=false
+
+usage() {
+    sed -n '/^# Usage:/,/^[^#]/p' "$0" | grep '^#' | sed 's/^# \?//'
+    exit 0
+}
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --out-dir) OUT_DIR="$2"; shift 2 ;;
+        --name)    NAME="$2";    shift 2 ;;
+        --force)   FORCE=true;   shift   ;;
+        --help|-h) usage ;;
+        *) die "Unknown option: $1" ;;
+    esac
+done
+
+# Verify openssl is available
+command -v openssl >/dev/null 2>&1 || die "openssl is required but not found in PATH"
+
+PRIVATE_KEY="$OUT_DIR/$NAME.private.pem"
+PUBLIC_KEY="$OUT_DIR/$NAME.public.pem"
+
+# Check for existing files
+if [[ "$FORCE" == false ]]; then
+    for f in "$PRIVATE_KEY" "$PUBLIC_KEY"; do
+        if [[ -e "$f" ]]; then
+            die "File already exists: $f (use --force to overwrite)"
+        fi
+    done
+fi
+
+mkdir -p "$OUT_DIR"
+chmod 700 "$OUT_DIR"
+
+echo "Generating ES256 EC key pair (P-256)..." >&2
+
+# Generate private key (PKCS#8 format)
+openssl genpkey -algorithm EC \
+    -pkeyopt ec_paramgen_curve:P-256 \
+    -out "$PRIVATE_KEY" 2>/dev/null
+
+chmod 600 "$PRIVATE_KEY"
+
+# Extract public key
+openssl pkey -pubout -in "$PRIVATE_KEY" -out "$PUBLIC_KEY" 2>/dev/null
+
+chmod 644 "$PUBLIC_KEY"
+
+echo "Validating generated keys..." >&2
+
+# Validate: check key type and curve
+CURVE=$(openssl pkey -noout -text -in "$PRIVATE_KEY" 2>/dev/null | grep -i "NIST P-256\|prime256v1\|P-256" | head -1)
+if [[ -z "$CURVE" ]]; then
+    # Try alternate detection
+    KEY_INFO=$(openssl pkey -noout -text -in "$PRIVATE_KEY" 2>/dev/null)
+    if ! echo "$KEY_INFO" | grep -qi "256\|prime256"; then
+        die "Key validation failed: expected P-256 curve"
+    fi
+fi
+
+# Validate: sign and verify a test message
+TEST_MSG=$(mktemp)
+TEST_SIG=$(mktemp)
+TEST_VERIFY=$(mktemp)
+echo "validation-test" > "$TEST_MSG"
+
+openssl dgst -sha256 -sign "$PRIVATE_KEY" -out "$TEST_SIG" "$TEST_MSG" 2>/dev/null
+VERIFY_RESULT=$(openssl dgst -sha256 -verify "$PUBLIC_KEY" -signature "$TEST_SIG" "$TEST_MSG" 2>/dev/null)
+
+rm -f "$TEST_MSG" "$TEST_SIG" "$TEST_VERIFY"
+
+if [[ "$VERIFY_RESULT" != "Verified OK" ]]; then
+    die "Key validation failed: sign/verify round-trip unsuccessful"
+fi
+
+echo "" >&2
+echo "Keys generated and validated successfully:" >&2
+echo "  Private key: $PRIVATE_KEY" >&2
+echo "  Public key:  $PUBLIC_KEY" >&2
+echo "" >&2
+echo "Environment variables (add to .env):" >&2
+echo "  JWT_PRIVATE_KEY_FILE=$PRIVATE_KEY" >&2
+echo "  JWT_PUBLIC_KEY_FILE=$PUBLIC_KEY" >&2

--- a/scripts/generate-secret.sh
+++ b/scripts/generate-secret.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# generate-secret.sh — Generate cryptographically secure random secrets
+#
+# Usage:
+#   ./scripts/generate-secret.sh [OPTIONS]
+#
+# Options:
+#   --name NAME      Variable name to use in output (default: SECRET)
+#   --bytes N        Number of random bytes (default: 32, produces 64 hex chars)
+#   --format FORMAT  Output format: hex (default), base64, base64url
+#   --out FILE       Append export line to file instead of stdout
+#   --force          Overwrite existing entry in --out file
+#   --help           Show this help message
+#
+# Examples:
+#   # Generate HMAC pepper
+#   ./scripts/generate-secret.sh --name HMAC_PEPPER
+#
+#   # Generate session secret (URL-safe base64)
+#   ./scripts/generate-secret.sh --name SESSION_SECRET --format base64url
+#
+#   # Append to .env file
+#   ./scripts/generate-secret.sh --name HMAC_PEPPER --out .env
+
+set -euo pipefail
+
+NAME="SECRET"
+BYTES=32
+FORMAT="hex"
+OUT_FILE=""
+FORCE=false
+
+usage() {
+    sed -n '/^# Usage:/,/^[^#]/p' "$0" | grep '^#' | sed 's/^# \?//'
+    exit 0
+}
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --name)   NAME="$2";     shift 2 ;;
+        --bytes)  BYTES="$2";    shift 2 ;;
+        --format) FORMAT="$2";   shift 2 ;;
+        --out)    OUT_FILE="$2"; shift 2 ;;
+        --force)  FORCE=true;    shift   ;;
+        --help|-h) usage ;;
+        *) die "Unknown option: $1" ;;
+    esac
+done
+
+# Validate bytes is a positive integer
+[[ "$BYTES" =~ ^[1-9][0-9]*$ ]] || die "--bytes must be a positive integer"
+
+# Validate format
+case "$FORMAT" in
+    hex|base64|base64url) ;;
+    *) die "--format must be one of: hex, base64, base64url" ;;
+esac
+
+# Generate random bytes using /dev/urandom (preferred) or openssl fallback
+generate_random() {
+    local bytes="$1"
+    if [[ -r /dev/urandom ]]; then
+        dd if=/dev/urandom bs=1 count="$bytes" 2>/dev/null | od -An -tx1 | tr -d ' \n'
+    elif command -v openssl >/dev/null 2>&1; then
+        openssl rand -hex "$bytes"
+    else
+        die "No entropy source available: /dev/urandom not readable and openssl not found"
+    fi
+}
+
+# Generate raw hex bytes
+HEX_BYTES=$(generate_random "$BYTES")
+
+# Format output
+case "$FORMAT" in
+    hex)
+        SECRET="$HEX_BYTES"
+        ;;
+    base64)
+        SECRET=$(echo "$HEX_BYTES" | xxd -r -p 2>/dev/null | base64)
+        if [[ -z "$SECRET" ]]; then
+            # xxd fallback via openssl
+            SECRET=$(openssl rand -base64 "$BYTES")
+        fi
+        ;;
+    base64url)
+        SECRET=$(echo "$HEX_BYTES" | xxd -r -p 2>/dev/null | base64 | tr '+/' '-_' | tr -d '=')
+        if [[ -z "$SECRET" ]]; then
+            SECRET=$(openssl rand -base64 "$BYTES" | tr '+/' '-_' | tr -d '=')
+        fi
+        ;;
+esac
+
+EXPORT_LINE="$NAME=$SECRET"
+
+if [[ -z "$OUT_FILE" ]]; then
+    echo "$EXPORT_LINE"
+else
+    # Check if variable already exists in file
+    if [[ -f "$OUT_FILE" ]] && grep -q "^$NAME=" "$OUT_FILE"; then
+        if [[ "$FORCE" == false ]]; then
+            die "$NAME already set in $OUT_FILE (use --force to overwrite)"
+        fi
+        # Replace existing line (grep -v exits 1 when no lines pass the filter, hence || true)
+        TMP=$(mktemp)
+        grep -v "^$NAME=" "$OUT_FILE" > "$TMP" || true
+        echo "$EXPORT_LINE" >> "$TMP"
+        cp "$TMP" "$OUT_FILE"
+        echo "Updated $NAME in $OUT_FILE" >&2
+    else
+        echo "$EXPORT_LINE" >> "$OUT_FILE"
+        echo "Appended $NAME to $OUT_FILE" >&2
+    fi
+fi


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-43.

Closes #43

## Changes

Create `scripts/generate-keys.sh` (generates ES256 EC key pair for JWT signing, outputs PEM files, validates with openssl), `scripts/generate-secret.sh` (generates cryptographically secure random secrets for HMAC pepper, session secrets, etc., using /dev/urandom or openssl). Both scripts should be idempotent, refuse to overwrite existing keys without `--force`, and print clear usage instructions.