### PR TITLE
GH-56: CI validation with Spectral

### DIFF
--- a/.github/workflows/spectral.yml
+++ b/.github/workflows/spectral.yml
@@ -1,0 +1,27 @@
+name: OpenAPI Lint
+
+on:
+  pull_request:
+    paths:
+      - 'api/**'
+      - '.spectral.yaml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'api/**'
+      - '.spectral.yaml'
+
+jobs:
+  spectral:
+    name: Spectral OpenAPI Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Spectral
+        uses: stoplightio/spectral-action@latest
+        with:
+          file_glob: 'api/*.openapi.yaml'
+          spectral_ruleset: '.spectral.yaml'

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,21 @@
+extends:
+  - spectral:oas
+
+rules:
+  # Require all operations to have operationId
+  operation-operationId: error
+
+  # Require all operations to have at least one tag
+  operation-tags: error
+
+  # Require info object to have contact
+  info-contact: warn
+
+  # Require all parameters to have descriptions
+  operation-parameters: error
+
+  # Require response bodies to have examples
+  oas3-valid-media-example: error
+
+  # Require descriptions on all schema properties
+  oas3-schema: error


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-56.

Closes #56

## Changes

GitHub Issue #56: CI validation with Spectral

Parent: GH-39

Add `.spectral.yaml` ruleset config at the repo root and a GitHub Actions workflow step (`.github/workflows/`) that runs `spectral lint api/*.openapi.yaml` on every PR. Ensures specs stay valid and consistent as the API evolves. Touches `.github/workflows/` and root config only.