### PR TITLE
GH-87: Admin domain models and validation (`internal/domain/`)

### DIFF
--- a/internal/domain/admin.go
+++ b/internal/domain/admin.go
@@ -1,0 +1,137 @@
+package domain
+
+import "time"
+
+// --- Admin request structs ---
+
+// CreateUserRequest is the validated request body for admin user creation.
+type CreateUserRequest struct {
+	Email    string   `json:"email"    validate:"required,email"`
+	Password string   `json:"password" validate:"required,nist_password"`
+	Name     string   `json:"name"     validate:"required,min=1,max=255"`
+	Roles    []string `json:"roles"    validate:"omitempty,dive,oneof=admin user"`
+}
+
+// UpdateUserRequest is the validated request body for admin user updates.
+type UpdateUserRequest struct {
+	Email  *string  `json:"email"  validate:"omitempty,email"`
+	Name   *string  `json:"name"   validate:"omitempty,min=1,max=255"`
+	Roles  []string `json:"roles"  validate:"omitempty,dive,oneof=admin user"`
+	Locked *bool    `json:"locked"`
+}
+
+// ListUsersRequest holds pagination parameters for listing users.
+type ListUsersRequest struct {
+	Limit  int    `form:"limit"  validate:"omitempty,min=1,max=100"`
+	Offset int    `form:"offset" validate:"omitempty,min=0"`
+	Status string `form:"status" validate:"omitempty,oneof=active locked deleted"`
+}
+
+// DefaultLimit returns the effective limit, defaulting to 20 if unset.
+func (r *ListUsersRequest) DefaultLimit() int {
+	if r.Limit == 0 {
+		return 20
+	}
+	return r.Limit
+}
+
+// CreateClientRequest is the validated request body for admin client creation.
+type CreateClientRequest struct {
+	Name       string   `json:"name"        validate:"required,min=1,max=255"`
+	ClientType string   `json:"client_type" validate:"required,client_type"`
+	Scopes     []string `json:"scopes"      validate:"required,min=1,dive,valid_scope"`
+	OwnerID    string   `json:"owner_id"    validate:"omitempty"`
+}
+
+// UpdateClientRequest is the validated request body for admin client updates.
+type UpdateClientRequest struct {
+	Name   *string  `json:"name"   validate:"omitempty,min=1,max=255"`
+	Scopes []string `json:"scopes" validate:"omitempty,min=1,dive,valid_scope"`
+	Active *bool    `json:"active"`
+}
+
+// ListClientsRequest holds pagination parameters for listing clients.
+type ListClientsRequest struct {
+	Limit      int    `form:"limit"       validate:"omitempty,min=1,max=100"`
+	Offset     int    `form:"offset"      validate:"omitempty,min=0"`
+	ClientType string `form:"client_type" validate:"omitempty,client_type"`
+}
+
+// DefaultLimit returns the effective limit, defaulting to 20 if unset.
+func (r *ListClientsRequest) DefaultLimit() int {
+	if r.Limit == 0 {
+		return 20
+	}
+	return r.Limit
+}
+
+// IntrospectTokenRequest is the validated request body for token introspection (RFC 7662).
+type IntrospectTokenRequest struct {
+	Token string `json:"token" validate:"required"`
+}
+
+// --- Admin response structs ---
+
+// AdminUserResponse is the admin view of a user, including status and timestamps.
+type AdminUserResponse struct {
+	ID        string     `json:"id"`
+	Email     string     `json:"email"`
+	Name      string     `json:"name"`
+	Roles     []string   `json:"roles"`
+	Status    string     `json:"status"`
+	Locked    bool       `json:"locked"`
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
+}
+
+// AdminClientResponse is the admin view of an OAuth2 client.
+type AdminClientResponse struct {
+	ID         string    `json:"id"`
+	Name       string    `json:"name"`
+	ClientID   string    `json:"client_id"`
+	ClientType string    `json:"client_type"`
+	Scopes     []string  `json:"scopes"`
+	OwnerID    string    `json:"owner_id,omitempty"`
+	Active     bool      `json:"active"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+// IntrospectionResponse follows RFC 7662 token introspection response format.
+type IntrospectionResponse struct {
+	Active    bool   `json:"active"`
+	Sub       string `json:"sub,omitempty"`
+	ClientID  string `json:"client_id,omitempty"`
+	Scope     string `json:"scope,omitempty"`
+	Exp       int64  `json:"exp,omitempty"`
+	Iat       int64  `json:"iat,omitempty"`
+	TokenType string `json:"token_type,omitempty"`
+}
+
+// PaginatedResponse is a generic wrapper for paginated list endpoints.
+type PaginatedResponse struct {
+	Items  interface{} `json:"items"`
+	Total  int64       `json:"total"`
+	Limit  int         `json:"limit"`
+	Offset int         `json:"offset"`
+}
+
+// --- Admin validation rules ---
+
+// ValidClientTypes are the allowed client_type values.
+var ValidClientTypes = map[string]bool{
+	ClientTypeService: true,
+	ClientTypeAgent:   true,
+}
+
+// ValidScopes are the allowed OAuth2 scope values for system clients.
+var ValidScopes = map[string]bool{
+	"read:users":    true,
+	"write:users":   true,
+	"read:clients":  true,
+	"write:clients": true,
+	"read:tokens":   true,
+	"write:tokens":  true,
+	"admin":         true,
+}

--- a/internal/domain/admin_test.go
+++ b/internal/domain/admin_test.go
@@ -1,0 +1,358 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateUserRequest_Validation(t *testing.T) {
+	v := NewValidator()
+
+	tests := []struct {
+		name    string
+		req     CreateUserRequest
+		wantErr bool
+	}{
+		{
+			name: "valid request",
+			req: CreateUserRequest{
+				Email:    "admin@example.com",
+				Password: "a]very$ecurePassw0rd",
+				Name:     "Admin User",
+				Roles:    []string{"admin"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing email",
+			req: CreateUserRequest{
+				Password: "a]very$ecurePassw0rd",
+				Name:     "Admin User",
+			},
+			wantErr: true,
+		},
+		{
+			name: "short password",
+			req: CreateUserRequest{
+				Email:    "admin@example.com",
+				Password: "short",
+				Name:     "Admin User",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid role",
+			req: CreateUserRequest{
+				Email:    "admin@example.com",
+				Password: "a]very$ecurePassw0rd",
+				Name:     "Admin User",
+				Roles:    []string{"superadmin"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "no roles is valid",
+			req: CreateUserRequest{
+				Email:    "admin@example.com",
+				Password: "a]very$ecurePassw0rd",
+				Name:     "Admin User",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.Struct(tt.req)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestUpdateUserRequest_Validation(t *testing.T) {
+	v := NewValidator()
+
+	email := "new@example.com"
+	badEmail := "notanemail"
+
+	tests := []struct {
+		name    string
+		req     UpdateUserRequest
+		wantErr bool
+	}{
+		{
+			name:    "empty update is valid",
+			req:     UpdateUserRequest{},
+			wantErr: false,
+		},
+		{
+			name:    "valid email update",
+			req:     UpdateUserRequest{Email: &email},
+			wantErr: false,
+		},
+		{
+			name:    "invalid email",
+			req:     UpdateUserRequest{Email: &badEmail},
+			wantErr: true,
+		},
+		{
+			name:    "invalid role in update",
+			req:     UpdateUserRequest{Roles: []string{"root"}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.Struct(tt.req)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCreateClientRequest_Validation(t *testing.T) {
+	v := NewValidator()
+
+	tests := []struct {
+		name    string
+		req     CreateClientRequest
+		wantErr bool
+	}{
+		{
+			name: "valid service client",
+			req: CreateClientRequest{
+				Name:       "My Service",
+				ClientType: "service",
+				Scopes:     []string{"read:users", "write:users"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid agent client",
+			req: CreateClientRequest{
+				Name:       "My Agent",
+				ClientType: "agent",
+				Scopes:     []string{"read:tokens"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid client_type",
+			req: CreateClientRequest{
+				Name:       "Bad Type",
+				ClientType: "user",
+				Scopes:     []string{"read:users"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid scope",
+			req: CreateClientRequest{
+				Name:       "Bad Scope",
+				ClientType: "service",
+				Scopes:     []string{"delete:everything"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty scopes",
+			req: CreateClientRequest{
+				Name:       "No Scopes",
+				ClientType: "service",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing name",
+			req: CreateClientRequest{
+				ClientType: "service",
+				Scopes:     []string{"read:users"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.Struct(tt.req)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestUpdateClientRequest_Validation(t *testing.T) {
+	v := NewValidator()
+
+	name := "Updated Name"
+
+	tests := []struct {
+		name    string
+		req     UpdateClientRequest
+		wantErr bool
+	}{
+		{
+			name:    "empty update is valid",
+			req:     UpdateClientRequest{},
+			wantErr: false,
+		},
+		{
+			name:    "valid name update",
+			req:     UpdateClientRequest{Name: &name},
+			wantErr: false,
+		},
+		{
+			name:    "valid scopes update",
+			req:     UpdateClientRequest{Scopes: []string{"admin"}},
+			wantErr: false,
+		},
+		{
+			name:    "invalid scope in update",
+			req:     UpdateClientRequest{Scopes: []string{"nuke:everything"}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.Struct(tt.req)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestIntrospectTokenRequest_Validation(t *testing.T) {
+	v := NewValidator()
+
+	t.Run("valid", func(t *testing.T) {
+		req := IntrospectTokenRequest{Token: "qf_at_abc123"}
+		assert.NoError(t, v.Struct(req))
+	})
+
+	t.Run("missing token", func(t *testing.T) {
+		req := IntrospectTokenRequest{}
+		assert.Error(t, v.Struct(req))
+	})
+}
+
+func TestListUsersRequest_DefaultLimit(t *testing.T) {
+	t.Run("returns 20 when unset", func(t *testing.T) {
+		r := &ListUsersRequest{}
+		assert.Equal(t, 20, r.DefaultLimit())
+	})
+
+	t.Run("returns set value", func(t *testing.T) {
+		r := &ListUsersRequest{Limit: 50}
+		assert.Equal(t, 50, r.DefaultLimit())
+	})
+}
+
+func TestListClientsRequest_DefaultLimit(t *testing.T) {
+	t.Run("returns 20 when unset", func(t *testing.T) {
+		r := &ListClientsRequest{}
+		assert.Equal(t, 20, r.DefaultLimit())
+	})
+
+	t.Run("returns set value", func(t *testing.T) {
+		r := &ListClientsRequest{Limit: 10}
+		assert.Equal(t, 10, r.DefaultLimit())
+	})
+}
+
+func TestListUsersRequest_StatusValidation(t *testing.T) {
+	v := NewValidator()
+
+	tests := []struct {
+		name    string
+		status  string
+		wantErr bool
+	}{
+		{"empty is valid", "", false},
+		{"active", "active", false},
+		{"locked", "locked", false},
+		{"deleted", "deleted", false},
+		{"invalid", "banned", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := ListUsersRequest{Status: tt.status}
+			err := v.Struct(req)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestListClientsRequest_ClientTypeValidation(t *testing.T) {
+	v := NewValidator()
+
+	tests := []struct {
+		name       string
+		clientType string
+		wantErr    bool
+	}{
+		{"empty is valid", "", false},
+		{"service", "service", false},
+		{"agent", "agent", false},
+		{"invalid", "user", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := ListClientsRequest{ClientType: tt.clientType}
+			err := v.Struct(req)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidationMessages_AdminTypes(t *testing.T) {
+	v := NewValidator()
+
+	t.Run("client_type message", func(t *testing.T) {
+		req := CreateClientRequest{
+			Name:       "Test",
+			ClientType: "invalid",
+			Scopes:     []string{"read:users"},
+		}
+		err := v.Struct(req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "client_type")
+	})
+
+	t.Run("valid_scope message", func(t *testing.T) {
+		req := CreateClientRequest{
+			Name:       "Test",
+			ClientType: "service",
+			Scopes:     []string{"bad:scope"},
+		}
+		err := v.Struct(req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "valid_scope")
+	})
+}

--- a/internal/domain/validation.go
+++ b/internal/domain/validation.go
@@ -70,7 +70,19 @@ type PasswordChangeRequest struct {
 func NewValidator() *validator.Validate {
 	v := validator.New()
 	_ = v.RegisterValidation("nist_password", validateNistPassword)
+	_ = v.RegisterValidation("client_type", validateClientType)
+	_ = v.RegisterValidation("valid_scope", validateScope)
 	return v
+}
+
+// validateClientType ensures the value is one of "service" or "agent".
+func validateClientType(fl validator.FieldLevel) bool {
+	return ValidClientTypes[fl.Field().String()]
+}
+
+// validateScope ensures the value is one of the allowed OAuth2 scopes.
+func validateScope(fl validator.FieldLevel) bool {
+	return ValidScopes[fl.Field().String()]
 }
 
 // validateNistPassword enforces NIST SP 800-63-4 password policy:
@@ -140,6 +152,10 @@ func validationMessage(fe validator.FieldError) string {
 		return fmt.Sprintf("must be one of: %s", fe.Param())
 	case "required_if":
 		return fmt.Sprintf("%s is required for this grant type", strings.ToLower(fe.Field()))
+	case "client_type":
+		return "must be one of: service, agent"
+	case "valid_scope":
+		return "invalid scope"
 	default:
 		return fmt.Sprintf("failed validation: %s", fe.Tag())
 	}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-87.

Closes #87

## Changes

GitHub Issue #87: Admin domain models and validation (`internal/domain/`)

Parent: GH-13

Define all admin-specific request and response types: `CreateUserRequest`, `UpdateUserRequest`, `ListUsersRequest` (pagination params), `CreateClientRequest`, `UpdateClientRequest`, `IntrospectTokenRequest`. Define response structs: `AdminUserResponse` (includes status, locked, timestamps), `AdminClientResponse` (includes scopes, client_type, owner), `IntrospectionResponse` (RFC 7662: active, sub, client_id, scope, exp, iat, token_type), and `PaginatedResponse` wrapper (items, total, limit, offset). Add validation rules for admin fields (e.g., client_type must be one of service/agent, scopes validation). This subtask has no dependencies and is needed by subtask 2.