### PR TITLE
GH-8: Client credentials flow for systems and AI agents

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/qf-studio/auth-service/internal/api"
 	"github.com/qf-studio/auth-service/internal/auth"
+	"github.com/qf-studio/auth-service/internal/client"
 	"github.com/qf-studio/auth-service/internal/config"
 	"github.com/qf-studio/auth-service/internal/health"
 	"github.com/qf-studio/auth-service/internal/httpserver"
@@ -62,12 +63,23 @@ func run(log *zap.Logger) error {
 	}
 	defer func() { _ = redisClient.Close() }()
 
+	// ── PostgreSQL ────────────────────────────────────────────────────────
+	pgPool, err := storage.NewPostgresPool(cfg.Postgres.DSN(), cfg.Postgres.MaxConns)
+	if err != nil {
+		return fmt.Errorf("postgres connection failed: %w", err)
+	}
+	defer pgPool.Close()
+
 	// ── Services ─────────────────────────────────────────────────────────
 	authSvc := auth.NewService(redisClient, log)
 	tokenSvc, err := token.NewService(cfg.JWT, redisClient, log)
 	if err != nil {
 		return fmt.Errorf("token service init failed: %w", err)
 	}
+
+	clientRepo := storage.NewPostgresClientRepository(pgPool)
+	clientSvc := client.NewService(clientRepo, tokenSvc, log)
+	tokenSvc.SetClientAuthenticator(clientSvc)
 
 	services := &api.Services{
 		Auth:  authSvc,
@@ -77,6 +89,7 @@ func run(log *zap.Logger) error {
 	// ── Health ─────────────────────────────────────────────────────────────
 	healthCheckers := []health.Checker{
 		health.NewRedisChecker(redisClient),
+		health.NewPostgresChecker(pgPool),
 	}
 	healthSvc := health.NewService(healthCheckers...)
 
@@ -97,9 +110,9 @@ func run(log *zap.Logger) error {
 	}
 
 	// ── Admin services ────────────────────────────────────────────────────
-	// Admin service implementations will be wired here as they are built.
-	// For now, nil services are guarded by NewAdminRouter's nil checks.
-	adminServices := &api.AdminServices{}
+	adminServices := &api.AdminServices{
+		Clients: clientSvc,
+	}
 
 	adminDeps := &api.AdminDeps{
 		Health:  healthSvc,

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.1
+	golang.org/x/crypto v0.49.0
 	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -50,7 +51,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/arch v0.22.0 // indirect
-	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -46,6 +46,12 @@ type TokenService interface {
 	JWKS(ctx context.Context) (*JWKSResponse, error)
 }
 
+// ClientAuthenticator performs the OAuth2 client credentials grant.
+// Implemented by the client service and injected into the token service.
+type ClientAuthenticator interface {
+	ClientCredentialsGrant(ctx context.Context, clientID, clientSecret string) (*AuthResult, error)
+}
+
 // Services aggregates all service interfaces required by the API handlers.
 type Services struct {
 	Auth  AuthService

--- a/internal/client/service.go
+++ b/internal/client/service.go
@@ -1,0 +1,373 @@
+// Package client implements OAuth2 client management and the client credentials grant.
+package client
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+	"golang.org/x/crypto/argon2"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+const (
+	// clientSecretPrefix is prepended to generated secrets for leak detection.
+	clientSecretPrefix = "qf_cs_"
+
+	// secretBytes is the number of random bytes in a client secret (256 bits).
+	secretBytes = 32
+
+	// saltBytes is the number of random bytes for the Argon2id salt.
+	saltBytes = 16
+
+	// Argon2id parameters per NIST SP 800-63B / project security profile.
+	argon2Memory      uint32 = 19456 // KiB (19 MiB)
+	argon2Time        uint32 = 2
+	argon2Parallelism uint8  = 1
+	argon2KeyLen      uint32 = 32
+
+	// Default access token TTLs by client type (seconds).
+	defaultServiceTTL = 900 // 15 minutes
+	defaultAgentTTL   = 300 // 5 minutes
+)
+
+// TokenIssuer can issue access-only tokens for M2M clients.
+// Implemented by *token.Service.
+type TokenIssuer interface {
+	IssueAccessTokenOnly(ctx context.Context, subject string, scopes []string, clientType string, ttl time.Duration) (*api.AuthResult, error)
+}
+
+// Service manages OAuth2 clients and implements the client credentials grant.
+// It satisfies api.AdminClientService and api.ClientAuthenticator.
+type Service struct {
+	repo   storage.ClientRepository
+	tokens TokenIssuer
+	logger *zap.Logger
+}
+
+// NewService creates a new client Service.
+func NewService(repo storage.ClientRepository, tokens TokenIssuer, logger *zap.Logger) *Service {
+	return &Service{
+		repo:   repo,
+		tokens: tokens,
+		logger: logger,
+	}
+}
+
+// ── Client Credentials Grant (api.ClientAuthenticator) ─────────────────────
+
+// ClientCredentialsGrant authenticates a client and issues a short-lived access token.
+func (s *Service) ClientCredentialsGrant(ctx context.Context, clientID, clientSecret string) (*api.AuthResult, error) {
+	client, err := s.authenticateClient(ctx, clientID, clientSecret)
+	if err != nil {
+		return nil, fmt.Errorf("authenticate client: %w", api.ErrUnauthorized)
+	}
+
+	result, err := s.tokens.IssueAccessTokenOnly(ctx,
+		client.ID.String(),
+		client.Scopes,
+		string(client.ClientType),
+		client.AccessTokenDuration(),
+	)
+	if err != nil {
+		s.logger.Error("failed to issue access token",
+			zap.String("client_id", clientID),
+			zap.Error(err),
+		)
+		return nil, fmt.Errorf("issue token: %w", api.ErrInternalError)
+	}
+
+	return result, nil
+}
+
+// authenticateClient verifies client_id and client_secret, checks status, and
+// updates last_used_at. Returns a generic error for both not-found and wrong-secret
+// to prevent client enumeration.
+func (s *Service) authenticateClient(ctx context.Context, clientID, clientSecret string) (*domain.Client, error) {
+	client, err := s.repo.FindByID(ctx, clientID)
+	if err != nil {
+		s.logger.Debug("client lookup failed during authentication",
+			zap.String("client_id", clientID),
+			zap.Error(err),
+		)
+		return nil, storage.ErrInvalidCredentials
+	}
+
+	ok, err := verifySecret(clientSecret, client.SecretHash)
+	if err != nil || !ok {
+		if err != nil {
+			s.logger.Error("secret verification error", zap.Error(err))
+		}
+		return nil, storage.ErrInvalidCredentials
+	}
+
+	if !client.IsActive() {
+		return nil, storage.ErrAccountSuspended
+	}
+
+	if err := s.repo.UpdateLastUsedAt(ctx, clientID, time.Now().UTC()); err != nil {
+		// Non-fatal: log but continue.
+		s.logger.Warn("failed to update client last_used_at",
+			zap.String("client_id", clientID),
+			zap.Error(err),
+		)
+	}
+
+	return client, nil
+}
+
+// ── Admin Operations (api.AdminClientService) ───────────────────────────────
+
+// ListClients returns a paginated list of clients.
+func (s *Service) ListClients(ctx context.Context, page, perPage int, includeDeleted bool) (*api.AdminClientList, error) {
+	clients, total, err := s.repo.List(ctx, page, perPage, includeDeleted)
+	if err != nil {
+		s.logger.Error("list clients failed", zap.Error(err))
+		return nil, fmt.Errorf("list clients: %w", api.ErrInternalError)
+	}
+
+	out := make([]api.AdminClient, 0, len(clients))
+	for _, c := range clients {
+		out = append(out, domainToAdminClient(c))
+	}
+
+	return &api.AdminClientList{
+		Clients: out,
+		Total:   total,
+		Page:    page,
+		PerPage: perPage,
+	}, nil
+}
+
+// GetClient retrieves a single client by ID.
+func (s *Service) GetClient(ctx context.Context, clientID string) (*api.AdminClient, error) {
+	client, err := s.repo.FindByID(ctx, clientID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("client %s: %w", clientID, api.ErrNotFound)
+		}
+		return nil, fmt.Errorf("get client: %w", api.ErrInternalError)
+	}
+	out := domainToAdminClient(client)
+	return &out, nil
+}
+
+// CreateClient generates a new OAuth2 client with a random secret.
+// The plaintext secret is returned only once and never stored.
+func (s *Service) CreateClient(ctx context.Context, req *api.CreateClientRequest) (*api.AdminClientWithSecret, error) {
+	clientType := domain.ClientType(req.ClientType)
+	if !clientType.IsValid() {
+		return nil, fmt.Errorf("invalid client_type %q: %w", req.ClientType, api.ErrInternalError)
+	}
+
+	plaintextSecret, secretHash, err := generateSecret()
+	if err != nil {
+		return nil, fmt.Errorf("generate client secret: %w", api.ErrInternalError)
+	}
+
+	ttl := defaultServiceTTL
+	if clientType == domain.ClientTypeAgent {
+		ttl = defaultAgentTTL
+	}
+
+	now := time.Now().UTC()
+	client := &domain.Client{
+		ID:             uuid.New(),
+		Name:           req.Name,
+		ClientType:     clientType,
+		SecretHash:     secretHash,
+		Scopes:         req.Scopes,
+		Owner:          "",
+		AccessTokenTTL: ttl,
+		Status:         domain.ClientStatusActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	created, err := s.repo.Create(ctx, client)
+	if err != nil {
+		if errors.Is(err, storage.ErrDuplicateClient) {
+			return nil, fmt.Errorf("client name %q already exists: %w", req.Name, api.ErrConflict)
+		}
+		s.logger.Error("create client failed", zap.Error(err))
+		return nil, fmt.Errorf("create client: %w", api.ErrInternalError)
+	}
+
+	return &api.AdminClientWithSecret{
+		AdminClient:  domainToAdminClient(created),
+		ClientSecret: plaintextSecret,
+	}, nil
+}
+
+// UpdateClient modifies a client's name and/or scopes.
+func (s *Service) UpdateClient(ctx context.Context, clientID string, req *api.UpdateClientRequest) (*api.AdminClient, error) {
+	client, err := s.repo.FindByID(ctx, clientID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("client %s: %w", clientID, api.ErrNotFound)
+		}
+		return nil, fmt.Errorf("find client: %w", api.ErrInternalError)
+	}
+
+	if req.Name != nil {
+		client.Name = *req.Name
+	}
+	if req.Scopes != nil {
+		client.Scopes = req.Scopes
+	}
+
+	updated, err := s.repo.Update(ctx, client)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("client %s: %w", clientID, api.ErrNotFound)
+		}
+		if errors.Is(err, storage.ErrDuplicateClient) {
+			return nil, fmt.Errorf("client name already taken: %w", api.ErrConflict)
+		}
+		s.logger.Error("update client failed", zap.Error(err))
+		return nil, fmt.Errorf("update client: %w", api.ErrInternalError)
+	}
+
+	out := domainToAdminClient(updated)
+	return &out, nil
+}
+
+// DeleteClient soft-deletes a client by setting its status to "revoked".
+func (s *Service) DeleteClient(ctx context.Context, clientID string) error {
+	if err := s.repo.Delete(ctx, clientID); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return fmt.Errorf("client %s: %w", clientID, api.ErrNotFound)
+		}
+		s.logger.Error("delete client failed", zap.Error(err))
+		return fmt.Errorf("delete client: %w", api.ErrInternalError)
+	}
+	return nil
+}
+
+// RotateSecret generates a new client secret and replaces the stored hash.
+// The old secret is immediately invalidated. The new plaintext secret is
+// returned once and never stored.
+func (s *Service) RotateSecret(ctx context.Context, clientID string) (*api.AdminClientWithSecret, error) {
+	client, err := s.repo.FindByID(ctx, clientID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("client %s: %w", clientID, api.ErrNotFound)
+		}
+		return nil, fmt.Errorf("find client: %w", api.ErrInternalError)
+	}
+
+	plaintextSecret, secretHash, err := generateSecret()
+	if err != nil {
+		return nil, fmt.Errorf("generate new secret: %w", api.ErrInternalError)
+	}
+
+	client.SecretHash = secretHash
+	updated, err := s.repo.Update(ctx, client)
+	if err != nil {
+		s.logger.Error("rotate secret failed", zap.Error(err))
+		return nil, fmt.Errorf("rotate secret: %w", api.ErrInternalError)
+	}
+
+	return &api.AdminClientWithSecret{
+		AdminClient:  domainToAdminClient(updated),
+		ClientSecret: plaintextSecret,
+	}, nil
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+// generateSecret produces a cryptographically random 256-bit client secret
+// prefixed with "qf_cs_", and returns both the plaintext and its Argon2id hash.
+func generateSecret() (plaintext, hash string, err error) {
+	raw := make([]byte, secretBytes)
+	if _, err = rand.Read(raw); err != nil {
+		return "", "", fmt.Errorf("crypto/rand: %w", err)
+	}
+
+	plaintext = clientSecretPrefix + base64.RawURLEncoding.EncodeToString(raw)
+
+	hash, err = hashSecret(plaintext)
+	if err != nil {
+		return "", "", fmt.Errorf("hash secret: %w", err)
+	}
+
+	return plaintext, hash, nil
+}
+
+// hashSecret hashes a secret with Argon2id and returns a PHC-format string.
+// Format: $argon2id$v=<version>$m=<memory>,t=<time>,p=<parallelism>$<salt_b64>$<hash_b64>
+func hashSecret(secret string) (string, error) {
+	salt := make([]byte, saltBytes)
+	if _, err := rand.Read(salt); err != nil {
+		return "", fmt.Errorf("generate salt: %w", err)
+	}
+
+	hash := argon2.IDKey([]byte(secret), salt, argon2Time, argon2Memory, argon2Parallelism, argon2KeyLen)
+
+	encoded := fmt.Sprintf("$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
+		argon2.Version,
+		argon2Memory, argon2Time, argon2Parallelism,
+		base64.RawStdEncoding.EncodeToString(salt),
+		base64.RawStdEncoding.EncodeToString(hash),
+	)
+
+	return encoded, nil
+}
+
+// verifySecret verifies a plaintext secret against an Argon2id PHC hash string.
+func verifySecret(secret, encoded string) (bool, error) {
+	// $argon2id$v=19$m=<M>,t=<T>,p=<P>$<salt_b64>$<hash_b64>
+	parts := strings.Split(encoded, "$")
+	if len(parts) != 6 || parts[1] != "argon2id" {
+		return false, fmt.Errorf("invalid hash format")
+	}
+
+	var m, t, p int
+	if _, err := fmt.Sscanf(parts[3], "m=%d,t=%d,p=%d", &m, &t, &p); err != nil {
+		return false, fmt.Errorf("parse argon2 params: %w", err)
+	}
+
+	salt, err := base64.RawStdEncoding.DecodeString(parts[4])
+	if err != nil {
+		return false, fmt.Errorf("decode salt: %w", err)
+	}
+
+	expectedHash, err := base64.RawStdEncoding.DecodeString(parts[5])
+	if err != nil {
+		return false, fmt.Errorf("decode hash: %w", err)
+	}
+
+	computed := argon2.IDKey(
+		[]byte(secret), salt,
+		uint32(t), uint32(m), uint8(p), //nolint:gosec // parsed from trusted PHC string
+		uint32(len(expectedHash)),
+	)
+
+	return subtle.ConstantTimeCompare(computed, expectedHash) == 1, nil
+}
+
+// domainToAdminClient converts a domain.Client to an api.AdminClient response type.
+func domainToAdminClient(c *domain.Client) api.AdminClient {
+	return api.AdminClient{
+		ID:         c.ID.String(),
+		Name:       c.Name,
+		ClientType: string(c.ClientType),
+		Scopes:     c.Scopes,
+		CreatedAt:  c.CreatedAt,
+		UpdatedAt:  c.UpdatedAt,
+	}
+}
+
+// Compile-time interface checks.
+var _ api.AdminClientService = (*Service)(nil)
+var _ api.ClientAuthenticator = (*Service)(nil)

--- a/internal/client/service_test.go
+++ b/internal/client/service_test.go
@@ -1,0 +1,845 @@
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/client"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+// mockClientRepo implements storage.ClientRepository for testing.
+type mockClientRepo struct {
+	createFn          func(ctx context.Context, c *domain.Client) (*domain.Client, error)
+	findByIDFn        func(ctx context.Context, id string) (*domain.Client, error)
+	listFn            func(ctx context.Context, page, perPage int, includeRevoked bool) ([]*domain.Client, int, error)
+	updateFn          func(ctx context.Context, c *domain.Client) (*domain.Client, error)
+	deleteFn          func(ctx context.Context, id string) error
+	updateLastUsedAtFn func(ctx context.Context, id string, t time.Time) error
+}
+
+func (m *mockClientRepo) Create(ctx context.Context, c *domain.Client) (*domain.Client, error) {
+	if m.createFn != nil {
+		return m.createFn(ctx, c)
+	}
+	c.CreatedAt = time.Now().UTC()
+	c.UpdatedAt = c.CreatedAt
+	return c, nil
+}
+
+func (m *mockClientRepo) FindByID(ctx context.Context, id string) (*domain.Client, error) {
+	if m.findByIDFn != nil {
+		return m.findByIDFn(ctx, id)
+	}
+	return nil, storage.ErrNotFound
+}
+
+func (m *mockClientRepo) List(ctx context.Context, page, perPage int, includeRevoked bool) ([]*domain.Client, int, error) {
+	if m.listFn != nil {
+		return m.listFn(ctx, page, perPage, includeRevoked)
+	}
+	return nil, 0, nil
+}
+
+func (m *mockClientRepo) Update(ctx context.Context, c *domain.Client) (*domain.Client, error) {
+	if m.updateFn != nil {
+		return m.updateFn(ctx, c)
+	}
+	c.UpdatedAt = time.Now().UTC()
+	return c, nil
+}
+
+func (m *mockClientRepo) Delete(ctx context.Context, id string) error {
+	if m.deleteFn != nil {
+		return m.deleteFn(ctx, id)
+	}
+	return nil
+}
+
+func (m *mockClientRepo) UpdateLastUsedAt(ctx context.Context, id string, t time.Time) error {
+	if m.updateLastUsedAtFn != nil {
+		return m.updateLastUsedAtFn(ctx, id, t)
+	}
+	return nil
+}
+
+// mockTokenIssuer implements client.TokenIssuer for testing.
+type mockTokenIssuer struct {
+	issueAccessTokenOnlyFn func(ctx context.Context, subject string, scopes []string, clientType string, ttl time.Duration) (*api.AuthResult, error)
+}
+
+func (m *mockTokenIssuer) IssueAccessTokenOnly(ctx context.Context, subject string, scopes []string, clientType string, ttl time.Duration) (*api.AuthResult, error) {
+	if m.issueAccessTokenOnlyFn != nil {
+		return m.issueAccessTokenOnlyFn(ctx, subject, scopes, clientType, ttl)
+	}
+	return &api.AuthResult{
+		AccessToken:  "qf_at_testtoken",
+		RefreshToken: "",
+		TokenType:    "Bearer",
+		ExpiresIn:    int(ttl.Seconds()),
+	}, nil
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+func newTestService(repo storage.ClientRepository, issuer client.TokenIssuer) *client.Service {
+	return client.NewService(repo, issuer, zap.NewNop())
+}
+
+// buildActiveClient creates a domain.Client for use in tests.
+// The SecretHash is a real Argon2id hash of "qf_cs_testsecret".
+func buildActiveServiceClient(t *testing.T) (*domain.Client, string) {
+	t.Helper()
+	// We create a client via the service so the hash is correct.
+	svc := newTestService(&mockClientRepo{}, &mockTokenIssuer{})
+	ctx := context.Background()
+
+	result, err := svc.CreateClient(ctx, &api.CreateClientRequest{
+		Name:       "test-service",
+		ClientType: "service",
+		Scopes:     []string{"read:users"},
+	})
+	require.NoError(t, err)
+
+	// Return a domain.Client from the repo mock so we can use the real hash.
+	// The mock's Create echoes the client back, and CreateClient sets SecretHash.
+	c := &domain.Client{
+		ID:             uuid.MustParse(result.ID),
+		Name:           result.Name,
+		ClientType:     domain.ClientTypeService,
+		SecretHash:     "", // Will be populated via separate hash call
+		Scopes:         result.Scopes,
+		Owner:          "",
+		AccessTokenTTL: 900,
+		Status:         domain.ClientStatusActive,
+		CreatedAt:      result.CreatedAt,
+		UpdatedAt:      result.UpdatedAt,
+	}
+	return c, result.ClientSecret
+}
+
+// ── CreateClient tests ────────────────────────────────────────────────────────
+
+func TestCreateClient_ServiceType(t *testing.T) {
+	repo := &mockClientRepo{}
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	result, err := svc.CreateClient(context.Background(), &api.CreateClientRequest{
+		Name:       "my-service",
+		ClientType: "service",
+		Scopes:     []string{"read:users"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "my-service", result.Name)
+	assert.Equal(t, "service", result.ClientType)
+	assert.True(t, strings.HasPrefix(result.ClientSecret, "qf_cs_"), "secret must have qf_cs_ prefix")
+	assert.NotEmpty(t, result.ID)
+}
+
+func TestCreateClient_AgentType(t *testing.T) {
+	repo := &mockClientRepo{}
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	result, err := svc.CreateClient(context.Background(), &api.CreateClientRequest{
+		Name:       "my-agent",
+		ClientType: "agent",
+		Scopes:     []string{"read:users"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "agent", result.ClientType)
+	assert.True(t, strings.HasPrefix(result.ClientSecret, "qf_cs_"))
+}
+
+func TestCreateClient_SecretNotStoredInPlaintext(t *testing.T) {
+	var capturedClient *domain.Client
+	repo := &mockClientRepo{
+		createFn: func(_ context.Context, c *domain.Client) (*domain.Client, error) {
+			capturedClient = c
+			c.CreatedAt = time.Now().UTC()
+			c.UpdatedAt = c.CreatedAt
+			return c, nil
+		},
+	}
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	result, err := svc.CreateClient(context.Background(), &api.CreateClientRequest{
+		Name:       "secure-service",
+		ClientType: "service",
+		Scopes:     []string{"read:users"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, capturedClient)
+
+	// The hash stored in DB must not equal the plaintext secret.
+	assert.NotEqual(t, result.ClientSecret, capturedClient.SecretHash)
+	// The hash should follow PHC format.
+	assert.True(t, strings.HasPrefix(capturedClient.SecretHash, "$argon2id$"))
+}
+
+func TestCreateClient_DuplicateName(t *testing.T) {
+	repo := &mockClientRepo{
+		createFn: func(_ context.Context, _ *domain.Client) (*domain.Client, error) {
+			return nil, storage.ErrDuplicateClient
+		},
+	}
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	_, err := svc.CreateClient(context.Background(), &api.CreateClientRequest{
+		Name:       "existing",
+		ClientType: "service",
+		Scopes:     []string{},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrConflict)
+}
+
+func TestCreateClient_DefaultTTL_Service(t *testing.T) {
+	var capturedClient *domain.Client
+	repo := &mockClientRepo{
+		createFn: func(_ context.Context, c *domain.Client) (*domain.Client, error) {
+			capturedClient = c
+			return c, nil
+		},
+	}
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	_, err := svc.CreateClient(context.Background(), &api.CreateClientRequest{
+		Name:       "svc",
+		ClientType: "service",
+		Scopes:     []string{},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 900, capturedClient.AccessTokenTTL, "service TTL should be 900s (15 min)")
+}
+
+func TestCreateClient_DefaultTTL_Agent(t *testing.T) {
+	var capturedClient *domain.Client
+	repo := &mockClientRepo{
+		createFn: func(_ context.Context, c *domain.Client) (*domain.Client, error) {
+			capturedClient = c
+			return c, nil
+		},
+	}
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	_, err := svc.CreateClient(context.Background(), &api.CreateClientRequest{
+		Name:       "agt",
+		ClientType: "agent",
+		Scopes:     []string{},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 300, capturedClient.AccessTokenTTL, "agent TTL should be 300s (5 min)")
+}
+
+// ── ClientCredentialsGrant tests ──────────────────────────────────────────────
+
+func TestClientCredentialsGrant_Success(t *testing.T) {
+	clientID := uuid.New().String()
+	// Hash a known secret.
+	plainSecret := "qf_cs_testsecretXYZ"
+	svc0 := newTestService(&mockClientRepo{}, &mockTokenIssuer{})
+	_ = svc0 // used for side-effect check only
+
+	// Build a hash using the service's internal logic by calling CreateClient
+	// with a controlled repo that captures the hash.
+	var capturedHash string
+	capturedClientID := clientID
+
+	// We need a real hash. Create one by calling the service end-to-end.
+	setupRepo := &mockClientRepo{
+		createFn: func(_ context.Context, c *domain.Client) (*domain.Client, error) {
+			capturedHash = c.SecretHash
+			c.ID = uuid.MustParse(capturedClientID)
+			c.CreatedAt = time.Now().UTC()
+			c.UpdatedAt = c.CreatedAt
+			return c, nil
+		},
+	}
+	setupSvc := newTestService(setupRepo, &mockTokenIssuer{})
+	result, err := setupSvc.CreateClient(context.Background(), &api.CreateClientRequest{
+		Name:       "auth-service",
+		ClientType: "service",
+		Scopes:     []string{"read:users"},
+	})
+	require.NoError(t, err)
+	plainSecret = result.ClientSecret // use the real generated secret
+
+	// Now test authentication with the captured hash.
+	activeClient := &domain.Client{
+		ID:             uuid.MustParse(clientID),
+		Name:           "auth-service",
+		ClientType:     domain.ClientTypeService,
+		SecretHash:     capturedHash,
+		Scopes:         []string{"read:users"},
+		AccessTokenTTL: 900,
+		Status:         domain.ClientStatusActive,
+	}
+
+	repo := &mockClientRepo{
+		findByIDFn: func(_ context.Context, id string) (*domain.Client, error) {
+			if id == clientID {
+				return activeClient, nil
+			}
+			return nil, storage.ErrNotFound
+		},
+	}
+
+	var issuedSubject string
+	var issuedTTL time.Duration
+	issuer := &mockTokenIssuer{
+		issueAccessTokenOnlyFn: func(_ context.Context, subject string, _ []string, _ string, ttl time.Duration) (*api.AuthResult, error) {
+			issuedSubject = subject
+			issuedTTL = ttl
+			return &api.AuthResult{
+				AccessToken: "qf_at_testtoken",
+				TokenType:   "Bearer",
+				ExpiresIn:   int(ttl.Seconds()),
+			}, nil
+		},
+	}
+
+	svc := newTestService(repo, issuer)
+	authResult, err := svc.ClientCredentialsGrant(context.Background(), clientID, plainSecret)
+	require.NoError(t, err)
+	assert.Equal(t, "qf_at_testtoken", authResult.AccessToken)
+	assert.Empty(t, authResult.RefreshToken, "no refresh token for M2M clients")
+	assert.Equal(t, clientID, issuedSubject)
+	assert.Equal(t, 900*time.Second, issuedTTL)
+}
+
+func TestClientCredentialsGrant_WrongSecret(t *testing.T) {
+	clientID := uuid.New().String()
+	activeClient := &domain.Client{
+		ID:             uuid.MustParse(clientID),
+		ClientType:     domain.ClientTypeService,
+		SecretHash:     "$argon2id$v=19$m=19456,t=2,p=1$AAAAAAAAAAAAAAAA$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", // invalid hash
+		AccessTokenTTL: 900,
+		Status:         domain.ClientStatusActive,
+	}
+
+	repo := &mockClientRepo{
+		findByIDFn: func(_ context.Context, _ string) (*domain.Client, error) {
+			return activeClient, nil
+		},
+	}
+
+	svc := newTestService(repo, &mockTokenIssuer{})
+	_, err := svc.ClientCredentialsGrant(context.Background(), clientID, "qf_cs_wrongsecret")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrUnauthorized)
+}
+
+func TestClientCredentialsGrant_NotFound(t *testing.T) {
+	repo := &mockClientRepo{
+		findByIDFn: func(_ context.Context, _ string) (*domain.Client, error) {
+			return nil, storage.ErrNotFound
+		},
+	}
+
+	svc := newTestService(repo, &mockTokenIssuer{})
+	_, err := svc.ClientCredentialsGrant(context.Background(), "nonexistent-id", "qf_cs_secret")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrUnauthorized)
+}
+
+func TestClientCredentialsGrant_Suspended(t *testing.T) {
+	clientID := uuid.New().String()
+
+	// Create a real hash for a valid secret.
+	var capturedHash string
+	setupRepo := &mockClientRepo{
+		createFn: func(_ context.Context, c *domain.Client) (*domain.Client, error) {
+			capturedHash = c.SecretHash
+			return c, nil
+		},
+	}
+	setupSvc := newTestService(setupRepo, &mockTokenIssuer{})
+	result, err := setupSvc.CreateClient(context.Background(), &api.CreateClientRequest{
+		Name:       "suspended-client",
+		ClientType: "service",
+		Scopes:     []string{},
+	})
+	require.NoError(t, err)
+
+	suspendedClient := &domain.Client{
+		ID:             uuid.MustParse(clientID),
+		ClientType:     domain.ClientTypeService,
+		SecretHash:     capturedHash,
+		AccessTokenTTL: 900,
+		Status:         domain.ClientStatusSuspended,
+	}
+
+	repo := &mockClientRepo{
+		findByIDFn: func(_ context.Context, _ string) (*domain.Client, error) {
+			return suspendedClient, nil
+		},
+	}
+
+	svc := newTestService(repo, &mockTokenIssuer{})
+	_, err = svc.ClientCredentialsGrant(context.Background(), clientID, result.ClientSecret)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrUnauthorized)
+}
+
+func TestClientCredentialsGrant_AgentTTL(t *testing.T) {
+	clientID := uuid.New().String()
+
+	var capturedHash string
+	setupRepo := &mockClientRepo{
+		createFn: func(_ context.Context, c *domain.Client) (*domain.Client, error) {
+			capturedHash = c.SecretHash
+			return c, nil
+		},
+	}
+	setupSvc := newTestService(setupRepo, &mockTokenIssuer{})
+	result, err := setupSvc.CreateClient(context.Background(), &api.CreateClientRequest{
+		Name:       "ai-agent",
+		ClientType: "agent",
+		Scopes:     []string{"read:users"},
+	})
+	require.NoError(t, err)
+
+	agentClient := &domain.Client{
+		ID:             uuid.MustParse(clientID),
+		ClientType:     domain.ClientTypeAgent,
+		SecretHash:     capturedHash,
+		Scopes:         []string{"read:users"},
+		AccessTokenTTL: 300,
+		Status:         domain.ClientStatusActive,
+	}
+
+	repo := &mockClientRepo{
+		findByIDFn: func(_ context.Context, _ string) (*domain.Client, error) {
+			return agentClient, nil
+		},
+	}
+
+	var issuedTTL time.Duration
+	issuer := &mockTokenIssuer{
+		issueAccessTokenOnlyFn: func(_ context.Context, _ string, _ []string, _ string, ttl time.Duration) (*api.AuthResult, error) {
+			issuedTTL = ttl
+			return &api.AuthResult{AccessToken: "qf_at_tok", TokenType: "Bearer", ExpiresIn: int(ttl.Seconds())}, nil
+		},
+	}
+
+	svc := newTestService(repo, issuer)
+	_, err = svc.ClientCredentialsGrant(context.Background(), clientID, result.ClientSecret)
+	require.NoError(t, err)
+	assert.Equal(t, 300*time.Second, issuedTTL, "agent should get 5-min TTL")
+}
+
+// ── Admin CRUD tests ──────────────────────────────────────────────────────────
+
+func TestGetClient_NotFound(t *testing.T) {
+	repo := &mockClientRepo{}
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	_, err := svc.GetClient(context.Background(), "nonexistent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrNotFound)
+}
+
+func TestGetClient_Success(t *testing.T) {
+	id := uuid.New()
+	repo := &mockClientRepo{
+		findByIDFn: func(_ context.Context, _ string) (*domain.Client, error) {
+			return &domain.Client{
+				ID:         id,
+				Name:       "my-svc",
+				ClientType: domain.ClientTypeService,
+				Scopes:     []string{"read:users"},
+				Status:     domain.ClientStatusActive,
+				CreatedAt:  time.Now(),
+				UpdatedAt:  time.Now(),
+			}, nil
+		},
+	}
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	got, err := svc.GetClient(context.Background(), id.String())
+	require.NoError(t, err)
+	assert.Equal(t, id.String(), got.ID)
+	assert.Equal(t, "my-svc", got.Name)
+}
+
+func TestDeleteClient_NotFound(t *testing.T) {
+	repo := &mockClientRepo{
+		deleteFn: func(_ context.Context, _ string) error {
+			return storage.ErrNotFound
+		},
+	}
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	err := svc.DeleteClient(context.Background(), "nonexistent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrNotFound)
+}
+
+func TestRotateSecret_ReturnsNewSecret(t *testing.T) {
+	id := uuid.New()
+	const oldHash = "$argon2id$v=19$m=19456,t=2,p=1$oldhash$oldhashvalue"
+
+	var updatedHash string
+	repo := &mockClientRepo{
+		findByIDFn: func(_ context.Context, _ string) (*domain.Client, error) {
+			// Return a fresh copy each call to avoid mutation aliasing.
+			return &domain.Client{
+				ID:             id,
+				Name:           "svc",
+				ClientType:     domain.ClientTypeService,
+				SecretHash:     oldHash,
+				Scopes:         []string{"read:users"},
+				AccessTokenTTL: 900,
+				Status:         domain.ClientStatusActive,
+				CreatedAt:      time.Now(),
+				UpdatedAt:      time.Now(),
+			}, nil
+		},
+		updateFn: func(_ context.Context, c *domain.Client) (*domain.Client, error) {
+			updatedHash = c.SecretHash
+			c.UpdatedAt = time.Now().UTC()
+			return c, nil
+		},
+	}
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	result, err := svc.RotateSecret(context.Background(), id.String())
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(result.ClientSecret, "qf_cs_"), "rotated secret must have prefix")
+	assert.True(t, strings.HasPrefix(updatedHash, "$argon2id$"), "new hash must be Argon2id PHC format")
+	assert.NotEqual(t, oldHash, updatedHash, "hash must change after rotation")
+}
+
+func TestUpdateClient_PartialUpdate(t *testing.T) {
+	id := uuid.New()
+	existing := &domain.Client{
+		ID:             id,
+		Name:           "old-name",
+		ClientType:     domain.ClientTypeService,
+		SecretHash:     "$argon2id$v=19$m=19456,t=2,p=1$abc$def",
+		Scopes:         []string{"read:users"},
+		AccessTokenTTL: 900,
+		Status:         domain.ClientStatusActive,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+
+	repo := &mockClientRepo{
+		findByIDFn: func(_ context.Context, _ string) (*domain.Client, error) {
+			return existing, nil
+		},
+	}
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	newName := "new-name"
+	got, err := svc.UpdateClient(context.Background(), id.String(), &api.UpdateClientRequest{
+		Name: &newName,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "new-name", got.Name)
+}
+
+func TestGetClient_InternalError(t *testing.T) {
+	repo := &mockClientRepo{
+		findByIDFn: func(_ context.Context, _ string) (*domain.Client, error) {
+			return nil, fmt.Errorf("db unavailable")
+		},
+	}
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	_, err := svc.GetClient(context.Background(), "some-id")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrInternalError)
+}
+
+func TestDeleteClient_InternalError(t *testing.T) {
+	repo := &mockClientRepo{
+		deleteFn: func(_ context.Context, _ string) error {
+			return fmt.Errorf("db unavailable")
+		},
+	}
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	err := svc.DeleteClient(context.Background(), "some-id")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrInternalError)
+}
+
+func TestUpdateClient_NotFound(t *testing.T) {
+	repo := &mockClientRepo{} // default returns ErrNotFound
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	name := "new-name"
+	_, err := svc.UpdateClient(context.Background(), "nonexistent", &api.UpdateClientRequest{Name: &name})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrNotFound)
+}
+
+func TestUpdateClient_UpdateRepoError(t *testing.T) {
+	id := uuid.New()
+	existing := &domain.Client{
+		ID:             id,
+		Name:           "svc",
+		ClientType:     domain.ClientTypeService,
+		SecretHash:     "$argon2id$v=19$m=19456,t=2,p=1$abc$def",
+		Scopes:         []string{"read:users"},
+		AccessTokenTTL: 900,
+		Status:         domain.ClientStatusActive,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+
+	tests := []struct {
+		name     string
+		repoErr  error
+		wantErr  error
+	}{
+		{"duplicate name", storage.ErrDuplicateClient, api.ErrConflict},
+		{"not found on update", storage.ErrNotFound, api.ErrNotFound},
+		{"internal error", fmt.Errorf("db unavailable"), api.ErrInternalError},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &mockClientRepo{
+				findByIDFn: func(_ context.Context, _ string) (*domain.Client, error) {
+					c := *existing
+					return &c, nil
+				},
+				updateFn: func(_ context.Context, _ *domain.Client) (*domain.Client, error) {
+					return nil, tc.repoErr
+				},
+			}
+			svc := newTestService(repo, &mockTokenIssuer{})
+			newName := "updated"
+			_, err := svc.UpdateClient(context.Background(), id.String(), &api.UpdateClientRequest{Name: &newName})
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestUpdateClient_ScopesUpdate(t *testing.T) {
+	id := uuid.New()
+	existing := &domain.Client{
+		ID:             id,
+		Name:           "svc",
+		ClientType:     domain.ClientTypeService,
+		SecretHash:     "$argon2id$v=19$m=19456,t=2,p=1$abc$def",
+		Scopes:         []string{"read:users"},
+		AccessTokenTTL: 900,
+		Status:         domain.ClientStatusActive,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+
+	var updatedScopes []string
+	repo := &mockClientRepo{
+		findByIDFn: func(_ context.Context, _ string) (*domain.Client, error) {
+			c := *existing
+			return &c, nil
+		},
+		updateFn: func(_ context.Context, c *domain.Client) (*domain.Client, error) {
+			updatedScopes = c.Scopes
+			return c, nil
+		},
+	}
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	newScopes := []string{"read:users", "write:users"}
+	_, err := svc.UpdateClient(context.Background(), id.String(), &api.UpdateClientRequest{
+		Scopes: newScopes,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, newScopes, updatedScopes)
+}
+
+func TestRotateSecret_NotFound(t *testing.T) {
+	repo := &mockClientRepo{} // default returns ErrNotFound
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	_, err := svc.RotateSecret(context.Background(), "nonexistent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrNotFound)
+}
+
+func TestRotateSecret_FindInternalError(t *testing.T) {
+	repo := &mockClientRepo{
+		findByIDFn: func(_ context.Context, _ string) (*domain.Client, error) {
+			return nil, fmt.Errorf("db unavailable")
+		},
+	}
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	_, err := svc.RotateSecret(context.Background(), "some-id")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrInternalError)
+}
+
+func TestRotateSecret_UpdateError(t *testing.T) {
+	id := uuid.New()
+	repo := &mockClientRepo{
+		findByIDFn: func(_ context.Context, _ string) (*domain.Client, error) {
+			return &domain.Client{
+				ID:             id,
+				ClientType:     domain.ClientTypeService,
+				SecretHash:     "$argon2id$v=19$m=19456,t=2,p=1$abc$def",
+				AccessTokenTTL: 900,
+				Status:         domain.ClientStatusActive,
+				CreatedAt:      time.Now(),
+				UpdatedAt:      time.Now(),
+			}, nil
+		},
+		updateFn: func(_ context.Context, _ *domain.Client) (*domain.Client, error) {
+			return nil, fmt.Errorf("db unavailable")
+		},
+	}
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	_, err := svc.RotateSecret(context.Background(), id.String())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrInternalError)
+}
+
+func TestListClients_RepoError(t *testing.T) {
+	repo := &mockClientRepo{
+		listFn: func(_ context.Context, _, _ int, _ bool) ([]*domain.Client, int, error) {
+			return nil, 0, fmt.Errorf("db unavailable")
+		},
+	}
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	_, err := svc.ListClients(context.Background(), 1, 20, false)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrInternalError)
+}
+
+func TestClientCredentialsGrant_TokenIssuerError(t *testing.T) {
+	clientID := uuid.New().String()
+
+	var capturedHash string
+	setupRepo := &mockClientRepo{
+		createFn: func(_ context.Context, c *domain.Client) (*domain.Client, error) {
+			capturedHash = c.SecretHash
+			return c, nil
+		},
+	}
+	setupSvc := newTestService(setupRepo, &mockTokenIssuer{})
+	result, err := setupSvc.CreateClient(context.Background(), &api.CreateClientRequest{
+		Name:       "svc-tok-err",
+		ClientType: "service",
+		Scopes:     []string{"read:users"},
+	})
+	require.NoError(t, err)
+
+	activeClient := &domain.Client{
+		ID:             uuid.MustParse(clientID),
+		ClientType:     domain.ClientTypeService,
+		SecretHash:     capturedHash,
+		Scopes:         []string{"read:users"},
+		AccessTokenTTL: 900,
+		Status:         domain.ClientStatusActive,
+	}
+
+	repo := &mockClientRepo{
+		findByIDFn: func(_ context.Context, _ string) (*domain.Client, error) {
+			return activeClient, nil
+		},
+	}
+	issuer := &mockTokenIssuer{
+		issueAccessTokenOnlyFn: func(_ context.Context, _ string, _ []string, _ string, _ time.Duration) (*api.AuthResult, error) {
+			return nil, fmt.Errorf("token service unavailable")
+		},
+	}
+
+	svc := newTestService(repo, issuer)
+	_, err = svc.ClientCredentialsGrant(context.Background(), clientID, result.ClientSecret)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrInternalError)
+}
+
+func TestListClients_ReturnsPaginatedResults(t *testing.T) {
+	id1 := uuid.New()
+	id2 := uuid.New()
+	now := time.Now()
+
+	repo := &mockClientRepo{
+		listFn: func(_ context.Context, page, perPage int, _ bool) ([]*domain.Client, int, error) {
+			return []*domain.Client{
+				{ID: id1, Name: "svc1", ClientType: domain.ClientTypeService, Status: domain.ClientStatusActive, CreatedAt: now, UpdatedAt: now},
+				{ID: id2, Name: "svc2", ClientType: domain.ClientTypeAgent, Status: domain.ClientStatusActive, CreatedAt: now, UpdatedAt: now},
+			}, 2, nil
+		},
+	}
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	list, err := svc.ListClients(context.Background(), 1, 20, false)
+	require.NoError(t, err)
+	assert.Equal(t, 2, list.Total)
+	assert.Len(t, list.Clients, 2)
+}
+
+func TestCreateClient_InvalidClientType(t *testing.T) {
+	svc := newTestService(&mockClientRepo{}, &mockTokenIssuer{})
+
+	_, err := svc.CreateClient(context.Background(), &api.CreateClientRequest{
+		Name:       "bad-type",
+		ClientType: "invalid",
+		Scopes:     []string{"read:users"},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrInternalError)
+}
+
+func TestCreateClient_InternalRepoError(t *testing.T) {
+	repo := &mockClientRepo{
+		createFn: func(_ context.Context, _ *domain.Client) (*domain.Client, error) {
+			return nil, fmt.Errorf("db unavailable")
+		},
+	}
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	_, err := svc.CreateClient(context.Background(), &api.CreateClientRequest{
+		Name:       "new-svc",
+		ClientType: "service",
+		Scopes:     []string{"read:users"},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrInternalError)
+}
+
+// TestAuthenticateClient_MalformedHash verifies that a malformed secret hash
+// returns ErrInvalidCredentials rather than an unexpected error type.
+func TestAuthenticateClient_MalformedHash(t *testing.T) {
+	clientID := uuid.New().String()
+	client := &domain.Client{
+		ID:             uuid.MustParse(clientID),
+		ClientType:     domain.ClientTypeService,
+		SecretHash:     "notavalidhashstring",
+		AccessTokenTTL: 900,
+		Status:         domain.ClientStatusActive,
+	}
+
+	repo := &mockClientRepo{
+		findByIDFn: func(_ context.Context, _ string) (*domain.Client, error) {
+			return client, nil
+		},
+	}
+	svc := newTestService(repo, &mockTokenIssuer{})
+
+	_, err := svc.ClientCredentialsGrant(context.Background(), clientID, "qf_cs_anything")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrUnauthorized)
+}

--- a/internal/domain/client.go
+++ b/internal/domain/client.go
@@ -7,24 +7,12 @@ import (
 )
 
 // ClientType represents the kind of OAuth2 client.
+// Constants "service" and "agent" are defined in claims.go alongside "user".
 type ClientType string
-
-const (
-	ClientTypeService ClientType = "service"
-	ClientTypeAgent   ClientType = "agent"
-)
-
-// ValidClientTypes enumerates all accepted ClientType values.
-var ValidClientTypes = []ClientType{ClientTypeService, ClientTypeAgent}
 
 // IsValid returns true if the ClientType is a recognised value.
 func (ct ClientType) IsValid() bool {
-	for _, v := range ValidClientTypes {
-		if ct == v {
-			return true
-		}
-	}
-	return false
+	return ValidClientTypes[string(ct)]
 }
 
 // Client status constants.

--- a/internal/storage/client_repository.go
+++ b/internal/storage/client_repository.go
@@ -1,0 +1,198 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// ClientRepository defines persistence operations for OAuth2 clients.
+type ClientRepository interface {
+	// Create inserts a new client. Returns ErrDuplicateClient if name is already taken.
+	Create(ctx context.Context, client *domain.Client) (*domain.Client, error)
+
+	// FindByID retrieves a client by UUID string. Returns ErrNotFound if absent.
+	FindByID(ctx context.Context, id string) (*domain.Client, error)
+
+	// List returns a paginated list of clients and the total count.
+	// When includeRevoked is false, clients with status "revoked" are excluded.
+	List(ctx context.Context, page, perPage int, includeRevoked bool) ([]*domain.Client, int, error)
+
+	// Update modifies a client record. Returns ErrNotFound if absent.
+	Update(ctx context.Context, client *domain.Client) (*domain.Client, error)
+
+	// Delete soft-deletes a client by setting its status to "revoked".
+	// Returns ErrNotFound if absent or already revoked.
+	Delete(ctx context.Context, id string) error
+
+	// UpdateLastUsedAt sets the last_used_at timestamp for a client.
+	UpdateLastUsedAt(ctx context.Context, id string, t time.Time) error
+}
+
+// PostgresClientRepository implements ClientRepository using pgx against PostgreSQL.
+type PostgresClientRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresClientRepository creates a new PostgreSQL-backed client repository.
+func NewPostgresClientRepository(pool *pgxpool.Pool) *PostgresClientRepository {
+	return &PostgresClientRepository{pool: pool}
+}
+
+const clientScanColumns = `id, name, client_type, secret_hash, scopes, owner, access_token_ttl, status, created_at, updated_at, last_used_at`
+
+// scanClientRow scans a single client row into a domain.Client.
+func scanClientRow(row pgx.Row) (*domain.Client, error) {
+	c := &domain.Client{}
+	var clientTypeStr string
+	err := row.Scan(
+		&c.ID, &c.Name, &clientTypeStr, &c.SecretHash, &c.Scopes,
+		&c.Owner, &c.AccessTokenTTL, &c.Status,
+		&c.CreatedAt, &c.UpdatedAt, &c.LastUsedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	c.ClientType = domain.ClientType(clientTypeStr)
+	return c, nil
+}
+
+// Create inserts a new client. Returns ErrDuplicateClient if the name is already taken.
+func (r *PostgresClientRepository) Create(ctx context.Context, client *domain.Client) (*domain.Client, error) {
+	query := `
+		INSERT INTO clients (id, name, client_type, secret_hash, scopes, owner, access_token_ttl, status, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		RETURNING ` + clientScanColumns
+
+	out, err := scanClientRow(r.pool.QueryRow(ctx, query,
+		client.ID, client.Name, string(client.ClientType), client.SecretHash, client.Scopes,
+		client.Owner, client.AccessTokenTTL, client.Status,
+		client.CreatedAt, client.UpdatedAt,
+	))
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return nil, fmt.Errorf("client %s: %w", client.Name, ErrDuplicateClient)
+		}
+		return nil, fmt.Errorf("insert client: %w", err)
+	}
+	return out, nil
+}
+
+// FindByID retrieves a client by its UUID string. Returns ErrNotFound if absent.
+func (r *PostgresClientRepository) FindByID(ctx context.Context, id string) (*domain.Client, error) {
+	query := `SELECT ` + clientScanColumns + ` FROM clients WHERE id = $1`
+
+	out, err := scanClientRow(r.pool.QueryRow(ctx, query, id))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("client %s: %w", id, ErrNotFound)
+		}
+		return nil, fmt.Errorf("find client by id: %w", err)
+	}
+	return out, nil
+}
+
+// List retrieves a paginated list of clients and the total matching count.
+func (r *PostgresClientRepository) List(ctx context.Context, page, perPage int, includeRevoked bool) ([]*domain.Client, int, error) {
+	if page < 1 {
+		page = 1
+	}
+	offset := (page - 1) * perPage
+
+	// Build optional WHERE clause.
+	filter := " WHERE status != 'revoked'"
+	if includeRevoked {
+		filter = ""
+	}
+
+	var total int
+	countQuery := `SELECT COUNT(*) FROM clients` + filter
+	if err := r.pool.QueryRow(ctx, countQuery).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count clients: %w", err)
+	}
+
+	listQuery := `SELECT ` + clientScanColumns + ` FROM clients` + filter + ` ORDER BY created_at DESC LIMIT $1 OFFSET $2`
+	rows, err := r.pool.Query(ctx, listQuery, perPage, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list clients: %w", err)
+	}
+	defer rows.Close()
+
+	var clients []*domain.Client
+	for rows.Next() {
+		c := &domain.Client{}
+		var clientTypeStr string
+		if err := rows.Scan(
+			&c.ID, &c.Name, &clientTypeStr, &c.SecretHash, &c.Scopes,
+			&c.Owner, &c.AccessTokenTTL, &c.Status,
+			&c.CreatedAt, &c.UpdatedAt, &c.LastUsedAt,
+		); err != nil {
+			return nil, 0, fmt.Errorf("scan client row: %w", err)
+		}
+		c.ClientType = domain.ClientType(clientTypeStr)
+		clients = append(clients, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate clients: %w", err)
+	}
+
+	return clients, total, nil
+}
+
+// Update modifies the name, scopes, access_token_ttl, status, and secret_hash of a client.
+func (r *PostgresClientRepository) Update(ctx context.Context, client *domain.Client) (*domain.Client, error) {
+	query := `
+		UPDATE clients
+		SET name = $1, scopes = $2, access_token_ttl = $3, status = $4, secret_hash = $5, updated_at = $6
+		WHERE id = $7
+		RETURNING ` + clientScanColumns
+
+	out, err := scanClientRow(r.pool.QueryRow(ctx, query,
+		client.Name, client.Scopes, client.AccessTokenTTL, client.Status, client.SecretHash,
+		time.Now().UTC(), client.ID,
+	))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("client %s: %w", client.ID, ErrNotFound)
+		}
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return nil, fmt.Errorf("client name %s: %w", client.Name, ErrDuplicateClient)
+		}
+		return nil, fmt.Errorf("update client: %w", err)
+	}
+	return out, nil
+}
+
+// Delete soft-deletes a client by setting its status to "revoked".
+func (r *PostgresClientRepository) Delete(ctx context.Context, id string) error {
+	query := `UPDATE clients SET status = 'revoked', updated_at = $1 WHERE id = $2 AND status != 'revoked'`
+
+	tag, err := r.pool.Exec(ctx, query, time.Now().UTC(), id)
+	if err != nil {
+		return fmt.Errorf("delete client: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("client %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
+// UpdateLastUsedAt sets the last_used_at timestamp for a client.
+func (r *PostgresClientRepository) UpdateLastUsedAt(ctx context.Context, id string, t time.Time) error {
+	query := `UPDATE clients SET last_used_at = $1, updated_at = $2 WHERE id = $3`
+
+	_, err := r.pool.Exec(ctx, query, t, time.Now().UTC(), id)
+	if err != nil {
+		return fmt.Errorf("update client last_used_at: %w", err)
+	}
+	return nil
+}

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -26,4 +26,7 @@ var (
 
 	// ErrTokenExpired indicates the refresh token has expired.
 	ErrTokenExpired = errors.New("token expired")
+
+	// ErrDuplicateClient indicates a client with the given name already exists.
+	ErrDuplicateClient = errors.New("duplicate client")
 )

--- a/internal/token/service.go
+++ b/internal/token/service.go
@@ -59,6 +59,7 @@ type Service struct {
 	privateKey    crypto.Signer
 	publicKey     crypto.PublicKey
 	signingMethod jwt.SigningMethod
+	clientAuth    api.ClientAuthenticator
 }
 
 // NewService creates a new token Service, loading the private key from the
@@ -103,9 +104,15 @@ func NewServiceFromKey(cfg config.JWTConfig, privateKey crypto.Signer, redisClie
 	}, nil
 }
 
+// SetClientAuthenticator wires the client credentials authenticator into the token service.
+// Must be called after both the token service and client service are constructed.
+func (s *Service) SetClientAuthenticator(auth api.ClientAuthenticator) {
+	s.clientAuth = auth
+}
+
 // IssueTokenPair generates an access/refresh token pair for the given subject.
 func (s *Service) IssueTokenPair(ctx context.Context, subject string, roles, scopes []string, clientType string) (*api.AuthResult, error) {
-	accessToken, err := s.issueAccessToken(subject, roles, scopes, clientType)
+	accessToken, err := s.issueAccessToken(subject, roles, scopes, clientType, s.cfg.AccessTokenTTL)
 	if err != nil {
 		return nil, fmt.Errorf("issue access token: %w", err)
 	}
@@ -138,11 +145,29 @@ func (s *Service) Refresh(ctx context.Context, rawRefreshToken string) (*api.Aut
 	return s.IssueTokenPair(ctx, subject, nil, nil, domain.ClientTypeUser)
 }
 
-// ClientCredentials issues an access token for service-to-service authentication.
-// Stub: client verification depends on client repository (future issue).
-func (s *Service) ClientCredentials(_ context.Context, _, _ string) (*api.AuthResult, error) {
-	// TODO(GH-XX): implement client credentials grant with client repository lookup.
-	return nil, fmt.Errorf("client credentials not yet implemented: %w", api.ErrInternalError)
+// IssueAccessTokenOnly issues a single access token with a caller-specified TTL.
+// No refresh token is issued; the returned AuthResult has an empty RefreshToken field.
+func (s *Service) IssueAccessTokenOnly(_ context.Context, subject string, scopes []string, clientType string, ttl time.Duration) (*api.AuthResult, error) {
+	accessToken, err := s.issueAccessToken(subject, nil, scopes, clientType, ttl)
+	if err != nil {
+		return nil, fmt.Errorf("issue access token: %w", err)
+	}
+	return &api.AuthResult{
+		AccessToken:  accessToken,
+		RefreshToken: "",
+		TokenType:    "Bearer",
+		ExpiresIn:    int(ttl.Seconds()),
+	}, nil
+}
+
+// ClientCredentials delegates the client credentials grant to the configured
+// ClientAuthenticator (the client service). Returns ErrInternalError if the
+// authenticator has not been wired via SetClientAuthenticator.
+func (s *Service) ClientCredentials(ctx context.Context, clientID, clientSecret string) (*api.AuthResult, error) {
+	if s.clientAuth == nil {
+		return nil, fmt.Errorf("client authenticator not configured: %w", api.ErrInternalError)
+	}
+	return s.clientAuth.ClientCredentialsGrant(ctx, clientID, clientSecret)
 }
 
 // Revoke invalidates a token by adding its JTI to the Redis blocklist.
@@ -232,7 +257,7 @@ func (c *customClaims) GetJTI() (string, error) {
 	return c.ID, nil
 }
 
-func (s *Service) issueAccessToken(subject string, roles, scopes []string, clientType string) (string, error) {
+func (s *Service) issueAccessToken(subject string, roles, scopes []string, clientType string, ttl time.Duration) (string, error) {
 	jti, err := generateRandomID(jtiBytes)
 	if err != nil {
 		return "", fmt.Errorf("generate jti: %w", err)
@@ -244,7 +269,7 @@ func (s *Service) issueAccessToken(subject string, roles, scopes []string, clien
 			Subject:   subject,
 			Issuer:    issuer,
 			IssuedAt:  jwt.NewNumericDate(now),
-			ExpiresAt: jwt.NewNumericDate(now.Add(s.cfg.AccessTokenTTL)),
+			ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
 			ID:        jti,
 		},
 		Roles:      roles,

--- a/internal/token/service_test.go
+++ b/internal/token/service_test.go
@@ -492,15 +492,14 @@ func TestJWKS_EdDSA(t *testing.T) {
 	assert.NotEmpty(t, keyMap["x"])
 }
 
-// ── ClientCredentials (stub) ─────────────────────────────────────────────────
+// ── ClientCredentials ─────────────────────────────────────────────────────────
 
-func TestClientCredentials_ReturnsNotImplemented(t *testing.T) {
+func TestClientCredentials_NoAuthenticator(t *testing.T) {
 	svc, _ := newES256Service(t)
-	ctx := context.Background()
 
-	_, err := svc.ClientCredentials(ctx, "client-id", "client-secret")
+	_, err := svc.ClientCredentials(context.Background(), "client-id", "client-secret")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not yet implemented")
+	assert.Contains(t, err.Error(), "client authenticator not configured")
 }
 
 // ── NewServiceFromKey validation ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-8.

Closes #8

## Changes

GitHub Issue #8: Client credentials flow for systems and AI agents

# TASK-08: Client Credentials Flow for Systems and AI Agents

**Status**: 🚧 In Progress
**Created**: 2026-02-24

---

## Context

**Problem**: Services and AI agents cannot authenticate. Only human user flow exists.

**Goal**: OAuth2 Client Credentials flow for M2M authentication. System clients (services, agents) authenticate with client_id + client_secret and receive short-lived access tokens.

**Success Criteria**:
- [ ] System clients authenticate via Client Credentials grant
- [ ] Access tokens are short-lived (5-15 min, per-client configurable)
- [ ] No refresh tokens for system clients
- [ ] Client type (service vs agent) reflected in token claims

---

## Implementation Plan

### Phase 1: Client Service
**Goal**: Client registration and credential management

**Tasks**:
- [ ] `CreateClient(ctx, name, clientType, owner string, scopes []string) (*domain.Client, clientSecret string, error)` — admin-only
- [ ] Generate client_id (UUID) and client_secret (256-bit from crypto/rand, prefixed `qf_cs_`)
- [ ] Hash client_secret with Argon2id before storage
- [ ] Return plaintext secret only on creation (never retrievable again)

**Files**:
- `internal/client/service.go`

### Phase 2: Client Authentication
**Tasks**:
- [ ] `AuthenticateClient(ctx, clientID, clientSecret string) (*domain.Client, error)`
- [ ] Look up client by ID, verify secret hash
- [ ] Check client status (active only)
- [ ] Update `last_used_at` timestamp
- [ ] Return generic error for both "not found" and "wrong secret"

### Phase 3: Token Issuance
**Tasks**:
- [ ] `ClientCredentialsGrant(ctx, clientID, clientSecret string, requestedScopes []string) (*domain.TokenPair, error)`
- [ ] Authenticate client
- [ ] Validate requested scopes are subset of client's allowed scopes
- [ ] Generate access token with `client_type` claim (service/agent)
- [ ] TTL: use client's `AccessTokenTTL` or default (15 min for services, 5 min for agents)
- [ ] No refresh token issued

### Phase 4: Tests
**Tasks**:
- [ ] Client creation with secret generation
- [ ] Client authentication: success, wrong secret, not found, suspended
- [ ] Client credentials grant: success, scope validation, type-specific TTL
- [ ] Secret never stored in plaintext

**Files**:
- `internal/client/service_test.go`

---

## Technical Decisions

| Decision | Options | Chosen | Reasoning |
|---|---|---|---|
| Refresh tokens for M2M | yes, no | No | Short-lived only, re-authenticate per cycle |
| Default TTL by type | same for all, type-specific | Type-specific (15m service, 5m agent) | Agents need shorter windows |
| Secret format | random, UUID | 256-bit random, prefixed qf_cs_ | Leak detection via prefix |
| Secret hashing | bcrypt, argon2id | Argon2id | Consistent with user passwords |

---

## Dependencies

**Requires**: #3 (client repository), #4 (domain types), #5 (token system)
**Blocks**: #13, #14

---

## Verify

```bash
go test ./internal/client/ -v -cover -race
```

---

## Done

- [ ] Admin can create system clients (service and agent types)
- [ ] Client secret returned only at creation time
- [ ] Client Credentials grant returns short-lived access token
- [ ] Scope validation restricts to client's allowed scopes
- [ ] Agent clients get 5-min TTL, service clients get 15-min TTL
- [ ] Suspended/revoked clients cannot authenticate
- [ ] Tests pass with >90% coverage

---

**Last Updated**: 2026-02-24


## Planned Steps (execute all in sequence)

1. **Client Repository (`internal/storage/`)** — Create `client_repository.go` in the existing `storage` package, following the established patterns from `user_repository.go` and `refresh_token_repository.go`. Define `ClientRepository` interface with methods: `Create`, `FindByID`, `List`, `Count`, `Update`, `Delete` (soft-delete), `UpdateLastUsedAt`. Implement `PostgresClientRepository` backed by `pgxpool.Pool`, scanning into `domain.Client`. Add `ErrDuplicateClient` sentinel error to `errors.go`. The `clients` table migration already exists.
2. **Token Service: Access-Token-Only Issuance (`internal/token/`) - Add an `IssueAccessTokenOnly(ctx, subject string, scopes []string, clientType string, ttl time.Duration) (*api.AuthResult, error)` method to the token `Service`** — issues a single access token with a caller-specified TTL and no refresh token (returns empty `refresh_token` in `AuthResult`). Also add a `ClientAuthenticator` interface (`ClientCredentialsGrant(ctx, clientID, clientSecret string) (*api.AuthResult, error)`) with a setter, and update the `ClientCredentials` stub to delegate to this authenticator. Add unit tests for `IssueAccessTokenOnly` covering custom TTL, correct claims, and no-refresh-token behavior.
3. **Client Service & Tests (`internal/client/`) - New package. `service.go` implements: (a) `CreateClient`** — generates UUID `client_id` + 256-bit `qf_cs_`-prefixed secret, hashes with Argon2id (`m=19456, t=2, p=1`), stores via `ClientRepository`, returns plaintext secret only once; (b) `AuthenticateClient` — looks up by ID, verifies Argon2id hash, checks `IsActive()`, updates `last_used_at`, returns generic error for not-found/wrong-secret; (c) `ClientCredentialsGrant` — authenticates client, validates requested scopes are subset of client's allowed scopes, calls token service's `IssueAccessTokenOnly` with client's `AccessTokenDuration()` (15m services, 5m agents default), returns `AuthResult`. Also implement `api.AdminClientService` (List, Get, Create, Update, Delete, RotateSecret). `service_test.go` covers: creation with secret generation, authentication success/failure/suspended, grant with scope validation, type-specific TTL, secret never stored plaintext. Use mock interfaces for `ClientRepository` and token issuer. Target >90% coverage.
4. **Server Wiring (`cmd/server/`) - In `main.go`: add PostgreSQL pool initialization via `storage.NewPostgresPool`, add `pgCloser` (like `redisCloser`), create `storage.NewPostgresClientRepository(pool)`, create `client.NewService(repo, tokenSvc, logger)`, call `tokenSvc.SetClientAuthenticator(clientSvc)`, wire `adminServices.Clients = clientSvc`. Add `health.NewPostgresChecker(pool)` to health checkers. Add `golang.org/x/crypto/argon2` to `go.mod` (currently indirect** — will become direct when `internal/client/` imports it).
