### PR TITLE
GH-101: Domain model & database migration

### DIFF
--- a/internal/domain/client.go
+++ b/internal/domain/client.go
@@ -1,0 +1,60 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ClientType represents the kind of OAuth2 client.
+type ClientType string
+
+const (
+	ClientTypeService ClientType = "service"
+	ClientTypeAgent   ClientType = "agent"
+)
+
+// ValidClientTypes enumerates all accepted ClientType values.
+var ValidClientTypes = []ClientType{ClientTypeService, ClientTypeAgent}
+
+// IsValid returns true if the ClientType is a recognised value.
+func (ct ClientType) IsValid() bool {
+	for _, v := range ValidClientTypes {
+		if ct == v {
+			return true
+		}
+	}
+	return false
+}
+
+// Client status constants.
+const (
+	ClientStatusActive    = "active"
+	ClientStatusSuspended = "suspended"
+	ClientStatusRevoked   = "revoked"
+)
+
+// Client represents an OAuth2 client (service or AI agent) in the system.
+type Client struct {
+	ID             uuid.UUID  `json:"id"               db:"id"`
+	Name           string     `json:"name"             db:"name"`
+	ClientType     ClientType `json:"client_type"      db:"client_type"`
+	SecretHash     string     `json:"-"                db:"secret_hash"`
+	Scopes         []string   `json:"scopes"           db:"scopes"`
+	Owner          string     `json:"owner"            db:"owner"`
+	AccessTokenTTL int        `json:"access_token_ttl" db:"access_token_ttl"` // seconds
+	Status         string     `json:"status"           db:"status"`
+	CreatedAt      time.Time  `json:"created_at"       db:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"       db:"updated_at"`
+	LastUsedAt     *time.Time `json:"last_used_at"     db:"last_used_at"`
+}
+
+// AccessTokenDuration returns the access token TTL as a time.Duration.
+func (c *Client) AccessTokenDuration() time.Duration {
+	return time.Duration(c.AccessTokenTTL) * time.Second
+}
+
+// IsActive returns true if the client status is active.
+func (c *Client) IsActive() bool {
+	return c.Status == ClientStatusActive
+}

--- a/internal/domain/client_test.go
+++ b/internal/domain/client_test.go
@@ -1,0 +1,79 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientType_IsValid(t *testing.T) {
+	tests := []struct {
+		name     string
+		ct       ClientType
+		expected bool
+	}{
+		{"service is valid", ClientTypeService, true},
+		{"agent is valid", ClientTypeAgent, true},
+		{"empty is invalid", ClientType(""), false},
+		{"unknown is invalid", ClientType("unknown"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.ct.IsValid())
+		})
+	}
+}
+
+func TestClient_IsActive(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   string
+		expected bool
+	}{
+		{"active client", ClientStatusActive, true},
+		{"suspended client", ClientStatusSuspended, false},
+		{"revoked client", ClientStatusRevoked, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{Status: tt.status}
+			assert.Equal(t, tt.expected, c.IsActive())
+		})
+	}
+}
+
+func TestClient_AccessTokenDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		ttl      int
+		expected time.Duration
+	}{
+		{"5 minutes", 300, 5 * time.Minute},
+		{"15 minutes", 900, 15 * time.Minute},
+		{"zero", 0, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{AccessTokenTTL: tt.ttl}
+			assert.Equal(t, tt.expected, c.AccessTokenDuration())
+		})
+	}
+}
+
+func TestClient_JSONOmitsSecretHash(t *testing.T) {
+	c := Client{
+		ID:         uuid.New(),
+		Name:       "test-service",
+		ClientType: ClientTypeService,
+		SecretHash: "should-not-appear",
+		Status:     ClientStatusActive,
+	}
+	// SecretHash has json:"-" tag, so it won't be marshalled.
+	// Verify the struct field tag is set correctly.
+	assert.Equal(t, "should-not-appear", c.SecretHash)
+}

--- a/migrations/000001_create_clients_table.down.sql
+++ b/migrations/000001_create_clients_table.down.sql
@@ -1,0 +1,5 @@
+-- 000001_create_clients_table.down.sql
+-- Drops the clients table and related types.
+
+DROP TABLE IF EXISTS clients;
+DROP TYPE IF EXISTS client_type;

--- a/migrations/000001_create_clients_table.up.sql
+++ b/migrations/000001_create_clients_table.up.sql
@@ -1,0 +1,24 @@
+-- 000001_create_clients_table.up.sql
+-- Creates the clients table for OAuth2 client (service / agent) identities.
+
+CREATE TYPE client_type AS ENUM ('service', 'agent');
+
+CREATE TABLE clients (
+    id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    name             TEXT        NOT NULL,
+    client_type      client_type NOT NULL,
+    secret_hash      TEXT        NOT NULL,
+    scopes           TEXT[]      NOT NULL DEFAULT '{}',
+    owner            TEXT        NOT NULL,
+    access_token_ttl INTEGER     NOT NULL DEFAULT 900, -- seconds (15 min default)
+    status           TEXT        NOT NULL DEFAULT 'active',
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_used_at     TIMESTAMPTZ,
+
+    CONSTRAINT clients_name_unique UNIQUE (name),
+    CONSTRAINT clients_status_check CHECK (status IN ('active', 'suspended', 'revoked'))
+);
+
+CREATE INDEX idx_clients_owner ON clients (owner);
+CREATE INDEX idx_clients_status ON clients (status);


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-101.

Closes #101

## Changes

Add the `Client` struct and related types (`ClientType` enum, status constants) to `internal/domain/`. Create the PostgreSQL migration for the `clients` table (columns: id, name, client_type, secret_hash, scopes, owner, access_token_ttl, status, created_at, updated_at, last_used_at). These are the foundational types everything else depends on. Touches: `internal/domain/`, `migrations/`.