### PR TITLE
GH-9: Basic RBAC middleware

### DIFF
--- a/internal/domain/claims.go
+++ b/internal/domain/claims.go
@@ -1,0 +1,34 @@
+package domain
+
+// Client type constants for use in TokenClaims.ClientType.
+const (
+	ClientTypeUser    = "user"
+	ClientTypeService = "service"
+	ClientTypeAgent   = "agent"
+)
+
+// TokenClaims holds the parsed and validated claims from an access token.
+// It is populated by AuthMiddleware and stored in the Gin context under
+// the key "claims". Handlers retrieve it via middleware.GetClaims.
+type TokenClaims struct {
+	// Subject is the user ID (for user tokens) or client ID (for system tokens).
+	Subject string
+
+	// Roles are the roles granted to this subject (e.g., "admin", "user").
+	// Role checks use any-of semantics: access is granted if the subject holds
+	// at least one of the required roles.
+	Roles []string
+
+	// Scopes are the OAuth 2.1 scopes granted to system clients
+	// (e.g., "read:users", "write:tokens"). Scope checks use all-of semantics:
+	// all required scopes must be present.
+	Scopes []string
+
+	// ClientType identifies the kind of entity that owns this token:
+	// "user", "service", or "agent".
+	ClientType string
+
+	// TokenID is the unique identifier (jti) used for revocation checks
+	// against the Redis blocklist.
+	TokenID string
+}

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -1,0 +1,91 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// Context keys used by auth and RBAC middleware.
+const (
+	claimsContextKey = "claims"
+	userIDContextKey = "user_id"
+	accessTokenPrefix = "qf_at_"
+)
+
+// TokenValidator defines the token operations required by AuthMiddleware.
+// token.Service implements this interface.
+type TokenValidator interface {
+	// ValidateToken parses and cryptographically validates the raw token
+	// (with the qf_at_ prefix already stripped), returning its claims.
+	ValidateToken(ctx context.Context, rawToken string) (*domain.TokenClaims, error)
+
+	// IsRevoked reports whether the token identified by tokenID has been
+	// revoked (i.e., is present in the Redis blocklist).
+	IsRevoked(ctx context.Context, tokenID string) (bool, error)
+}
+
+// AuthMiddleware returns a Gin middleware that authenticates requests via
+// Bearer tokens. It:
+//
+//  1. Extracts the token from Authorization: Bearer <token>
+//  2. Verifies the qf_at_ prefix
+//  3. Validates the token via TokenValidator
+//  4. Checks the Redis revocation blocklist
+//  5. Stores *domain.TokenClaims under "claims" and the subject under "user_id"
+//
+// Returns 401 on any authentication failure.
+func AuthMiddleware(validator TokenValidator) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		raw := extractBearer(c)
+		if raw == "" {
+			domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized,
+				"missing or malformed Authorization header")
+			return
+		}
+
+		if !strings.HasPrefix(raw, accessTokenPrefix) {
+			domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized,
+				"invalid token format")
+			return
+		}
+		token := strings.TrimPrefix(raw, accessTokenPrefix)
+
+		claims, err := validator.ValidateToken(c.Request.Context(), token)
+		if err != nil {
+			domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized,
+				"invalid or expired token")
+			return
+		}
+
+		revoked, err := validator.IsRevoked(c.Request.Context(), claims.TokenID)
+		if err != nil {
+			domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized,
+				"token validation failed")
+			return
+		}
+		if revoked {
+			domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized,
+				"token has been revoked")
+			return
+		}
+
+		c.Set(claimsContextKey, claims)
+		c.Set(userIDContextKey, claims.Subject)
+		c.Next()
+	}
+}
+
+// extractBearer pulls the token value from the Authorization header.
+// Returns an empty string if the header is absent or not in Bearer format.
+func extractBearer(c *gin.Context) string {
+	auth := c.GetHeader("Authorization")
+	if len(auth) > 7 && auth[:7] == "Bearer " {
+		return auth[7:]
+	}
+	return ""
+}

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -1,0 +1,159 @@
+package middleware_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/middleware"
+)
+
+// mockValidator implements middleware.TokenValidator for testing.
+type mockValidator struct {
+	claims    *domain.TokenClaims
+	validateErr error
+	revoked   bool
+	revokeErr error
+}
+
+func (m *mockValidator) ValidateToken(_ context.Context, _ string) (*domain.TokenClaims, error) {
+	return m.claims, m.validateErr
+}
+
+func (m *mockValidator) IsRevoked(_ context.Context, _ string) (bool, error) {
+	return m.revoked, m.revokeErr
+}
+
+func newAuthTestRouter(v middleware.TokenValidator) *gin.Engine {
+	r := gin.New()
+	r.Use(middleware.AuthMiddleware(v))
+	r.GET("/protected", func(c *gin.Context) {
+		userID := c.GetString("user_id")
+		c.String(http.StatusOK, userID)
+	})
+	return r
+}
+
+func TestAuthMiddleware(t *testing.T) {
+	validClaims := &domain.TokenClaims{
+		Subject:    "user-123",
+		Roles:      []string{"user"},
+		ClientType: domain.ClientTypeUser,
+		TokenID:    "tok-abc",
+	}
+
+	tests := []struct {
+		name           string
+		authHeader     string
+		validator      *mockValidator
+		wantStatus     int
+		wantBodyContains string
+	}{
+		{
+			name:       "valid token passes, claims set in context",
+			authHeader: "Bearer qf_at_validtoken",
+			validator:  &mockValidator{claims: validClaims},
+			wantStatus: http.StatusOK,
+			wantBodyContains: "user-123",
+		},
+		{
+			name:       "missing Authorization header returns 401",
+			authHeader: "",
+			validator:  &mockValidator{claims: validClaims},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "malformed header (no Bearer) returns 401",
+			authHeader: "Token qf_at_something",
+			validator:  &mockValidator{claims: validClaims},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "token without qf_at_ prefix returns 401",
+			authHeader: "Bearer rawtoken_no_prefix",
+			validator:  &mockValidator{claims: validClaims},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "token that fails validation returns 401",
+			authHeader: "Bearer qf_at_badtoken",
+			validator:  &mockValidator{validateErr: errors.New("signature invalid")},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "revoked token returns 401",
+			authHeader: "Bearer qf_at_revokedtoken",
+			validator:  &mockValidator{claims: validClaims, revoked: true},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "revocation check error returns 401",
+			authHeader: "Bearer qf_at_token",
+			validator:  &mockValidator{claims: validClaims, revokeErr: errors.New("redis unavailable")},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "expired token (ValidateToken error) returns 401",
+			authHeader: "Bearer qf_at_expiredtoken",
+			validator:  &mockValidator{validateErr: errors.New("token expired")},
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			router := newAuthTestRouter(tc.validator)
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/protected", http.NoBody)
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+			if tc.wantBodyContains != "" {
+				assert.Contains(t, w.Body.String(), tc.wantBodyContains)
+			}
+		})
+	}
+}
+
+func TestAuthMiddleware_ClaimsStoredInContext(t *testing.T) {
+	claims := &domain.TokenClaims{
+		Subject:    "svc-456",
+		Roles:      []string{"service"},
+		Scopes:     []string{"read:users", "write:tokens"},
+		ClientType: domain.ClientTypeService,
+		TokenID:    "tok-xyz",
+	}
+	v := &mockValidator{claims: claims}
+
+	var capturedClaims *domain.TokenClaims
+	r := gin.New()
+	r.Use(middleware.AuthMiddleware(v))
+	r.GET("/check", func(c *gin.Context) {
+		got, err := middleware.GetClaims(c)
+		require.NoError(t, err)
+		capturedClaims = got
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/check", http.NoBody)
+	req.Header.Set("Authorization", "Bearer qf_at_token")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, capturedClaims)
+	assert.Equal(t, "svc-456", capturedClaims.Subject)
+	assert.Equal(t, []string{"read:users", "write:tokens"}, capturedClaims.Scopes)
+	assert.Equal(t, domain.ClientTypeService, capturedClaims.ClientType)
+}

--- a/internal/middleware/rbac.go
+++ b/internal/middleware/rbac.go
@@ -1,0 +1,111 @@
+package middleware
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// ErrNoClaims is returned by GetClaims when AuthMiddleware has not run or
+// claims are absent from the Gin context.
+var ErrNoClaims = errors.New("no token claims in context")
+
+// GetClaims retrieves the *domain.TokenClaims stored by AuthMiddleware.
+// Returns ErrNoClaims if the claims key is absent or has the wrong type.
+func GetClaims(c *gin.Context) (*domain.TokenClaims, error) {
+	raw, exists := c.Get(claimsContextKey)
+	if !exists {
+		return nil, ErrNoClaims
+	}
+	claims, ok := raw.(*domain.TokenClaims)
+	if !ok {
+		return nil, ErrNoClaims
+	}
+	return claims, nil
+}
+
+// RequireRoles returns a Gin middleware that enforces role-based access control.
+// Access is granted if the token's roles contain ANY of the specified roles
+// (any-of semantics). Returns 403 Forbidden if no role matches.
+// Returns 401 Unauthorized if AuthMiddleware has not populated claims.
+func RequireRoles(roles ...string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		claims, err := GetClaims(c)
+		if err != nil {
+			domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized,
+				"authentication required")
+			return
+		}
+
+		for _, required := range roles {
+			for _, held := range claims.Roles {
+				if held == required {
+					c.Next()
+					return
+				}
+			}
+		}
+
+		domain.RespondWithError(c, http.StatusForbidden, domain.CodeForbidden,
+			"insufficient role")
+	}
+}
+
+// RequireScopes returns a Gin middleware that enforces scope-based access control.
+// Access is granted only if the token's scopes contain ALL of the specified
+// scopes (all-of semantics). Returns 403 Forbidden if any scope is missing.
+// Returns 401 Unauthorized if AuthMiddleware has not populated claims.
+func RequireScopes(scopes ...string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		claims, err := GetClaims(c)
+		if err != nil {
+			domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized,
+				"authentication required")
+			return
+		}
+
+		held := make(map[string]struct{}, len(claims.Scopes))
+		for _, s := range claims.Scopes {
+			held[s] = struct{}{}
+		}
+
+		for _, required := range scopes {
+			if _, ok := held[required]; !ok {
+				domain.RespondWithError(c, http.StatusForbidden, domain.CodeForbidden,
+					"insufficient scope")
+				return
+			}
+		}
+
+		c.Next()
+	}
+}
+
+// RequireClientType returns a Gin middleware that restricts access to
+// specific client types. Access is granted if the token's ClientType matches
+// ANY of the specified types (any-of semantics). Returns 403 Forbidden if the
+// client type does not match.
+// Returns 401 Unauthorized if AuthMiddleware has not populated claims.
+func RequireClientType(types ...string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		claims, err := GetClaims(c)
+		if err != nil {
+			domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized,
+				"authentication required")
+			return
+		}
+
+		for _, t := range types {
+			if claims.ClientType == t {
+				c.Next()
+				return
+			}
+		}
+
+		domain.RespondWithError(c, http.StatusForbidden, domain.CodeForbidden,
+			"client type not permitted")
+	}
+}

--- a/internal/middleware/rbac_test.go
+++ b/internal/middleware/rbac_test.go
@@ -1,0 +1,293 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/middleware"
+)
+
+// injectClaims returns a Gin middleware that directly sets claims in the
+// context, bypassing token validation. Used to test RBAC middleware in
+// isolation from AuthMiddleware.
+func injectClaims(claims *domain.TokenClaims) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if claims != nil {
+			c.Set("claims", claims)
+			c.Set("user_id", claims.Subject)
+		}
+		c.Next()
+	}
+}
+
+// --- GetClaims ---
+
+func TestGetClaims_ReturnsClaims(t *testing.T) {
+	claims := &domain.TokenClaims{Subject: "u1", Roles: []string{"user"}}
+
+	var got *domain.TokenClaims
+	r := gin.New()
+	r.Use(injectClaims(claims))
+	r.GET("/", func(c *gin.Context) {
+		var err error
+		got, err = middleware.GetClaims(c)
+		require.NoError(t, err)
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, got)
+	assert.Equal(t, "u1", got.Subject)
+}
+
+func TestGetClaims_ErrorWhenAbsent(t *testing.T) {
+	r := gin.New()
+	r.GET("/", func(c *gin.Context) {
+		_, err := middleware.GetClaims(c)
+		assert.ErrorIs(t, err, middleware.ErrNoClaims)
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestGetClaims_ErrorOnWrongType(t *testing.T) {
+	// Store a non-*domain.TokenClaims value under the claims key to hit the
+	// type assertion failure branch.
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("claims", "not-a-claims-struct")
+		c.Next()
+	})
+	r.GET("/", func(c *gin.Context) {
+		_, err := middleware.GetClaims(c)
+		assert.ErrorIs(t, err, middleware.ErrNoClaims)
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// --- RequireRoles ---
+
+func TestRequireRoles(t *testing.T) {
+	tests := []struct {
+		name       string
+		claims     *domain.TokenClaims
+		required   []string
+		wantStatus int
+	}{
+		{
+			name:       "user has the required role",
+			claims:     &domain.TokenClaims{Roles: []string{"user"}},
+			required:   []string{"user"},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "user has one of multiple required roles (any-of)",
+			claims:     &domain.TokenClaims{Roles: []string{"user", "moderator"}},
+			required:   []string{"admin", "moderator"},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "admin satisfies admin-only route",
+			claims:     &domain.TokenClaims{Roles: []string{"admin"}},
+			required:   []string{"admin"},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "user lacks all required roles",
+			claims:     &domain.TokenClaims{Roles: []string{"user"}},
+			required:   []string{"admin"},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "empty roles returns forbidden",
+			claims:     &domain.TokenClaims{Roles: []string{}},
+			required:   []string{"admin"},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "no claims returns 401",
+			claims:     nil,
+			required:   []string{"user"},
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := gin.New()
+			r.Use(injectClaims(tc.claims))
+			r.GET("/route", middleware.RequireRoles(tc.required...), func(c *gin.Context) {
+				c.Status(http.StatusOK)
+			})
+
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/route", http.NoBody))
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
+// --- RequireScopes ---
+
+func TestRequireScopes(t *testing.T) {
+	tests := []struct {
+		name       string
+		claims     *domain.TokenClaims
+		required   []string
+		wantStatus int
+	}{
+		{
+			name:       "client has all required scopes",
+			claims:     &domain.TokenClaims{Scopes: []string{"read:users", "write:tokens"}},
+			required:   []string{"read:users", "write:tokens"},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "client has superset of required scopes",
+			claims:     &domain.TokenClaims{Scopes: []string{"read:users", "write:tokens", "admin:all"}},
+			required:   []string{"read:users"},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "client missing one required scope",
+			claims:     &domain.TokenClaims{Scopes: []string{"read:users"}},
+			required:   []string{"read:users", "write:tokens"},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "client has no scopes",
+			claims:     &domain.TokenClaims{Scopes: []string{}},
+			required:   []string{"read:users"},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "no claims returns 401",
+			claims:     nil,
+			required:   []string{"read:users"},
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := gin.New()
+			r.Use(injectClaims(tc.claims))
+			r.GET("/route", middleware.RequireScopes(tc.required...), func(c *gin.Context) {
+				c.Status(http.StatusOK)
+			})
+
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/route", http.NoBody))
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
+// --- RequireClientType ---
+
+func TestRequireClientType(t *testing.T) {
+	tests := []struct {
+		name       string
+		claims     *domain.TokenClaims
+		allowed    []string
+		wantStatus int
+	}{
+		{
+			name:       "user client type allowed",
+			claims:     &domain.TokenClaims{ClientType: domain.ClientTypeUser},
+			allowed:    []string{domain.ClientTypeUser},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "service client type allowed",
+			claims:     &domain.TokenClaims{ClientType: domain.ClientTypeService},
+			allowed:    []string{domain.ClientTypeService},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "agent client type allowed among multiple",
+			claims:     &domain.TokenClaims{ClientType: domain.ClientTypeAgent},
+			allowed:    []string{domain.ClientTypeService, domain.ClientTypeAgent},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "user type rejected from service-only route",
+			claims:     &domain.TokenClaims{ClientType: domain.ClientTypeUser},
+			allowed:    []string{domain.ClientTypeService},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "unknown client type rejected",
+			claims:     &domain.TokenClaims{ClientType: "unknown"},
+			allowed:    []string{domain.ClientTypeUser, domain.ClientTypeService, domain.ClientTypeAgent},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "no claims returns 401",
+			claims:     nil,
+			allowed:    []string{domain.ClientTypeUser},
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := gin.New()
+			r.Use(injectClaims(tc.claims))
+			r.GET("/route", middleware.RequireClientType(tc.allowed...), func(c *gin.Context) {
+				c.Status(http.StatusOK)
+			})
+
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/route", http.NoBody))
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
+// --- Chained middleware integration ---
+
+func TestChainedAuthAndRBAC(t *testing.T) {
+	claims := &domain.TokenClaims{
+		Subject:    "admin-user",
+		Roles:      []string{"admin"},
+		Scopes:     []string{"admin:all"},
+		ClientType: domain.ClientTypeUser,
+		TokenID:    "tok-1",
+	}
+	v := &mockValidator{claims: claims}
+
+	r := gin.New()
+	r.Use(middleware.AuthMiddleware(v))
+	r.GET("/admin",
+		middleware.RequireRoles("admin"),
+		middleware.RequireScopes("admin:all"),
+		middleware.RequireClientType(domain.ClientTypeUser),
+		func(c *gin.Context) {
+			c.Status(http.StatusOK)
+		},
+	)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/admin", http.NoBody)
+	req.Header.Set("Authorization", "Bearer qf_at_tok")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/internal/token/service.go
+++ b/internal/token/service.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/domain"
 )
 
 // Service implements api.TokenService.
@@ -44,4 +45,18 @@ func (s *Service) Revoke(_ context.Context, _ string) error {
 func (s *Service) JWKS(_ context.Context) (*api.JWKSResponse, error) {
 	// TODO(GH-XX): implement JWKS from loaded public keys.
 	return &api.JWKSResponse{Keys: []interface{}{}}, nil
+}
+
+// ValidateToken parses and validates the given raw token (qf_at_ prefix
+// already stripped), returning its claims. Implements middleware.TokenValidator.
+func (s *Service) ValidateToken(_ context.Context, _ string) (*domain.TokenClaims, error) {
+	// TODO(GH-XX): implement JWT parsing and ES256/EdDSA validation.
+	return nil, fmt.Errorf("token validation not yet implemented: %w", api.ErrInternalError)
+}
+
+// IsRevoked reports whether the token with the given ID is present in the
+// Redis revocation blocklist. Implements middleware.TokenValidator.
+func (s *Service) IsRevoked(_ context.Context, _ string) (bool, error) {
+	// TODO(GH-XX): implement Redis blocklist check.
+	return false, nil
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-9.

Closes #9

## Changes

GitHub Issue #9: Basic RBAC middleware

# TASK-09: Basic RBAC Middleware

**Status**: 🚧 In Progress
**Created**: 2026-02-24

---

## Context

**Problem**: No authorization enforcement. Authenticated users/clients can access any endpoint.

**Goal**: Role-based access control via JWT claims. Middleware checks roles from token before allowing access.

**Success Criteria**:
- [ ] Middleware extracts and validates JWT from Authorization header
- [ ] Role-based route protection (admin, user, service, agent)
- [ ] Scope-based access control for system clients

---

## Implementation Plan

### Phase 1: Auth Middleware
**Goal**: JWT extraction and validation

**Tasks**:
- [ ] `AuthMiddleware(tokenService) gin.HandlerFunc` — extracts Bearer token, validates, sets claims in context
- [ ] Extract token from `Authorization: Bearer <token>` header
- [ ] Strip `qf_at_` prefix, validate via token service
- [ ] Check revocation (Redis blocklist)
- [ ] Set `TokenClaims` in Gin context: `c.Set("claims", claims)`
- [ ] Return 401 with structured error on failure

**Files**:
- `internal/middleware/auth.go`

### Phase 2: Role Middleware
**Tasks**:
- [ ] `RequireRoles(roles ...string) gin.HandlerFunc` — checks claims.Roles against required roles
- [ ] `RequireScopes(scopes ...string) gin.HandlerFunc` — checks claims.Scopes (for system clients)
- [ ] `RequireClientType(types ...string) gin.HandlerFunc` — restricts to specific client types
- [ ] Helper: `GetClaims(c *gin.Context) (*domain.TokenClaims, error)` — extract claims from context

**Files**:
- `internal/middleware/rbac.go`

### Phase 3: Tests
**Tasks**:
- [ ] Auth middleware: valid token, expired, revoked, missing header, malformed
- [ ] Role middleware: authorized, unauthorized, multiple roles
- [ ] Scope middleware: sufficient, insufficient
- [ ] Client type restrictions

**Files**:
- `internal/middleware/auth_test.go`
- `internal/middleware/rbac_test.go`

---

## Technical Decisions

| Decision | Options | Chosen | Reasoning |
|---|---|---|---|
| Claim storage | custom header, context | Gin context c.Set() | Idiomatic Gin, type-safe retrieval |
| Role check | any-of, all-of | Any-of (user has ANY required role) | Most flexible for Phase 1 |
| Missing token | 401, 403 | 401 Unauthorized | RFC 7235 compliance |
| Insufficient role | 401, 403 | 403 Forbidden | Authenticated but not authorized |

---

## Dependencies

**Requires**: #4 (domain types), #5 (token validation)
**Blocks**: #13, #14

---

## Verify

```bash
go test ./internal/middleware/ -v -cover -race
```

---

## Done

- [ ] Valid JWT passes middleware, claims available in context
- [ ] Expired/revoked/invalid tokens return 401
- [ ] Missing Authorization header returns 401
- [ ] Insufficient role returns 403
- [ ] Scope checking works for system clients
- [ ] Client type restrictions enforce user vs service vs agent
- [ ] Tests pass with >90% coverage

---

**Last Updated**: 2026-02-24


## Planned Steps (execute all in sequence)

1. **Implement RBAC middleware with auth, role/scope enforcement, and tests** — Implement the full `internal/middleware/` package in one pass: `AuthMiddleware` (JWT extraction from Bearer header, `qf_at_` prefix stripping, token validation via token service, revocation check against Redis blocklist, claims injection into Gin context, structured 401 errors); `RequireRoles`, `RequireScopes`, `RequireClientType` middleware functions plus `GetClaims` helper in `rbac.go` (403 on insufficient permissions, any-of semantics for roles); and comprehensive table-driven tests in `auth_test.go` and `rbac_test.go` covering valid/expired/revoked/missing/malformed tokens, authorized/unauthorized roles, sufficient/insufficient scopes, and client type restrictions. Target >90% coverage. Verify with `go test ./internal/middleware/ -v -cover -race`.
This is a single-subtask plan because the entire scope is one Go package. Splitting `auth.go` from `rbac.go` into parallel subtasks would risk conflicts on shared types, imports, and test helpers within `internal/middleware/`.
