### PR TITLE
GH-37: golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,114 @@
+# golangci-lint v2 configuration for auth-service
+# https://golangci-lint.run/usage/configuration/
+
+version: "2"
+
+run:
+  timeout: 5m
+  modules-download-mode: readonly
+
+linters:
+  default: none
+  enable:
+    # Default
+    - errcheck
+    - govet
+    - staticcheck
+    - unused
+    - ineffassign
+
+    # Style
+    - misspell
+    - revive
+
+    # Security
+    - gosec
+    - gocritic
+
+    # Performance
+    - prealloc
+    - bodyclose
+
+    # Complexity
+    - gocyclo
+    - funlen
+
+  settings:
+    gocyclo:
+      min-complexity: 15
+
+    funlen:
+      lines: 100
+      statements: 60
+
+    gosec:
+      excludes:
+        - G104 # Duplicates errcheck
+
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - style
+        - performance
+      disabled-checks:
+        - hugeParam # Too noisy for request/response structs
+
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: exported
+        - name: increment-decrement
+        - name: var-naming
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: indent-error-flow
+        - name: errorf
+        - name: empty-block
+        - name: superfluous-else
+        - name: unreachable-code
+
+    misspell:
+      locale: US
+
+  exclusions:
+    rules:
+      # Test files can have longer functions
+      - path: _test\.go
+        linters:
+          - funlen
+          - gocyclo
+
+      # Test files can use dot imports for testify
+      - path: _test\.go
+        text: "dot-imports"
+
+      # Package name "api" is intentional for the API layer
+      - path: internal/api/
+        text: "avoid meaningless package names"
+        linters:
+          - revive
+
+      # Generated code
+      - path: ".*\\.pb\\.go"
+        linters:
+          - govet
+          - revive
+          - gocritic
+
+    max-issues-per-linter: 0
+    max-same-issues: 0
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes: github.com/qf-studio/auth-service

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.PHONY: build test lint fmt clean
+
+# Build
+build:
+	go build -o bin/auth-service cmd/server/main.go
+
+# Test
+test:
+	go test -race ./...
+
+test-cover:
+	go test -race -coverprofile=coverage.out ./...
+	go tool cover -html=coverage.out -o coverage.html
+
+# Lint
+lint:
+	golangci-lint run
+
+lint-fix:
+	golangci-lint run --fix
+
+# Format
+fmt:
+	go fmt ./...
+	goimports -w .
+
+# Clean
+clean:
+	rm -rf bin/ coverage.out coverage.html

--- a/internal/api/auth_handlers.go
+++ b/internal/api/auth_handlers.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+
 	"github.com/qf-studio/auth-service/internal/domain"
 )
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
+
 	"github.com/qf-studio/auth-service/internal/domain"
 )
 
@@ -51,10 +52,8 @@ func NewPublicRouter(svc *Services, mw *MiddlewareStack) *gin.Engine {
 		auth.POST("/revoke", validateReq(v, &domain.RevokeRequest{}), tokenH.Revoke)
 
 		pw := auth.Group("/password")
-		{
-			pw.POST("/reset", validateReq(v, &domain.PasswordResetRequest{}), authH.ResetPassword)
-			pw.POST("/reset/confirm", validateReq(v, &domain.PasswordResetConfirmRequest{}), authH.ConfirmPasswordReset)
-		}
+		pw.POST("/reset", validateReq(v, &domain.PasswordResetRequest{}), authH.ResetPassword)
+		pw.POST("/reset/confirm", validateReq(v, &domain.PasswordResetConfirmRequest{}), authH.ConfirmPasswordReset)
 	}
 
 	// Protected auth routes (require auth middleware).
@@ -62,12 +61,10 @@ func NewPublicRouter(svc *Services, mw *MiddlewareStack) *gin.Engine {
 	if mw != nil && mw.Auth != nil {
 		protected.Use(mw.Auth)
 	}
-	{
-		protected.GET("/me", authH.Me)
-		protected.PUT("/me/password", validateReq(v, &domain.PasswordChangeRequest{}), authH.ChangePassword)
-		protected.POST("/logout", authH.Logout)
-		protected.POST("/logout/all", authH.LogoutAll)
-	}
+	protected.GET("/me", authH.Me)
+	protected.PUT("/me/password", validateReq(v, &domain.PasswordChangeRequest{}), authH.ChangePassword)
+	protected.POST("/logout", authH.Logout)
+	protected.POST("/logout/all", authH.LogoutAll)
 
 	return r
 }

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -10,10 +10,11 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/qf-studio/auth-service/internal/api"
-	"github.com/qf-studio/auth-service/internal/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/domain"
 )
 
 func init() {
@@ -23,14 +24,14 @@ func init() {
 // --- Mock services ---
 
 type mockAuthService struct {
-	registerFn            func(ctx context.Context, email, password, name string) (*api.UserInfo, error)
-	loginFn               func(ctx context.Context, email, password string) (*api.AuthResult, error)
-	resetPasswordFn       func(ctx context.Context, email string) error
+	registerFn             func(ctx context.Context, email, password, name string) (*api.UserInfo, error)
+	loginFn                func(ctx context.Context, email, password string) (*api.AuthResult, error)
+	resetPasswordFn        func(ctx context.Context, email string) error
 	confirmPasswordResetFn func(ctx context.Context, token, newPassword string) error
-	getMeFn               func(ctx context.Context, userID string) (*api.UserInfo, error)
-	changePasswordFn      func(ctx context.Context, userID, oldPassword, newPassword string) error
-	logoutFn              func(ctx context.Context, userID, token string) error
-	logoutAllFn           func(ctx context.Context, userID string) error
+	getMeFn                func(ctx context.Context, userID string) (*api.UserInfo, error)
+	changePasswordFn       func(ctx context.Context, userID, oldPassword, newPassword string) error
+	logoutFn               func(ctx context.Context, userID, token string) error
+	logoutAllFn            func(ctx context.Context, userID string) error
 }
 
 func (m *mockAuthService) Register(ctx context.Context, email, password, name string) (*api.UserInfo, error) {
@@ -167,7 +168,7 @@ func doRequest(router *gin.Engine, method, path string, body interface{}, header
 		req = httptest.NewRequest(method, path, jsonBody(body))
 		req.Header.Set("Content-Type", "application/json")
 	} else {
-		req = httptest.NewRequest(method, path, nil)
+		req = httptest.NewRequest(method, path, http.NoBody)
 	}
 	for i := 0; i+1 < len(headers); i += 2 {
 		req.Header.Set(headers[i], headers[i+1])

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -54,9 +54,9 @@ type Services struct {
 
 // MiddlewareStack holds middleware handler functions used by the router.
 type MiddlewareStack struct {
-	CorrelationID gin.HandlerFunc
+	CorrelationID   gin.HandlerFunc
 	SecurityHeaders gin.HandlerFunc
-	RateLimit     gin.HandlerFunc
-	RequestSize   gin.HandlerFunc
-	Auth          gin.HandlerFunc
+	RateLimit       gin.HandlerFunc
+	RequestSize     gin.HandlerFunc
+	Auth            gin.HandlerFunc
 }

--- a/internal/api/token_handlers.go
+++ b/internal/api/token_handlers.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+
 	"github.com/qf-studio/auth-service/internal/domain"
 )
 

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -31,7 +31,7 @@ type ValidationErrorDetail struct {
 }
 
 // RespondWithError writes a structured JSON error response and aborts the Gin context.
-func RespondWithError(c *gin.Context, status int, code string, message string) {
+func RespondWithError(c *gin.Context, status int, code, message string) {
 	c.AbortWithStatusJSON(status, ErrorResponse{
 		Error: message,
 		Code:  code,

--- a/internal/domain/errors_test.go
+++ b/internal/domain/errors_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/qf-studio/auth-service/internal/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/domain"
 )
 
 func init() {

--- a/internal/domain/validation_test.go
+++ b/internal/domain/validation_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/qf-studio/auth-service/internal/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/domain"
 )
 
 func TestNewValidator_NistPassword(t *testing.T) {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-37.

Closes #37

## Changes

GitHub Issue #37: golangci-lint configuration

# TASK-37: golangci-lint Configuration

**Status**: 🚧 In Progress
**Created**: 2026-02-24

---

## Context

**Problem**: No linting rules defined. Code quality enforcement depends on individual discipline.

**Goal**: golangci-lint configuration enforcing consistent code quality, security checks, and Go best practices.

**Success Criteria**:
- [ ] `.golangci.yml` with curated linter set
- [ ] Security-focused linters enabled (gosec, gocritic)
- [ ] Zero lint errors on clean codebase
- [ ] Integrated into Makefile and CI

---

## Implementation Plan

### Phase 1: Linter Config
**Tasks**:
- [ ] `.golangci.yml` with linters:
  - **Default**: errcheck, govet, staticcheck, unused, ineffassign
  - **Style**: gofmt, goimports, misspell, revive
  - **Security**: gosec, gocritic
  - **Performance**: prealloc, bodyclose
  - **Complexity**: gocyclo (max 15), funlen (max 100)
- [ ] Exclude patterns for generated code, test files where appropriate
- [ ] Timeout: 5 minutes (for CI)

**Files**:
- `.golangci.yml`

### Phase 2: Integration
**Tasks**:
- [ ] Makefile target: `lint: golangci-lint run`
- [ ] CI workflow uses golangci-lint GitHub Action
- [ ] Pre-commit hook (optional): `make lint`

---

## Dependencies

**Requires**: #1 (scaffold)
**Blocks**: #36 (CI needs lint config)

---

## Done

- [ ] `.golangci.yml` exists with security + style + performance linters
- [ ] `make lint` runs without errors on clean codebase
- [ ] CI uses the same config

---

**Last Updated**: 2026-02-24
