### PR TITLE
GH-55: Go embed and spec-serving handlers

### DIFF
--- a/api/admin.openapi.yaml
+++ b/api/admin.openapi.yaml
@@ -1,0 +1,39 @@
+openapi: "3.1.0"
+info:
+  title: Auth Service — Admin API
+  version: 0.1.0
+  description: >
+    Administrative endpoints for the QuantFlow Studio auth service.
+    Accessible only on the admin port (4001) via network-level isolation.
+  contact:
+    name: QuantFlow Studio
+    url: https://quantflow.studio
+  license:
+    name: Proprietary
+servers:
+  - url: http://localhost:4001
+    description: Local development (admin port)
+
+paths:
+  /admin/health:
+    get:
+      operationId: adminHealth
+      summary: Admin health check
+      tags: [Health]
+      responses:
+        "200":
+          description: Admin service is healthy
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+
+components:
+  schemas:
+    HealthResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: ok
+      required: [status]

--- a/api/public.openapi.yaml
+++ b/api/public.openapi.yaml
@@ -1,0 +1,373 @@
+openapi: "3.1.0"
+info:
+  title: Auth Service — Public API
+  version: 0.1.0
+  description: >
+    Authentication and authorization endpoints for the QuantFlow Studio ecosystem.
+    Serves Users (humans) and Systems (services + AI agents).
+  contact:
+    name: QuantFlow Studio
+    url: https://quantflow.studio
+  license:
+    name: Proprietary
+servers:
+  - url: https://auth.quantflow.studio
+    description: Production
+  - url: http://localhost:4000
+    description: Local development
+
+paths:
+  /health:
+    get:
+      operationId: getHealth
+      summary: Health check
+      tags: [Health]
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+
+  /auth/register:
+    post:
+      operationId: register
+      summary: Register a new user
+      tags: [Auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisterRequest"
+      responses:
+        "201":
+          description: User created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserInfo"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "409":
+          description: Email already registered
+
+  /auth/login:
+    post:
+      operationId: login
+      summary: Authenticate with email and password
+      tags: [Auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LoginRequest"
+      responses:
+        "200":
+          description: Authentication successful
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthResult"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /auth/token:
+    post:
+      operationId: token
+      summary: Exchange refresh token or client credentials for a new access token
+      tags: [Auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TokenRequest"
+      responses:
+        "200":
+          description: Token issued
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthResult"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /auth/revoke:
+    post:
+      operationId: revokeToken
+      summary: Revoke a refresh token
+      tags: [Auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RevokeRequest"
+      responses:
+        "204":
+          description: Token revoked
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  /auth/password/reset:
+    post:
+      operationId: resetPassword
+      summary: Request a password reset
+      tags: [Auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PasswordResetRequest"
+      responses:
+        "202":
+          description: Reset email sent (if account exists)
+
+  /auth/password/reset/confirm:
+    post:
+      operationId: confirmPasswordReset
+      summary: Confirm password reset with token
+      tags: [Auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PasswordResetConfirmRequest"
+      responses:
+        "204":
+          description: Password updated
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  /auth/me:
+    get:
+      operationId: getMe
+      summary: Get current user info
+      tags: [Auth]
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Current user info
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserInfo"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /auth/me/password:
+    put:
+      operationId: changePassword
+      summary: Change current user password
+      tags: [Auth]
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PasswordChangeRequest"
+      responses:
+        "204":
+          description: Password changed
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /auth/logout:
+    post:
+      operationId: logout
+      summary: Logout current session
+      tags: [Auth]
+      security:
+        - bearerAuth: []
+      responses:
+        "204":
+          description: Logged out
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /auth/logout/all:
+    post:
+      operationId: logoutAll
+      summary: Logout all sessions
+      tags: [Auth]
+      security:
+        - bearerAuth: []
+      responses:
+        "204":
+          description: All sessions terminated
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /.well-known/jwks.json:
+    get:
+      operationId: getJWKS
+      summary: JSON Web Key Set
+      tags: [Discovery]
+      responses:
+        "200":
+          description: Public keys for token verification
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JWKSResponse"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  responses:
+    ValidationError:
+      description: Validation error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    Unauthorized:
+      description: Authentication required or invalid
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+
+  schemas:
+    HealthResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: ok
+      required: [status]
+
+    RegisterRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          minLength: 15
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+      required: [email, password, name]
+
+    LoginRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+      required: [email, password]
+
+    TokenRequest:
+      type: object
+      properties:
+        grant_type:
+          type: string
+          enum: [refresh_token, client_credentials]
+        refresh_token:
+          type: string
+        client_id:
+          type: string
+        client_secret:
+          type: string
+      required: [grant_type]
+
+    RevokeRequest:
+      type: object
+      properties:
+        token:
+          type: string
+      required: [token]
+
+    PasswordResetRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+      required: [email]
+
+    PasswordResetConfirmRequest:
+      type: object
+      properties:
+        token:
+          type: string
+        new_password:
+          type: string
+          minLength: 15
+      required: [token, new_password]
+
+    PasswordChangeRequest:
+      type: object
+      properties:
+        old_password:
+          type: string
+        new_password:
+          type: string
+          minLength: 15
+      required: [old_password, new_password]
+
+    UserInfo:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+          format: email
+        name:
+          type: string
+      required: [id, email, name]
+
+    AuthResult:
+      type: object
+      properties:
+        access_token:
+          type: string
+        refresh_token:
+          type: string
+        token_type:
+          type: string
+          example: Bearer
+        expires_in:
+          type: integer
+      required: [access_token, token_type, expires_in]
+
+    JWKSResponse:
+      type: object
+      properties:
+        keys:
+          type: array
+          items:
+            type: object
+
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+        code:
+          type: string
+        details:
+          type: object
+      required: [error, code]

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -1,0 +1,119 @@
+// Package docs embeds OpenAPI specifications from api/ and provides Gin handlers
+// for serving them as JSON. Specs are converted from YAML to JSON at init time.
+//
+// After modifying specs in api/, run: go generate ./internal/docs/
+package docs
+
+//go:generate sh -c "cp ../../api/*.yaml specs/"
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed specs/*.yaml
+var specsFS embed.FS
+
+var (
+	publicJSON []byte
+	adminJSON  []byte
+	initOnce   sync.Once
+	initErr    error
+)
+
+// initSpecs converts embedded YAML specs to JSON exactly once.
+func initSpecs() {
+	initOnce.Do(func() {
+		publicJSON, initErr = yamlFileToJSON("specs/public.openapi.yaml")
+		if initErr != nil {
+			initErr = fmt.Errorf("public spec: %w", initErr)
+			return
+		}
+		adminJSON, initErr = yamlFileToJSON("specs/admin.openapi.yaml")
+		if initErr != nil {
+			initErr = fmt.Errorf("admin spec: %w", initErr)
+		}
+	})
+}
+
+func yamlFileToJSON(path string) ([]byte, error) {
+	raw, err := specsFS.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	var doc interface{}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	// yaml.v3 produces map[string]interface{} by default, which encoding/json handles fine.
+	j, err := json.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("marshal %s: %w", path, err)
+	}
+	return j, nil
+}
+
+// PublicSpec returns the Gin handler for GET /docs/openapi.json.
+func PublicSpec() gin.HandlerFunc {
+	initSpecs()
+	return func(c *gin.Context) {
+		if initErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "spec unavailable"})
+			return
+		}
+		c.Data(http.StatusOK, "application/json; charset=utf-8", publicJSON)
+	}
+}
+
+// AdminSpec returns the Gin handler for GET /admin/docs/openapi.json.
+func AdminSpec() gin.HandlerFunc {
+	initSpecs()
+	return func(c *gin.Context) {
+		if initErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "spec unavailable"})
+			return
+		}
+		c.Data(http.StatusOK, "application/json; charset=utf-8", adminJSON)
+	}
+}
+
+// RedocHTML returns a Gin handler that serves a Redoc UI page pointing at the given spec URL.
+func RedocHTML(specURL string) gin.HandlerFunc {
+	page := fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<head>
+  <title>Auth Service — API Docs</title>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>body { margin: 0; padding: 0; }</style>
+</head>
+<body>
+  <redoc spec-url='%s'></redoc>
+  <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+</body>
+</html>`, specURL)
+
+	return func(c *gin.Context) {
+		c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(page))
+	}
+}
+
+// RegisterPublicRoutes adds documentation routes to a public Gin router.
+func RegisterPublicRoutes(r *gin.Engine) {
+	r.GET("/docs/openapi.json", PublicSpec())
+	r.GET("/docs", RedocHTML("/docs/openapi.json"))
+}
+
+// RegisterAdminRoutes adds documentation routes to an admin Gin router.
+func RegisterAdminRoutes(r *gin.Engine) {
+	r.GET("/admin/docs/openapi.json", AdminSpec())
+	r.GET("/admin/docs", RedocHTML("/admin/docs/openapi.json"))
+}

--- a/internal/docs/docs_test.go
+++ b/internal/docs/docs_test.go
@@ -1,0 +1,158 @@
+package docs_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/docs"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func TestPublicSpec(t *testing.T) {
+	r := gin.New()
+	r.GET("/docs/openapi.json", docs.PublicSpec())
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/docs/openapi.json", http.NoBody)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+
+	var spec map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &spec)
+	require.NoError(t, err, "response must be valid JSON")
+
+	// Verify it's the public spec.
+	info, ok := spec["info"].(map[string]interface{})
+	require.True(t, ok, "spec must have info object")
+	assert.Contains(t, info["title"], "Public")
+}
+
+func TestAdminSpec(t *testing.T) {
+	r := gin.New()
+	r.GET("/admin/docs/openapi.json", docs.AdminSpec())
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/admin/docs/openapi.json", http.NoBody)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+
+	var spec map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &spec)
+	require.NoError(t, err, "response must be valid JSON")
+
+	info, ok := spec["info"].(map[string]interface{})
+	require.True(t, ok, "spec must have info object")
+	assert.Contains(t, info["title"], "Admin")
+}
+
+func TestPublicSpecContent(t *testing.T) {
+	r := gin.New()
+	r.GET("/docs/openapi.json", docs.PublicSpec())
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/docs/openapi.json", http.NoBody)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var spec map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &spec))
+
+	// Check OpenAPI version. yaml.v3 unmarshals unquoted "3.1.0" as float64.
+	assert.Contains(t, []interface{}{"3.1.0", 3.1}, spec["openapi"])
+
+	// Check paths exist.
+	paths, ok := spec["paths"].(map[string]interface{})
+	require.True(t, ok, "spec must have paths")
+	assert.Contains(t, paths, "/auth/register")
+	assert.Contains(t, paths, "/auth/login")
+	assert.Contains(t, paths, "/.well-known/jwks.json")
+}
+
+func TestRedocHTML(t *testing.T) {
+	r := gin.New()
+	r.GET("/docs", docs.RedocHTML("/docs/openapi.json"))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/docs", http.NoBody)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
+
+	body := w.Body.String()
+	assert.True(t, strings.Contains(body, "redoc"), "page must include redoc")
+	assert.True(t, strings.Contains(body, "/docs/openapi.json"), "page must reference spec URL")
+}
+
+func TestRegisterPublicRoutes(t *testing.T) {
+	r := gin.New()
+	docs.RegisterPublicRoutes(r)
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"spec endpoint", "/docs/openapi.json"},
+		{"redoc UI", "/docs"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tt.path, http.NoBody)
+			r.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusOK, w.Code)
+		})
+	}
+}
+
+func TestRegisterAdminRoutes(t *testing.T) {
+	r := gin.New()
+	docs.RegisterAdminRoutes(r)
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"spec endpoint", "/admin/docs/openapi.json"},
+		{"redoc UI", "/admin/docs"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tt.path, http.NoBody)
+			r.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusOK, w.Code)
+		})
+	}
+}
+
+func TestSpecsAreConsistentJSON(t *testing.T) {
+	// Both specs should produce identical results on repeated calls (cached).
+	r := gin.New()
+	docs.RegisterPublicRoutes(r)
+
+	w1 := httptest.NewRecorder()
+	r.ServeHTTP(w1, httptest.NewRequest(http.MethodGet, "/docs/openapi.json", http.NoBody))
+
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, httptest.NewRequest(http.MethodGet, "/docs/openapi.json", http.NoBody))
+
+	assert.Equal(t, w1.Body.String(), w2.Body.String(), "repeated requests must return identical content")
+}

--- a/internal/docs/specs/admin.openapi.yaml
+++ b/internal/docs/specs/admin.openapi.yaml
@@ -1,0 +1,39 @@
+openapi: "3.1.0"
+info:
+  title: Auth Service — Admin API
+  version: 0.1.0
+  description: >
+    Administrative endpoints for the QuantFlow Studio auth service.
+    Accessible only on the admin port (4001) via network-level isolation.
+  contact:
+    name: QuantFlow Studio
+    url: https://quantflow.studio
+  license:
+    name: Proprietary
+servers:
+  - url: http://localhost:4001
+    description: Local development (admin port)
+
+paths:
+  /admin/health:
+    get:
+      operationId: adminHealth
+      summary: Admin health check
+      tags: [Health]
+      responses:
+        "200":
+          description: Admin service is healthy
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+
+components:
+  schemas:
+    HealthResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: ok
+      required: [status]

--- a/internal/docs/specs/public.openapi.yaml
+++ b/internal/docs/specs/public.openapi.yaml
@@ -1,0 +1,373 @@
+openapi: "3.1.0"
+info:
+  title: Auth Service — Public API
+  version: 0.1.0
+  description: >
+    Authentication and authorization endpoints for the QuantFlow Studio ecosystem.
+    Serves Users (humans) and Systems (services + AI agents).
+  contact:
+    name: QuantFlow Studio
+    url: https://quantflow.studio
+  license:
+    name: Proprietary
+servers:
+  - url: https://auth.quantflow.studio
+    description: Production
+  - url: http://localhost:4000
+    description: Local development
+
+paths:
+  /health:
+    get:
+      operationId: getHealth
+      summary: Health check
+      tags: [Health]
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+
+  /auth/register:
+    post:
+      operationId: register
+      summary: Register a new user
+      tags: [Auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisterRequest"
+      responses:
+        "201":
+          description: User created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserInfo"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "409":
+          description: Email already registered
+
+  /auth/login:
+    post:
+      operationId: login
+      summary: Authenticate with email and password
+      tags: [Auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LoginRequest"
+      responses:
+        "200":
+          description: Authentication successful
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthResult"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /auth/token:
+    post:
+      operationId: token
+      summary: Exchange refresh token or client credentials for a new access token
+      tags: [Auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TokenRequest"
+      responses:
+        "200":
+          description: Token issued
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthResult"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /auth/revoke:
+    post:
+      operationId: revokeToken
+      summary: Revoke a refresh token
+      tags: [Auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RevokeRequest"
+      responses:
+        "204":
+          description: Token revoked
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  /auth/password/reset:
+    post:
+      operationId: resetPassword
+      summary: Request a password reset
+      tags: [Auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PasswordResetRequest"
+      responses:
+        "202":
+          description: Reset email sent (if account exists)
+
+  /auth/password/reset/confirm:
+    post:
+      operationId: confirmPasswordReset
+      summary: Confirm password reset with token
+      tags: [Auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PasswordResetConfirmRequest"
+      responses:
+        "204":
+          description: Password updated
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  /auth/me:
+    get:
+      operationId: getMe
+      summary: Get current user info
+      tags: [Auth]
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Current user info
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserInfo"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /auth/me/password:
+    put:
+      operationId: changePassword
+      summary: Change current user password
+      tags: [Auth]
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PasswordChangeRequest"
+      responses:
+        "204":
+          description: Password changed
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /auth/logout:
+    post:
+      operationId: logout
+      summary: Logout current session
+      tags: [Auth]
+      security:
+        - bearerAuth: []
+      responses:
+        "204":
+          description: Logged out
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /auth/logout/all:
+    post:
+      operationId: logoutAll
+      summary: Logout all sessions
+      tags: [Auth]
+      security:
+        - bearerAuth: []
+      responses:
+        "204":
+          description: All sessions terminated
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /.well-known/jwks.json:
+    get:
+      operationId: getJWKS
+      summary: JSON Web Key Set
+      tags: [Discovery]
+      responses:
+        "200":
+          description: Public keys for token verification
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JWKSResponse"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  responses:
+    ValidationError:
+      description: Validation error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    Unauthorized:
+      description: Authentication required or invalid
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+
+  schemas:
+    HealthResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: ok
+      required: [status]
+
+    RegisterRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          minLength: 15
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+      required: [email, password, name]
+
+    LoginRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+      required: [email, password]
+
+    TokenRequest:
+      type: object
+      properties:
+        grant_type:
+          type: string
+          enum: [refresh_token, client_credentials]
+        refresh_token:
+          type: string
+        client_id:
+          type: string
+        client_secret:
+          type: string
+      required: [grant_type]
+
+    RevokeRequest:
+      type: object
+      properties:
+        token:
+          type: string
+      required: [token]
+
+    PasswordResetRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+      required: [email]
+
+    PasswordResetConfirmRequest:
+      type: object
+      properties:
+        token:
+          type: string
+        new_password:
+          type: string
+          minLength: 15
+      required: [token, new_password]
+
+    PasswordChangeRequest:
+      type: object
+      properties:
+        old_password:
+          type: string
+        new_password:
+          type: string
+          minLength: 15
+      required: [old_password, new_password]
+
+    UserInfo:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+          format: email
+        name:
+          type: string
+      required: [id, email, name]
+
+    AuthResult:
+      type: object
+      properties:
+        access_token:
+          type: string
+        refresh_token:
+          type: string
+        token_type:
+          type: string
+          example: Bearer
+        expires_in:
+          type: integer
+      required: [access_token, token_type, expires_in]
+
+    JWKSResponse:
+      type: object
+      properties:
+        keys:
+          type: array
+          items:
+            type: object
+
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+        code:
+          type: string
+        details:
+          type: object
+      required: [error, code]


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-55.

Closes #55

## Changes

GitHub Issue #55: Go embed and spec-serving handlers

Parent: GH-39

Create an `internal/docs/` package that uses `//go:embed` to embed the YAML specs from `api/`, converts them to JSON, and exposes Gin handler functions for `GET /docs/openapi.json` (public port) and `GET /admin/docs/openapi.json` (admin port). Optionally include a Swagger UI / Redoc handler at `/docs/`. This subtask touches `internal/docs/` only — route registration into the Gin routers (in `cmd/server/` or `internal/server/`) should be handled by whoever wires up the server, or as a minimal addition if the server bootstrap already exists from issue #15.