### PR TITLE
GH-88: Admin API: router, service interfaces, handlers, wiring, and tests (`internal...

### DIFF
--- a/.agent/tasks/gh-88.md
+++ b/.agent/tasks/gh-88.md
@@ -1,0 +1,14 @@
+# GH-88
+
+**Created:** 2026-04-03
+
+## Problem
+
+GitHub Issue #88: Admin API: router, service interfaces, handlers, wiring, and tests (`internal...
+
+Parent: GH-13
+
+This is the core implementation. Define `AdminUserService`, `AdminClientService`, and `AdminTokenService` interfaces in `internal/api/`. Create `NewAdminRouter(services) *gin.Engine` with correlation ID middleware (no auth, no rate limiting). Implement all admin handlers: user CRUD (list/get/create/update/soft-delete/lock/unlock) in `admin_user_handlers.go`, client CRUD with secret rotation (24h grace period, return secret only on create/rotate) in `admin_client_handlers.go`, and RFC 7662 token introspection (JWT decode for access tokens, DB lookup for refresh tokens) in `admin_token_handlers.go`. Replace the stub `adminGinEngine()` in `main.go` with the real `NewAdminRouter()` wiring. Write comprehensive tests covering all endpoints, error cases, pagination, and soft-delete behavior in `admin_*_test.go`.
+
+## Acceptance Criteria
+

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -80,9 +80,14 @@ func run(log *zap.Logger) error {
 		RequestSize:     middleware.RequestSize(cfg.RequestLimit),
 	}
 
+	// ── Admin services ────────────────────────────────────────────────────
+	// Admin service implementations will be wired here as they are built.
+	// For now, nil services are guarded by NewAdminRouter's nil checks.
+	adminServices := &api.AdminServices{}
+
 	// ── HTTP servers ──────────────────────────────────────────────────────
 	publicRouter := api.NewPublicRouter(services, mw)
-	adminRouter := adminGinEngine()
+	adminRouter := api.NewAdminRouter(adminServices)
 
 	publicSrv := &http.Server{
 		Addr:              fmt.Sprintf(":%d", cfg.App.PublicPort),
@@ -127,17 +132,6 @@ func run(log *zap.Logger) error {
 
 	log.Info("auth service stopped")
 	return nil
-}
-
-// adminGinEngine returns a minimal Gin engine for the admin port.
-// Full admin routes will be wired up in a later issue.
-func adminGinEngine() *gin.Engine {
-	r := gin.New()
-	r.Use(gin.Recovery())
-	r.GET("/health", func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{"status": "ok"})
-	})
-	return r
 }
 
 // redisCloser adapts *redis.Client to the httpserver.Closer interface.

--- a/internal/api/admin_client_handlers.go
+++ b/internal/api/admin_client_handlers.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// AdminClientHandlers groups HTTP handlers for admin client management endpoints.
+type AdminClientHandlers struct {
+	clients AdminClientService
+}
+
+// NewAdminClientHandlers creates a new AdminClientHandlers with the given AdminClientService.
+func NewAdminClientHandlers(clients AdminClientService) *AdminClientHandlers {
+	return &AdminClientHandlers{clients: clients}
+}
+
+// List handles GET /admin/clients.
+// Query params: page (default 1), per_page (default 20), include_deleted (default false).
+func (h *AdminClientHandlers) List(c *gin.Context) {
+	page, perPage := parsePagination(c)
+	includeDeleted, _ := strconv.ParseBool(c.DefaultQuery("include_deleted", "false"))
+
+	result, err := h.clients.ListClients(c.Request.Context(), page, perPage, includeDeleted)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// Get handles GET /admin/clients/:id.
+func (h *AdminClientHandlers) Get(c *gin.Context) {
+	clientID := c.Param("id")
+
+	client, err := h.clients.GetClient(c.Request.Context(), clientID)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, client)
+}
+
+// Create handles POST /admin/clients.
+// Returns the client with the generated secret (only time secret is visible).
+func (h *AdminClientHandlers) Create(c *gin.Context) {
+	var req CreateClientRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid request body")
+		return
+	}
+
+	if err := adminValidator.Struct(req); err != nil {
+		handleValidationError(c, err)
+		return
+	}
+
+	client, err := h.clients.CreateClient(c.Request.Context(), &req)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, client)
+}
+
+// Update handles PATCH /admin/clients/:id.
+func (h *AdminClientHandlers) Update(c *gin.Context) {
+	clientID := c.Param("id")
+
+	var req UpdateClientRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid request body")
+		return
+	}
+
+	if err := adminValidator.Struct(req); err != nil {
+		handleValidationError(c, err)
+		return
+	}
+
+	client, err := h.clients.UpdateClient(c.Request.Context(), clientID, &req)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, client)
+}
+
+// Delete handles DELETE /admin/clients/:id (soft delete).
+func (h *AdminClientHandlers) Delete(c *gin.Context) {
+	clientID := c.Param("id")
+
+	if err := h.clients.DeleteClient(c.Request.Context(), clientID); err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "client deleted"})
+}
+
+// RotateSecret handles POST /admin/clients/:id/rotate-secret.
+// Returns the new secret with a 24-hour grace period for the old secret.
+func (h *AdminClientHandlers) RotateSecret(c *gin.Context) {
+	clientID := c.Param("id")
+
+	client, err := h.clients.RotateSecret(c.Request.Context(), clientID)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, client)
+}

--- a/internal/api/admin_client_handlers_test.go
+++ b/internal/api/admin_client_handlers_test.go
@@ -1,0 +1,309 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/api"
+)
+
+// --- Mock AdminClientService ---
+
+type mockAdminClientService struct {
+	listClientsFn  func(ctx context.Context, page, perPage int, includeDeleted bool) (*api.AdminClientList, error)
+	getClientFn    func(ctx context.Context, clientID string) (*api.AdminClient, error)
+	createClientFn func(ctx context.Context, req *api.CreateClientRequest) (*api.AdminClientWithSecret, error)
+	updateClientFn func(ctx context.Context, clientID string, req *api.UpdateClientRequest) (*api.AdminClient, error)
+	deleteClientFn func(ctx context.Context, clientID string) error
+	rotateSecretFn func(ctx context.Context, clientID string) (*api.AdminClientWithSecret, error)
+}
+
+func (m *mockAdminClientService) ListClients(ctx context.Context, page, perPage int, includeDeleted bool) (*api.AdminClientList, error) {
+	if m.listClientsFn != nil {
+		return m.listClientsFn(ctx, page, perPage, includeDeleted)
+	}
+	return &api.AdminClientList{
+		Clients: []api.AdminClient{{ID: "c1", Name: "test-client", ClientType: "service", Scopes: []string{"read:users"}, CreatedAt: time.Now(), UpdatedAt: time.Now()}},
+		Total:   1,
+		Page:    page,
+		PerPage: perPage,
+	}, nil
+}
+
+func (m *mockAdminClientService) GetClient(ctx context.Context, clientID string) (*api.AdminClient, error) {
+	if m.getClientFn != nil {
+		return m.getClientFn(ctx, clientID)
+	}
+	return &api.AdminClient{ID: clientID, Name: "test-client", ClientType: "service", Scopes: []string{"read:users"}, CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+}
+
+func (m *mockAdminClientService) CreateClient(ctx context.Context, req *api.CreateClientRequest) (*api.AdminClientWithSecret, error) {
+	if m.createClientFn != nil {
+		return m.createClientFn(ctx, req)
+	}
+	return &api.AdminClientWithSecret{
+		AdminClient: api.AdminClient{
+			ID:         "new-client",
+			Name:       req.Name,
+			ClientType: req.ClientType,
+			Scopes:     req.Scopes,
+			CreatedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+		},
+		ClientSecret: "qf_cs_generated_secret_value",
+	}, nil
+}
+
+func (m *mockAdminClientService) UpdateClient(ctx context.Context, clientID string, req *api.UpdateClientRequest) (*api.AdminClient, error) {
+	if m.updateClientFn != nil {
+		return m.updateClientFn(ctx, clientID, req)
+	}
+	name := "test-client"
+	if req.Name != nil {
+		name = *req.Name
+	}
+	return &api.AdminClient{ID: clientID, Name: name, ClientType: "service", Scopes: req.Scopes, CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+}
+
+func (m *mockAdminClientService) DeleteClient(ctx context.Context, clientID string) error {
+	if m.deleteClientFn != nil {
+		return m.deleteClientFn(ctx, clientID)
+	}
+	return nil
+}
+
+func (m *mockAdminClientService) RotateSecret(ctx context.Context, clientID string) (*api.AdminClientWithSecret, error) {
+	if m.rotateSecretFn != nil {
+		return m.rotateSecretFn(ctx, clientID)
+	}
+	graceEnd := time.Now().Add(24 * time.Hour)
+	return &api.AdminClientWithSecret{
+		AdminClient: api.AdminClient{
+			ID:         clientID,
+			Name:       "test-client",
+			ClientType: "service",
+			Scopes:     []string{"read:users"},
+			CreatedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+		},
+		ClientSecret:    "qf_cs_new_rotated_secret",
+		GracePeriodEnds: &graceEnd,
+	}, nil
+}
+
+// --- Helper ---
+
+func newAdminClientRouter(clientSvc api.AdminClientService) *gin.Engine {
+	svc := &api.AdminServices{Clients: clientSvc}
+	return api.NewAdminRouter(svc)
+}
+
+// --- List Clients ---
+
+func TestAdminListClients_Success(t *testing.T) {
+	r := newAdminClientRouter(&mockAdminClientService{})
+	w := doRequest(r, http.MethodGet, "/admin/clients", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminClientList
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.Total)
+	assert.Len(t, resp.Clients, 1)
+}
+
+func TestAdminListClients_Pagination(t *testing.T) {
+	svc := &mockAdminClientService{
+		listClientsFn: func(_ context.Context, page, perPage int, includeDeleted bool) (*api.AdminClientList, error) {
+			assert.Equal(t, 3, page)
+			assert.Equal(t, 5, perPage)
+			assert.False(t, includeDeleted)
+			return &api.AdminClientList{Clients: []api.AdminClient{}, Total: 50, Page: page, PerPage: perPage}, nil
+		},
+	}
+	r := newAdminClientRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/clients?page=3&per_page=5", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminClientList
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 3, resp.Page)
+	assert.Equal(t, 5, resp.PerPage)
+}
+
+// --- Get Client ---
+
+func TestAdminGetClient_Success(t *testing.T) {
+	r := newAdminClientRouter(&mockAdminClientService{})
+	w := doRequest(r, http.MethodGet, "/admin/clients/client-1", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminClient
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "client-1", resp.ID)
+}
+
+func TestAdminGetClient_NotFound(t *testing.T) {
+	svc := &mockAdminClientService{
+		getClientFn: func(_ context.Context, _ string) (*api.AdminClient, error) {
+			return nil, fmt.Errorf("client not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminClientRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/clients/nonexistent", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- Create Client ---
+
+func TestAdminCreateClient_Success(t *testing.T) {
+	r := newAdminClientRouter(&mockAdminClientService{})
+	body := map[string]interface{}{
+		"name":        "my-service",
+		"client_type": "service",
+		"scopes":      []string{"read:users", "write:users"},
+	}
+	w := doRequest(r, http.MethodPost, "/admin/clients", body)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp api.AdminClientWithSecret
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "my-service", resp.Name)
+	assert.Equal(t, "service", resp.ClientType)
+	assert.NotEmpty(t, resp.ClientSecret, "secret must be returned on create")
+}
+
+func TestAdminCreateClient_AgentType(t *testing.T) {
+	r := newAdminClientRouter(&mockAdminClientService{})
+	body := map[string]interface{}{
+		"name":        "my-agent",
+		"client_type": "agent",
+	}
+	w := doRequest(r, http.MethodPost, "/admin/clients", body)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+}
+
+func TestAdminCreateClient_InvalidType(t *testing.T) {
+	r := newAdminClientRouter(&mockAdminClientService{})
+	body := map[string]interface{}{
+		"name":        "bad-client",
+		"client_type": "user",
+	}
+	w := doRequest(r, http.MethodPost, "/admin/clients", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestAdminCreateClient_MissingName(t *testing.T) {
+	r := newAdminClientRouter(&mockAdminClientService{})
+	body := map[string]interface{}{
+		"client_type": "service",
+	}
+	w := doRequest(r, http.MethodPost, "/admin/clients", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestAdminCreateClient_Conflict(t *testing.T) {
+	svc := &mockAdminClientService{
+		createClientFn: func(_ context.Context, _ *api.CreateClientRequest) (*api.AdminClientWithSecret, error) {
+			return nil, fmt.Errorf("client name exists: %w", api.ErrConflict)
+		},
+	}
+	r := newAdminClientRouter(svc)
+	body := map[string]interface{}{
+		"name":        "dup-client",
+		"client_type": "service",
+	}
+	w := doRequest(r, http.MethodPost, "/admin/clients", body)
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+// --- Update Client ---
+
+func TestAdminUpdateClient_Success(t *testing.T) {
+	r := newAdminClientRouter(&mockAdminClientService{})
+	name := "updated-name"
+	body := map[string]interface{}{"name": name}
+	w := doRequest(r, http.MethodPatch, "/admin/clients/client-1", body)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminClient
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "updated-name", resp.Name)
+}
+
+func TestAdminUpdateClient_NotFound(t *testing.T) {
+	svc := &mockAdminClientService{
+		updateClientFn: func(_ context.Context, _ string, _ *api.UpdateClientRequest) (*api.AdminClient, error) {
+			return nil, fmt.Errorf("client not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminClientRouter(svc)
+	body := map[string]interface{}{"name": "nope"}
+	w := doRequest(r, http.MethodPatch, "/admin/clients/nonexistent", body)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- Delete Client ---
+
+func TestAdminDeleteClient_Success(t *testing.T) {
+	r := newAdminClientRouter(&mockAdminClientService{})
+	w := doRequest(r, http.MethodDelete, "/admin/clients/client-1", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestAdminDeleteClient_NotFound(t *testing.T) {
+	svc := &mockAdminClientService{
+		deleteClientFn: func(_ context.Context, _ string) error {
+			return fmt.Errorf("client not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminClientRouter(svc)
+	w := doRequest(r, http.MethodDelete, "/admin/clients/nonexistent", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- Rotate Secret ---
+
+func TestAdminRotateSecret_Success(t *testing.T) {
+	r := newAdminClientRouter(&mockAdminClientService{})
+	w := doRequest(r, http.MethodPost, "/admin/clients/client-1/rotate-secret", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminClientWithSecret
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.ClientSecret, "new secret must be returned on rotation")
+	assert.NotNil(t, resp.GracePeriodEnds, "grace period must be set on rotation")
+}
+
+func TestAdminRotateSecret_NotFound(t *testing.T) {
+	svc := &mockAdminClientService{
+		rotateSecretFn: func(_ context.Context, _ string) (*api.AdminClientWithSecret, error) {
+			return nil, fmt.Errorf("client not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminClientRouter(svc)
+	w := doRequest(r, http.MethodPost, "/admin/clients/nonexistent/rotate-secret", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/internal/api/admin_router.go
+++ b/internal/api/admin_router.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator/v10"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/middleware"
+)
+
+// adminValidator is the shared validator instance for admin request structs.
+var adminValidator = validator.New()
+
+// NewAdminRouter creates a *gin.Engine with the admin API route tree.
+// Only correlation ID middleware is applied (no auth, no rate limiting).
+// The admin port is protected at the network level.
+func NewAdminRouter(svc *AdminServices) *gin.Engine {
+	r := gin.New()
+	r.Use(gin.Recovery())
+	r.Use(middleware.CorrelationID())
+
+	// Health probe.
+	r.GET("/health", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
+
+	admin := r.Group("/admin")
+
+	// User management.
+	if svc.Users != nil {
+		userH := NewAdminUserHandlers(svc.Users)
+		users := admin.Group("/users")
+		{
+			users.GET("", userH.List)
+			users.GET("/:id", userH.Get)
+			users.POST("", userH.Create)
+			users.PATCH("/:id", userH.Update)
+			users.DELETE("/:id", userH.Delete)
+			users.POST("/:id/lock", userH.Lock)
+			users.POST("/:id/unlock", userH.Unlock)
+		}
+	}
+
+	// Client management.
+	if svc.Clients != nil {
+		clientH := NewAdminClientHandlers(svc.Clients)
+		clients := admin.Group("/clients")
+		{
+			clients.GET("", clientH.List)
+			clients.GET("/:id", clientH.Get)
+			clients.POST("", clientH.Create)
+			clients.PATCH("/:id", clientH.Update)
+			clients.DELETE("/:id", clientH.Delete)
+			clients.POST("/:id/rotate-secret", clientH.RotateSecret)
+		}
+	}
+
+	// Token introspection.
+	if svc.Tokens != nil {
+		tokenH := NewAdminTokenHandlers(svc.Tokens)
+		admin.POST("/tokens/introspect", tokenH.Introspect)
+	}
+
+	return r
+}
+
+// parsePagination extracts page and per_page query parameters with defaults.
+func parsePagination(c *gin.Context) (page, perPage int) {
+	page, _ = strconv.Atoi(c.DefaultQuery("page", "1"))
+	perPage, _ = strconv.Atoi(c.DefaultQuery("per_page", "20"))
+
+	if page < 1 {
+		page = 1
+	}
+	if perPage < 1 {
+		perPage = 20
+	}
+	if perPage > 100 {
+		perPage = 100
+	}
+
+	return page, perPage
+}
+
+// handleValidationError converts validator errors into domain validation error responses.
+func handleValidationError(c *gin.Context, err error) {
+	validationErrs, ok := err.(validator.ValidationErrors)
+	if !ok {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "validation failed")
+		return
+	}
+
+	details := make([]domain.ValidationErrorDetail, 0, len(validationErrs))
+	for _, fe := range validationErrs {
+		details = append(details, domain.ValidationErrorDetail{
+			Field:   fe.Field(),
+			Message: fe.Tag(),
+		})
+	}
+
+	domain.RespondWithValidationErrors(c, details)
+}

--- a/internal/api/admin_services.go
+++ b/internal/api/admin_services.go
@@ -1,0 +1,148 @@
+package api
+
+import (
+	"context"
+	"time"
+)
+
+// --- Admin response types ---
+
+// AdminUser represents a user record in admin API responses.
+type AdminUser struct {
+	ID           string     `json:"id"`
+	Email        string     `json:"email"`
+	Name         string     `json:"name"`
+	Roles        []string   `json:"roles"`
+	Locked       bool       `json:"locked"`
+	LockedAt     *time.Time `json:"locked_at,omitempty"`
+	LockedReason string     `json:"locked_reason,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at"`
+	DeletedAt    *time.Time `json:"deleted_at,omitempty"`
+}
+
+// AdminUserList is the paginated response for listing users.
+type AdminUserList struct {
+	Users   []AdminUser `json:"users"`
+	Total   int         `json:"total"`
+	Page    int         `json:"page"`
+	PerPage int         `json:"per_page"`
+}
+
+// AdminClient represents an OAuth2 client in admin API responses.
+type AdminClient struct {
+	ID          string     `json:"id"`
+	Name        string     `json:"name"`
+	ClientType  string     `json:"client_type"`
+	Scopes      []string   `json:"scopes"`
+	RedirectURIs []string  `json:"redirect_uris,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	DeletedAt   *time.Time `json:"deleted_at,omitempty"`
+}
+
+// AdminClientWithSecret is returned only on create and secret rotation.
+type AdminClientWithSecret struct {
+	AdminClient
+	ClientSecret    string     `json:"client_secret"`
+	GracePeriodEnds *time.Time `json:"grace_period_ends,omitempty"`
+}
+
+// AdminClientList is the paginated response for listing clients.
+type AdminClientList struct {
+	Clients []AdminClient `json:"clients"`
+	Total   int           `json:"total"`
+	Page    int           `json:"page"`
+	PerPage int           `json:"per_page"`
+}
+
+// IntrospectionResponse follows RFC 7662 token introspection.
+type IntrospectionResponse struct {
+	Active     bool   `json:"active"`
+	Sub        string `json:"sub,omitempty"`
+	ClientID   string `json:"client_id,omitempty"`
+	TokenType  string `json:"token_type,omitempty"`
+	Scope      string `json:"scope,omitempty"`
+	Exp        int64  `json:"exp,omitempty"`
+	Iat        int64  `json:"iat,omitempty"`
+	Iss        string `json:"iss,omitempty"`
+	Jti        string `json:"jti,omitempty"`
+	ClientType string `json:"client_type,omitempty"`
+}
+
+// --- Admin request types ---
+
+// CreateUserRequest is the request body for creating a user via admin API.
+type CreateUserRequest struct {
+	Email    string   `json:"email"    validate:"required,email"`
+	Password string   `json:"password" validate:"required,min=15"`
+	Name     string   `json:"name"     validate:"required,min=1,max=255"`
+	Roles    []string `json:"roles"    validate:"omitempty"`
+}
+
+// UpdateUserRequest is the request body for updating a user via admin API.
+type UpdateUserRequest struct {
+	Email *string  `json:"email" validate:"omitempty,email"`
+	Name  *string  `json:"name"  validate:"omitempty,min=1,max=255"`
+	Roles []string `json:"roles" validate:"omitempty"`
+}
+
+// LockUserRequest is the request body for locking a user account.
+type LockUserRequest struct {
+	Reason string `json:"reason" validate:"required,min=1,max=500"`
+}
+
+// CreateClientRequest is the request body for creating an OAuth2 client.
+type CreateClientRequest struct {
+	Name         string   `json:"name"          validate:"required,min=1,max=255"`
+	ClientType   string   `json:"client_type"   validate:"required,oneof=service agent"`
+	Scopes       []string `json:"scopes"        validate:"omitempty"`
+	RedirectURIs []string `json:"redirect_uris" validate:"omitempty"`
+}
+
+// UpdateClientRequest is the request body for updating an OAuth2 client.
+type UpdateClientRequest struct {
+	Name         *string  `json:"name"          validate:"omitempty,min=1,max=255"`
+	Scopes       []string `json:"scopes"        validate:"omitempty"`
+	RedirectURIs []string `json:"redirect_uris" validate:"omitempty"`
+}
+
+// IntrospectRequest is the request body for RFC 7662 token introspection.
+type IntrospectRequest struct {
+	Token string `json:"token" validate:"required"`
+}
+
+// --- Admin service interfaces ---
+
+// AdminUserService defines admin operations for user management.
+type AdminUserService interface {
+	ListUsers(ctx context.Context, page, perPage int, includeDeleted bool) (*AdminUserList, error)
+	GetUser(ctx context.Context, userID string) (*AdminUser, error)
+	CreateUser(ctx context.Context, req *CreateUserRequest) (*AdminUser, error)
+	UpdateUser(ctx context.Context, userID string, req *UpdateUserRequest) (*AdminUser, error)
+	DeleteUser(ctx context.Context, userID string) error
+	LockUser(ctx context.Context, userID string, reason string) (*AdminUser, error)
+	UnlockUser(ctx context.Context, userID string) (*AdminUser, error)
+}
+
+// AdminClientService defines admin operations for OAuth2 client management.
+type AdminClientService interface {
+	ListClients(ctx context.Context, page, perPage int, includeDeleted bool) (*AdminClientList, error)
+	GetClient(ctx context.Context, clientID string) (*AdminClient, error)
+	CreateClient(ctx context.Context, req *CreateClientRequest) (*AdminClientWithSecret, error)
+	UpdateClient(ctx context.Context, clientID string, req *UpdateClientRequest) (*AdminClient, error)
+	DeleteClient(ctx context.Context, clientID string) error
+	RotateSecret(ctx context.Context, clientID string) (*AdminClientWithSecret, error)
+}
+
+// AdminTokenService defines admin operations for token introspection.
+type AdminTokenService interface {
+	Introspect(ctx context.Context, token string) (*IntrospectionResponse, error)
+}
+
+// AdminServices aggregates all admin service interfaces required by admin API handlers.
+type AdminServices struct {
+	Users   AdminUserService
+	Clients AdminClientService
+	Tokens  AdminTokenService
+}

--- a/internal/api/admin_token_handlers.go
+++ b/internal/api/admin_token_handlers.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// AdminTokenHandlers groups HTTP handlers for admin token introspection endpoints.
+type AdminTokenHandlers struct {
+	tokens AdminTokenService
+}
+
+// NewAdminTokenHandlers creates a new AdminTokenHandlers with the given AdminTokenService.
+func NewAdminTokenHandlers(tokens AdminTokenService) *AdminTokenHandlers {
+	return &AdminTokenHandlers{tokens: tokens}
+}
+
+// Introspect handles POST /admin/tokens/introspect (RFC 7662).
+// For access tokens: decodes the JWT without DB lookup.
+// For refresh tokens: performs a DB lookup.
+func (h *AdminTokenHandlers) Introspect(c *gin.Context) {
+	var req IntrospectRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid request body")
+		return
+	}
+
+	if err := adminValidator.Struct(req); err != nil {
+		handleValidationError(c, err)
+		return
+	}
+
+	result, err := h.tokens.Introspect(c.Request.Context(), req.Token)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}

--- a/internal/api/admin_token_handlers_test.go
+++ b/internal/api/admin_token_handlers_test.go
@@ -1,0 +1,157 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/api"
+)
+
+// --- Mock AdminTokenService ---
+
+type mockAdminTokenService struct {
+	introspectFn func(ctx context.Context, token string) (*api.IntrospectionResponse, error)
+}
+
+func (m *mockAdminTokenService) Introspect(ctx context.Context, token string) (*api.IntrospectionResponse, error) {
+	if m.introspectFn != nil {
+		return m.introspectFn(ctx, token)
+	}
+	return &api.IntrospectionResponse{
+		Active:     true,
+		Sub:        "user-42",
+		TokenType:  "access_token",
+		Scope:      "read:users write:users",
+		Exp:        1700000000,
+		Iat:        1699996400,
+		Iss:        "auth-service",
+		Jti:        "token-id-1",
+		ClientType: "user",
+	}, nil
+}
+
+// --- Helper ---
+
+func newAdminTokenRouter(tokenSvc api.AdminTokenService) *gin.Engine {
+	svc := &api.AdminServices{Tokens: tokenSvc}
+	return api.NewAdminRouter(svc)
+}
+
+// --- Introspect ---
+
+func TestAdminIntrospect_ActiveToken(t *testing.T) {
+	r := newAdminTokenRouter(&mockAdminTokenService{})
+	body := map[string]string{"token": "qf_at_valid_access_token"}
+	w := doRequest(r, http.MethodPost, "/admin/tokens/introspect", body)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.IntrospectionResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Active)
+	assert.Equal(t, "user-42", resp.Sub)
+	assert.Equal(t, "access_token", resp.TokenType)
+	assert.Equal(t, "read:users write:users", resp.Scope)
+	assert.Equal(t, "auth-service", resp.Iss)
+	assert.Equal(t, "token-id-1", resp.Jti)
+}
+
+func TestAdminIntrospect_InactiveToken(t *testing.T) {
+	svc := &mockAdminTokenService{
+		introspectFn: func(_ context.Context, _ string) (*api.IntrospectionResponse, error) {
+			return &api.IntrospectionResponse{Active: false}, nil
+		},
+	}
+	r := newAdminTokenRouter(svc)
+	body := map[string]string{"token": "qf_at_expired_token"}
+	w := doRequest(r, http.MethodPost, "/admin/tokens/introspect", body)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.IntrospectionResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.False(t, resp.Active)
+	assert.Empty(t, resp.Sub, "inactive tokens should not expose claims")
+}
+
+func TestAdminIntrospect_RefreshToken(t *testing.T) {
+	svc := &mockAdminTokenService{
+		introspectFn: func(_ context.Context, token string) (*api.IntrospectionResponse, error) {
+			assert.Equal(t, "qf_rt_refresh_token", token)
+			return &api.IntrospectionResponse{
+				Active:    true,
+				Sub:       "user-99",
+				TokenType: "refresh_token",
+				Exp:       1700100000,
+				Iat:       1699996400,
+				Jti:       "rt-id-1",
+			}, nil
+		},
+	}
+	r := newAdminTokenRouter(svc)
+	body := map[string]string{"token": "qf_rt_refresh_token"}
+	w := doRequest(r, http.MethodPost, "/admin/tokens/introspect", body)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.IntrospectionResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Active)
+	assert.Equal(t, "refresh_token", resp.TokenType)
+}
+
+func TestAdminIntrospect_MissingToken(t *testing.T) {
+	r := newAdminTokenRouter(&mockAdminTokenService{})
+	body := map[string]string{}
+	w := doRequest(r, http.MethodPost, "/admin/tokens/introspect", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestAdminIntrospect_InvalidJSON(t *testing.T) {
+	r := newAdminTokenRouter(&mockAdminTokenService{})
+	w := doRequest(r, http.MethodPost, "/admin/tokens/introspect", nil)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminIntrospect_ServiceError(t *testing.T) {
+	svc := &mockAdminTokenService{
+		introspectFn: func(_ context.Context, _ string) (*api.IntrospectionResponse, error) {
+			return nil, fmt.Errorf("decode failed: %w", api.ErrInternalError)
+		},
+	}
+	r := newAdminTokenRouter(svc)
+	body := map[string]string{"token": "qf_at_malformed"}
+	w := doRequest(r, http.MethodPost, "/admin/tokens/introspect", body)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- Nil services don't crash ---
+
+func TestAdminRouter_NilServices(t *testing.T) {
+	svc := &api.AdminServices{}
+	router := api.NewAdminRouter(svc)
+
+	// Health should still work.
+	w := doRequest(router, http.MethodGet, "/health", nil)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Routes for nil services should 404 (not registered).
+	w = doRequest(router, http.MethodGet, "/admin/users", nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	w = doRequest(router, http.MethodGet, "/admin/clients", nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	w = doRequest(router, http.MethodPost, "/admin/tokens/introspect", map[string]string{"token": "x"})
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/internal/api/admin_user_handlers.go
+++ b/internal/api/admin_user_handlers.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// AdminUserHandlers groups HTTP handlers for admin user management endpoints.
+type AdminUserHandlers struct {
+	users AdminUserService
+}
+
+// NewAdminUserHandlers creates a new AdminUserHandlers with the given AdminUserService.
+func NewAdminUserHandlers(users AdminUserService) *AdminUserHandlers {
+	return &AdminUserHandlers{users: users}
+}
+
+// List handles GET /admin/users.
+// Query params: page (default 1), per_page (default 20), include_deleted (default false).
+func (h *AdminUserHandlers) List(c *gin.Context) {
+	page, perPage := parsePagination(c)
+	includeDeleted, _ := strconv.ParseBool(c.DefaultQuery("include_deleted", "false"))
+
+	result, err := h.users.ListUsers(c.Request.Context(), page, perPage, includeDeleted)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// Get handles GET /admin/users/:id.
+func (h *AdminUserHandlers) Get(c *gin.Context) {
+	userID := c.Param("id")
+
+	user, err := h.users.GetUser(c.Request.Context(), userID)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, user)
+}
+
+// Create handles POST /admin/users.
+func (h *AdminUserHandlers) Create(c *gin.Context) {
+	var req CreateUserRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid request body")
+		return
+	}
+
+	if err := adminValidator.Struct(req); err != nil {
+		handleValidationError(c, err)
+		return
+	}
+
+	user, err := h.users.CreateUser(c.Request.Context(), &req)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, user)
+}
+
+// Update handles PATCH /admin/users/:id.
+func (h *AdminUserHandlers) Update(c *gin.Context) {
+	userID := c.Param("id")
+
+	var req UpdateUserRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid request body")
+		return
+	}
+
+	if err := adminValidator.Struct(req); err != nil {
+		handleValidationError(c, err)
+		return
+	}
+
+	user, err := h.users.UpdateUser(c.Request.Context(), userID, &req)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, user)
+}
+
+// Delete handles DELETE /admin/users/:id (soft delete).
+func (h *AdminUserHandlers) Delete(c *gin.Context) {
+	userID := c.Param("id")
+
+	if err := h.users.DeleteUser(c.Request.Context(), userID); err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "user deleted"})
+}
+
+// Lock handles POST /admin/users/:id/lock.
+func (h *AdminUserHandlers) Lock(c *gin.Context) {
+	userID := c.Param("id")
+
+	var req LockUserRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid request body")
+		return
+	}
+
+	if err := adminValidator.Struct(req); err != nil {
+		handleValidationError(c, err)
+		return
+	}
+
+	user, err := h.users.LockUser(c.Request.Context(), userID, req.Reason)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, user)
+}
+
+// Unlock handles POST /admin/users/:id/unlock.
+func (h *AdminUserHandlers) Unlock(c *gin.Context) {
+	userID := c.Param("id")
+
+	user, err := h.users.UnlockUser(c.Request.Context(), userID)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, user)
+}

--- a/internal/api/admin_user_handlers_test.go
+++ b/internal/api/admin_user_handlers_test.go
@@ -1,0 +1,373 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/api"
+)
+
+// --- Mock AdminUserService ---
+
+type mockAdminUserService struct {
+	listUsersFn  func(ctx context.Context, page, perPage int, includeDeleted bool) (*api.AdminUserList, error)
+	getUserFn    func(ctx context.Context, userID string) (*api.AdminUser, error)
+	createUserFn func(ctx context.Context, req *api.CreateUserRequest) (*api.AdminUser, error)
+	updateUserFn func(ctx context.Context, userID string, req *api.UpdateUserRequest) (*api.AdminUser, error)
+	deleteUserFn func(ctx context.Context, userID string) error
+	lockUserFn   func(ctx context.Context, userID string, reason string) (*api.AdminUser, error)
+	unlockUserFn func(ctx context.Context, userID string) (*api.AdminUser, error)
+}
+
+func (m *mockAdminUserService) ListUsers(ctx context.Context, page, perPage int, includeDeleted bool) (*api.AdminUserList, error) {
+	if m.listUsersFn != nil {
+		return m.listUsersFn(ctx, page, perPage, includeDeleted)
+	}
+	return &api.AdminUserList{
+		Users:   []api.AdminUser{{ID: "u1", Email: "a@b.com", Name: "Alice", Roles: []string{"user"}, CreatedAt: time.Now(), UpdatedAt: time.Now()}},
+		Total:   1,
+		Page:    page,
+		PerPage: perPage,
+	}, nil
+}
+
+func (m *mockAdminUserService) GetUser(ctx context.Context, userID string) (*api.AdminUser, error) {
+	if m.getUserFn != nil {
+		return m.getUserFn(ctx, userID)
+	}
+	return &api.AdminUser{ID: userID, Email: "a@b.com", Name: "Alice", Roles: []string{"user"}, CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+}
+
+func (m *mockAdminUserService) CreateUser(ctx context.Context, req *api.CreateUserRequest) (*api.AdminUser, error) {
+	if m.createUserFn != nil {
+		return m.createUserFn(ctx, req)
+	}
+	return &api.AdminUser{ID: "new-user", Email: req.Email, Name: req.Name, Roles: req.Roles, CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+}
+
+func (m *mockAdminUserService) UpdateUser(ctx context.Context, userID string, req *api.UpdateUserRequest) (*api.AdminUser, error) {
+	if m.updateUserFn != nil {
+		return m.updateUserFn(ctx, userID, req)
+	}
+	name := "Alice"
+	if req.Name != nil {
+		name = *req.Name
+	}
+	return &api.AdminUser{ID: userID, Email: "a@b.com", Name: name, Roles: []string{"user"}, CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+}
+
+func (m *mockAdminUserService) DeleteUser(ctx context.Context, userID string) error {
+	if m.deleteUserFn != nil {
+		return m.deleteUserFn(ctx, userID)
+	}
+	return nil
+}
+
+func (m *mockAdminUserService) LockUser(ctx context.Context, userID string, reason string) (*api.AdminUser, error) {
+	if m.lockUserFn != nil {
+		return m.lockUserFn(ctx, userID, reason)
+	}
+	now := time.Now()
+	return &api.AdminUser{ID: userID, Email: "a@b.com", Name: "Alice", Roles: []string{"user"}, Locked: true, LockedAt: &now, LockedReason: reason, CreatedAt: now, UpdatedAt: now}, nil
+}
+
+func (m *mockAdminUserService) UnlockUser(ctx context.Context, userID string) (*api.AdminUser, error) {
+	if m.unlockUserFn != nil {
+		return m.unlockUserFn(ctx, userID)
+	}
+	now := time.Now()
+	return &api.AdminUser{ID: userID, Email: "a@b.com", Name: "Alice", Roles: []string{"user"}, Locked: false, CreatedAt: now, UpdatedAt: now}, nil
+}
+
+// --- Helper ---
+
+func newAdminUserRouter(userSvc api.AdminUserService) *gin.Engine {
+	svc := &api.AdminServices{Users: userSvc}
+	return api.NewAdminRouter(svc)
+}
+
+// --- List Users ---
+
+func TestAdminListUsers_Success(t *testing.T) {
+	r := newAdminUserRouter(&mockAdminUserService{})
+	w := doRequest(r, http.MethodGet, "/admin/users", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminUserList
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.Total)
+	assert.Len(t, resp.Users, 1)
+	assert.Equal(t, 1, resp.Page)
+	assert.Equal(t, 20, resp.PerPage)
+}
+
+func TestAdminListUsers_Pagination(t *testing.T) {
+	svc := &mockAdminUserService{
+		listUsersFn: func(_ context.Context, page, perPage int, includeDeleted bool) (*api.AdminUserList, error) {
+			assert.Equal(t, 2, page)
+			assert.Equal(t, 10, perPage)
+			assert.True(t, includeDeleted)
+			return &api.AdminUserList{Users: []api.AdminUser{}, Total: 25, Page: page, PerPage: perPage}, nil
+		},
+	}
+	r := newAdminUserRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/users?page=2&per_page=10&include_deleted=true", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminUserList
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 2, resp.Page)
+	assert.Equal(t, 10, resp.PerPage)
+	assert.Equal(t, 25, resp.Total)
+}
+
+func TestAdminListUsers_ServiceError(t *testing.T) {
+	svc := &mockAdminUserService{
+		listUsersFn: func(_ context.Context, _, _ int, _ bool) (*api.AdminUserList, error) {
+			return nil, fmt.Errorf("db down: %w", api.ErrInternalError)
+		},
+	}
+	r := newAdminUserRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/users", nil)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- Get User ---
+
+func TestAdminGetUser_Success(t *testing.T) {
+	r := newAdminUserRouter(&mockAdminUserService{})
+	w := doRequest(r, http.MethodGet, "/admin/users/user-42", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminUser
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "user-42", resp.ID)
+}
+
+func TestAdminGetUser_NotFound(t *testing.T) {
+	svc := &mockAdminUserService{
+		getUserFn: func(_ context.Context, _ string) (*api.AdminUser, error) {
+			return nil, fmt.Errorf("user not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminUserRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/users/nonexistent", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- Create User ---
+
+func TestAdminCreateUser_Success(t *testing.T) {
+	r := newAdminUserRouter(&mockAdminUserService{})
+	body := map[string]interface{}{
+		"email":    "new@example.com",
+		"password": "super-secure-password-123",
+		"name":     "New User",
+		"roles":    []string{"user"},
+	}
+	w := doRequest(r, http.MethodPost, "/admin/users", body)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp api.AdminUser
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "new@example.com", resp.Email)
+	assert.Equal(t, "New User", resp.Name)
+}
+
+func TestAdminCreateUser_ValidationError(t *testing.T) {
+	r := newAdminUserRouter(&mockAdminUserService{})
+	// Missing required fields
+	body := map[string]string{"email": "bad"}
+	w := doRequest(r, http.MethodPost, "/admin/users", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestAdminCreateUser_InvalidJSON(t *testing.T) {
+	r := newAdminUserRouter(&mockAdminUserService{})
+	w := doRequest(r, http.MethodPost, "/admin/users", nil)
+
+	// nil body → ShouldBindJSON fails with EOF
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminCreateUser_Conflict(t *testing.T) {
+	svc := &mockAdminUserService{
+		createUserFn: func(_ context.Context, _ *api.CreateUserRequest) (*api.AdminUser, error) {
+			return nil, fmt.Errorf("email already exists: %w", api.ErrConflict)
+		},
+	}
+	r := newAdminUserRouter(svc)
+	body := map[string]interface{}{
+		"email":    "dup@example.com",
+		"password": "super-secure-password-123",
+		"name":     "Dup User",
+	}
+	w := doRequest(r, http.MethodPost, "/admin/users", body)
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+// --- Update User ---
+
+func TestAdminUpdateUser_Success(t *testing.T) {
+	r := newAdminUserRouter(&mockAdminUserService{})
+	name := "Updated Name"
+	body := map[string]interface{}{"name": name}
+	w := doRequest(r, http.MethodPatch, "/admin/users/user-42", body)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminUser
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "Updated Name", resp.Name)
+}
+
+func TestAdminUpdateUser_NotFound(t *testing.T) {
+	svc := &mockAdminUserService{
+		updateUserFn: func(_ context.Context, _ string, _ *api.UpdateUserRequest) (*api.AdminUser, error) {
+			return nil, fmt.Errorf("user not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminUserRouter(svc)
+	body := map[string]interface{}{"name": "Nope"}
+	w := doRequest(r, http.MethodPatch, "/admin/users/nonexistent", body)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- Delete User (soft-delete) ---
+
+func TestAdminDeleteUser_Success(t *testing.T) {
+	r := newAdminUserRouter(&mockAdminUserService{})
+	w := doRequest(r, http.MethodDelete, "/admin/users/user-42", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestAdminDeleteUser_NotFound(t *testing.T) {
+	svc := &mockAdminUserService{
+		deleteUserFn: func(_ context.Context, _ string) error {
+			return fmt.Errorf("user not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminUserRouter(svc)
+	w := doRequest(r, http.MethodDelete, "/admin/users/nonexistent", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestAdminDeleteUser_AlreadyDeleted(t *testing.T) {
+	svc := &mockAdminUserService{
+		deleteUserFn: func(_ context.Context, _ string) error {
+			return fmt.Errorf("user already deleted: %w", api.ErrConflict)
+		},
+	}
+	r := newAdminUserRouter(svc)
+	w := doRequest(r, http.MethodDelete, "/admin/users/deleted-user", nil)
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+// --- Lock User ---
+
+func TestAdminLockUser_Success(t *testing.T) {
+	r := newAdminUserRouter(&mockAdminUserService{})
+	body := map[string]string{"reason": "Suspicious activity detected"}
+	w := doRequest(r, http.MethodPost, "/admin/users/user-42/lock", body)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminUser
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Locked)
+	assert.NotNil(t, resp.LockedAt)
+	assert.Equal(t, "Suspicious activity detected", resp.LockedReason)
+}
+
+func TestAdminLockUser_MissingReason(t *testing.T) {
+	r := newAdminUserRouter(&mockAdminUserService{})
+	body := map[string]string{}
+	w := doRequest(r, http.MethodPost, "/admin/users/user-42/lock", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestAdminLockUser_NotFound(t *testing.T) {
+	svc := &mockAdminUserService{
+		lockUserFn: func(_ context.Context, _ string, _ string) (*api.AdminUser, error) {
+			return nil, fmt.Errorf("user not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminUserRouter(svc)
+	body := map[string]string{"reason": "test"}
+	w := doRequest(r, http.MethodPost, "/admin/users/nonexistent/lock", body)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- Unlock User ---
+
+func TestAdminUnlockUser_Success(t *testing.T) {
+	r := newAdminUserRouter(&mockAdminUserService{})
+	w := doRequest(r, http.MethodPost, "/admin/users/user-42/unlock", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminUser
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.False(t, resp.Locked)
+}
+
+func TestAdminUnlockUser_NotFound(t *testing.T) {
+	svc := &mockAdminUserService{
+		unlockUserFn: func(_ context.Context, _ string) (*api.AdminUser, error) {
+			return nil, fmt.Errorf("user not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminUserRouter(svc)
+	w := doRequest(r, http.MethodPost, "/admin/users/nonexistent/unlock", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- Admin Health ---
+
+func TestAdminHealth(t *testing.T) {
+	r := newAdminUserRouter(&mockAdminUserService{})
+	w := doRequest(r, http.MethodGet, "/health", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "ok", resp["status"])
+}
+
+// --- Correlation ID ---
+
+func TestAdminCorrelationID(t *testing.T) {
+	r := newAdminUserRouter(&mockAdminUserService{})
+
+	// Without X-Request-ID → generates one.
+	w := doRequest(r, http.MethodGet, "/health", nil)
+	assert.NotEmpty(t, w.Header().Get("X-Request-ID"))
+
+	// With X-Request-ID → preserves it.
+	w = doRequest(r, http.MethodGet, "/health", nil, "X-Request-ID", "custom-id-123")
+	assert.Equal(t, "custom-id-123", w.Header().Get("X-Request-ID"))
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-88.

Closes #88

## Changes

GitHub Issue #88: Admin API: router, service interfaces, handlers, wiring, and tests (`internal...

Parent: GH-13

This is the core implementation. Define `AdminUserService`, `AdminClientService`, and `AdminTokenService` interfaces in `internal/api/`. Create `NewAdminRouter(services) *gin.Engine` with correlation ID middleware (no auth, no rate limiting). Implement all admin handlers: user CRUD (list/get/create/update/soft-delete/lock/unlock) in `admin_user_handlers.go`, client CRUD with secret rotation (24h grace period, return secret only on create/rotate) in `admin_client_handlers.go`, and RFC 7662 token introspection (JWT decode for access tokens, DB lookup for refresh tokens) in `admin_token_handlers.go`. Replace the stub `adminGinEngine()` in `main.go` with the real `NewAdminRouter()` wiring. Write comprehensive tests covering all endpoints, error cases, pagination, and soft-delete behavior in `admin_*_test.go`.