### PR TITLE
GH-120: Health Check Package (`internal/health/`)

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -1,0 +1,167 @@
+// Package health provides health checking for service dependencies.
+// It supports liveness, readiness, and detailed health reporting with
+// degraded status when some (but not all) checks fail.
+package health
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Status represents the overall health status.
+type Status string
+
+const (
+	StatusHealthy   Status = "healthy"
+	StatusDegraded  Status = "degraded"
+	StatusUnhealthy Status = "unhealthy"
+)
+
+// Result is the outcome of a single health check.
+type Result struct {
+	Status   Status        `json:"status"`
+	Message  string        `json:"message,omitempty"`
+	Duration time.Duration `json:"-"`
+}
+
+// Response is the full health check response returned to callers.
+type Response struct {
+	Status Status            `json:"status"`
+	Checks map[string]Result `json:"checks,omitempty"`
+	Uptime time.Duration     `json:"-"`
+}
+
+// MarshalableResponse is the JSON-friendly version of Response.
+type MarshalableResponse struct {
+	Status string                       `json:"status"`
+	Checks map[string]MarshalableResult `json:"checks,omitempty"`
+	Uptime string                       `json:"uptime"`
+}
+
+// MarshalableResult is the JSON-friendly version of Result.
+type MarshalableResult struct {
+	Status   string `json:"status"`
+	Message  string `json:"message,omitempty"`
+	Duration string `json:"duration"`
+}
+
+// ToMarshalable converts a Response to its JSON-friendly representation.
+func (r Response) ToMarshalable() MarshalableResponse {
+	m := MarshalableResponse{
+		Status: string(r.Status),
+		Uptime: r.Uptime.Round(time.Millisecond).String(),
+	}
+	if len(r.Checks) > 0 {
+		m.Checks = make(map[string]MarshalableResult, len(r.Checks))
+		for name, check := range r.Checks {
+			m.Checks[name] = MarshalableResult{
+				Status:   string(check.Status),
+				Message:  check.Message,
+				Duration: check.Duration.Round(time.Microsecond).String(),
+			}
+		}
+	}
+	return m
+}
+
+// Checker performs a named health check against a dependency.
+type Checker interface {
+	// Name returns a human-readable identifier for this checker.
+	Name() string
+	// Check runs the health check and returns the result.
+	Check(ctx context.Context) Result
+}
+
+// Service aggregates multiple health checkers and computes overall status.
+type Service struct {
+	checkers []Checker
+	start    time.Time
+}
+
+// NewService creates a health Service with the given checkers.
+func NewService(checkers ...Checker) *Service {
+	return &Service{
+		checkers: checkers,
+		start:    time.Now(),
+	}
+}
+
+// Liveness returns a simple OK response. It does not check dependencies.
+func (s *Service) Liveness() Response {
+	return Response{
+		Status: StatusHealthy,
+		Uptime: time.Since(s.start),
+	}
+}
+
+// Readiness checks all dependencies. All must pass for a healthy response.
+func (s *Service) Readiness(ctx context.Context) Response {
+	resp := s.Health(ctx)
+	// Readiness is binary: anything other than healthy becomes unhealthy.
+	if resp.Status != StatusHealthy {
+		resp.Status = StatusUnhealthy
+	}
+	return resp
+}
+
+// Health runs all checkers concurrently and computes overall status.
+// - All pass → healthy
+// - Some pass → degraded
+// - None pass → unhealthy
+func (s *Service) Health(ctx context.Context) Response {
+	if len(s.checkers) == 0 {
+		return Response{
+			Status: StatusHealthy,
+			Uptime: time.Since(s.start),
+		}
+	}
+
+	type namedResult struct {
+		name   string
+		result Result
+	}
+
+	results := make([]namedResult, len(s.checkers))
+	var wg sync.WaitGroup
+	wg.Add(len(s.checkers))
+
+	for i, c := range s.checkers {
+		go func(idx int, checker Checker) {
+			defer wg.Done()
+			results[idx] = namedResult{
+				name:   checker.Name(),
+				result: checker.Check(ctx),
+			}
+		}(i, c)
+	}
+
+	wg.Wait()
+
+	checks := make(map[string]Result, len(results))
+	var passed, failed int
+	for _, nr := range results {
+		checks[nr.name] = nr.result
+		if nr.result.Status == StatusHealthy {
+			passed++
+		} else {
+			failed++
+		}
+	}
+
+	var status Status
+	switch {
+	case failed == 0:
+		status = StatusHealthy
+	case passed == 0:
+		status = StatusUnhealthy
+	default:
+		status = StatusDegraded
+	}
+
+	return Response{
+		Status: status,
+		Checks: checks,
+		Uptime: time.Since(s.start),
+	}
+}

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -1,0 +1,195 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockChecker is a configurable health checker for testing.
+type mockChecker struct {
+	name   string
+	status Status
+	err    error
+	delay  time.Duration
+}
+
+func (m *mockChecker) Name() string { return m.name }
+
+func (m *mockChecker) Check(_ context.Context) Result {
+	if m.delay > 0 {
+		time.Sleep(m.delay)
+	}
+	if m.err != nil {
+		return Result{
+			Status:  StatusUnhealthy,
+			Message: m.err.Error(),
+		}
+	}
+	return Result{Status: m.status}
+}
+
+func newMock(name string, status Status) *mockChecker {
+	return &mockChecker{name: name, status: status}
+}
+
+func newFailingMock(name string, err error) *mockChecker {
+	return &mockChecker{name: name, status: StatusUnhealthy, err: err}
+}
+
+// --- Service tests ---
+
+func TestLiveness_AlwaysHealthy(t *testing.T) {
+	svc := NewService(newFailingMock("db", errors.New("down")))
+	resp := svc.Liveness()
+
+	assert.Equal(t, StatusHealthy, resp.Status)
+	assert.Empty(t, resp.Checks, "liveness must not run checkers")
+	assert.Greater(t, resp.Uptime, time.Duration(0))
+}
+
+func TestHealth_NoCheckers(t *testing.T) {
+	svc := NewService()
+	resp := svc.Health(context.Background())
+
+	assert.Equal(t, StatusHealthy, resp.Status)
+	assert.Empty(t, resp.Checks)
+}
+
+func TestHealth_AllHealthy(t *testing.T) {
+	svc := NewService(
+		newMock("postgres", StatusHealthy),
+		newMock("redis", StatusHealthy),
+	)
+	resp := svc.Health(context.Background())
+
+	assert.Equal(t, StatusHealthy, resp.Status)
+	require.Len(t, resp.Checks, 2)
+	assert.Equal(t, StatusHealthy, resp.Checks["postgres"].Status)
+	assert.Equal(t, StatusHealthy, resp.Checks["redis"].Status)
+}
+
+func TestHealth_AllUnhealthy(t *testing.T) {
+	svc := NewService(
+		newFailingMock("postgres", errors.New("connection refused")),
+		newFailingMock("redis", errors.New("timeout")),
+	)
+	resp := svc.Health(context.Background())
+
+	assert.Equal(t, StatusUnhealthy, resp.Status)
+	require.Len(t, resp.Checks, 2)
+	assert.Equal(t, StatusUnhealthy, resp.Checks["postgres"].Status)
+	assert.Equal(t, "connection refused", resp.Checks["postgres"].Message)
+	assert.Equal(t, StatusUnhealthy, resp.Checks["redis"].Status)
+	assert.Equal(t, "timeout", resp.Checks["redis"].Message)
+}
+
+func TestHealth_Degraded(t *testing.T) {
+	svc := NewService(
+		newMock("postgres", StatusHealthy),
+		newFailingMock("redis", errors.New("connection lost")),
+	)
+	resp := svc.Health(context.Background())
+
+	assert.Equal(t, StatusDegraded, resp.Status)
+	require.Len(t, resp.Checks, 2)
+	assert.Equal(t, StatusHealthy, resp.Checks["postgres"].Status)
+	assert.Equal(t, StatusUnhealthy, resp.Checks["redis"].Status)
+}
+
+func TestReadiness_HealthyWhenAllPass(t *testing.T) {
+	svc := NewService(
+		newMock("postgres", StatusHealthy),
+		newMock("redis", StatusHealthy),
+	)
+	resp := svc.Readiness(context.Background())
+
+	assert.Equal(t, StatusHealthy, resp.Status)
+}
+
+func TestReadiness_UnhealthyWhenDegraded(t *testing.T) {
+	svc := NewService(
+		newMock("postgres", StatusHealthy),
+		newFailingMock("redis", errors.New("down")),
+	)
+	resp := svc.Readiness(context.Background())
+
+	// Readiness is binary: degraded → unhealthy.
+	assert.Equal(t, StatusUnhealthy, resp.Status)
+}
+
+func TestReadiness_UnhealthyWhenAllFail(t *testing.T) {
+	svc := NewService(
+		newFailingMock("postgres", errors.New("down")),
+		newFailingMock("redis", errors.New("down")),
+	)
+	resp := svc.Readiness(context.Background())
+
+	assert.Equal(t, StatusUnhealthy, resp.Status)
+}
+
+func TestHealth_RunsConcurrently(t *testing.T) {
+	slow := &mockChecker{name: "slow", status: StatusHealthy, delay: 50 * time.Millisecond}
+	fast := &mockChecker{name: "fast", status: StatusHealthy, delay: 50 * time.Millisecond}
+
+	svc := NewService(slow, fast)
+	start := time.Now()
+	resp := svc.Health(context.Background())
+	elapsed := time.Since(start)
+
+	assert.Equal(t, StatusHealthy, resp.Status)
+	// If run sequentially, would take ≥100ms. Concurrent should be ~50ms.
+	assert.Less(t, elapsed, 90*time.Millisecond, "checks should run concurrently")
+}
+
+func TestHealth_UptimeIncreases(t *testing.T) {
+	svc := NewService()
+	resp1 := svc.Liveness()
+	time.Sleep(5 * time.Millisecond)
+	resp2 := svc.Liveness()
+
+	assert.Greater(t, resp2.Uptime, resp1.Uptime)
+}
+
+// --- ToMarshalable tests ---
+
+func TestResponse_ToMarshalable(t *testing.T) {
+	resp := Response{
+		Status: StatusDegraded,
+		Checks: map[string]Result{
+			"postgres": {Status: StatusHealthy, Duration: 1500 * time.Microsecond},
+			"redis":    {Status: StatusUnhealthy, Message: "timeout", Duration: 5 * time.Millisecond},
+		},
+		Uptime: 2*time.Hour + 30*time.Minute,
+	}
+
+	m := resp.ToMarshalable()
+	assert.Equal(t, "degraded", m.Status)
+	assert.Equal(t, "2h30m0s", m.Uptime)
+	require.Len(t, m.Checks, 2)
+	assert.Equal(t, "healthy", m.Checks["postgres"].Status)
+	assert.Equal(t, "unhealthy", m.Checks["redis"].Status)
+	assert.Equal(t, "timeout", m.Checks["redis"].Message)
+}
+
+func TestResponse_ToMarshalable_NoChecks(t *testing.T) {
+	resp := Response{
+		Status: StatusHealthy,
+		Uptime: time.Second,
+	}
+	m := resp.ToMarshalable()
+	assert.Equal(t, "healthy", m.Status)
+	assert.Nil(t, m.Checks)
+}
+
+// --- Status constants ---
+
+func TestStatusConstants(t *testing.T) {
+	assert.Equal(t, Status("healthy"), StatusHealthy)
+	assert.Equal(t, Status("degraded"), StatusDegraded)
+	assert.Equal(t, Status("unhealthy"), StatusUnhealthy)
+}

--- a/internal/health/postgres.go
+++ b/internal/health/postgres.go
@@ -1,0 +1,37 @@
+package health
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PostgresChecker checks PostgreSQL connectivity by pinging the pool.
+type PostgresChecker struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresChecker creates a checker for the given connection pool.
+func NewPostgresChecker(pool *pgxpool.Pool) *PostgresChecker {
+	return &PostgresChecker{pool: pool}
+}
+
+// Name returns the checker identifier.
+func (c *PostgresChecker) Name() string { return "postgres" }
+
+// Check pings the PostgreSQL pool and returns the result.
+func (c *PostgresChecker) Check(ctx context.Context) Result {
+	start := time.Now()
+	if err := c.pool.Ping(ctx); err != nil {
+		return Result{
+			Status:   StatusUnhealthy,
+			Message:  err.Error(),
+			Duration: time.Since(start),
+		}
+	}
+	return Result{
+		Status:   StatusHealthy,
+		Duration: time.Since(start),
+	}
+}

--- a/internal/health/redis.go
+++ b/internal/health/redis.go
@@ -1,0 +1,37 @@
+package health
+
+import (
+	"context"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisChecker checks Redis connectivity by pinging the client.
+type RedisChecker struct {
+	client *redis.Client
+}
+
+// NewRedisChecker creates a checker for the given Redis client.
+func NewRedisChecker(client *redis.Client) *RedisChecker {
+	return &RedisChecker{client: client}
+}
+
+// Name returns the checker identifier.
+func (c *RedisChecker) Name() string { return "redis" }
+
+// Check pings the Redis server and returns the result.
+func (c *RedisChecker) Check(ctx context.Context) Result {
+	start := time.Now()
+	if err := c.client.Ping(ctx).Err(); err != nil {
+		return Result{
+			Status:   StatusUnhealthy,
+			Message:  err.Error(),
+			Duration: time.Since(start),
+		}
+	}
+	return Result{
+		Status:   StatusHealthy,
+		Duration: time.Since(start),
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-120.

Closes #120

## Changes

Create a new standalone package for health checking logic:
- `HealthChecker` interface with `Check(ctx context.Context) HealthResult`
- `PostgresChecker` implementation (accepts `*pgxpool.Pool`, pings DB)
- `RedisChecker` implementation (accepts `*redis.Client`, pings Redis)
- `Service` that aggregates multiple checkers and computes overall status (`healthy | degraded | unhealthy`)
- Health status types and JSON response structs (`status`, `checks` map, `uptime`)
- Separate logic for liveness (always OK) vs readiness (all deps must pass) vs health (report with degraded support)
- Comprehensive unit tests with mock checkers (`internal/health/health_test.go`)