### PR TITLE
GH-127: Admin service implementations (`internal/admin/`) - Create a new `internal/ad...

### DIFF
--- a/internal/admin/client_service.go
+++ b/internal/admin/client_service.go
@@ -1,0 +1,230 @@
+package admin
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/password"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+const (
+	// clientSecretPrefix is prepended to client secrets for leak detection.
+	clientSecretPrefix = "qf_cs_"
+
+	// clientSecretBytes is the number of random bytes in a generated client secret.
+	clientSecretBytes = 32
+
+	// defaultAccessTokenTTL is the default access token TTL for new clients (1 hour).
+	defaultAccessTokenTTL = 3600
+
+	// secretRotationGracePeriod is how long the previous secret remains in the grace window.
+	// Note: actual dual-secret validation is a Phase 2 concern; here we communicate the boundary.
+	secretRotationGracePeriod = 24 * time.Hour
+)
+
+// ClientService implements api.AdminClientService for admin OAuth2 client management.
+type ClientService struct {
+	repo   ClientRepository
+	hasher password.Hasher
+}
+
+// NewClientService creates a new admin ClientService.
+func NewClientService(repo ClientRepository, hasher password.Hasher) *ClientService {
+	return &ClientService{repo: repo, hasher: hasher}
+}
+
+// ListClients returns a paginated list of OAuth2 clients.
+func (s *ClientService) ListClients(ctx context.Context, page, perPage int, includeDeleted bool) (*api.AdminClientList, error) {
+	if page < 1 {
+		page = 1
+	}
+	if perPage < 1 {
+		perPage = 20
+	}
+
+	offset := (page - 1) * perPage
+
+	clients, total, err := s.repo.FindAll(ctx, offset, perPage, includeDeleted)
+	if err != nil {
+		return nil, fmt.Errorf("list clients: %w", err)
+	}
+
+	result := make([]api.AdminClient, len(clients))
+	for i, c := range clients {
+		result[i] = domainClientToAdminClient(c)
+	}
+
+	return &api.AdminClientList{
+		Clients: result,
+		Total:   int(total),
+		Page:    page,
+		PerPage: perPage,
+	}, nil
+}
+
+// GetClient returns a single OAuth2 client by ID.
+func (s *ClientService) GetClient(ctx context.Context, clientID string) (*api.AdminClient, error) {
+	client, err := s.repo.FindByID(ctx, clientID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("client %s: %w", clientID, api.ErrNotFound)
+		}
+		return nil, fmt.Errorf("get client: %w", err)
+	}
+
+	result := domainClientToAdminClient(client)
+	return &result, nil
+}
+
+// CreateClient registers a new OAuth2 client, generates a secret, and returns it once.
+func (s *ClientService) CreateClient(ctx context.Context, req *api.CreateClientRequest) (*api.AdminClientWithSecret, error) {
+	rawSecret, err := generateClientSecret()
+	if err != nil {
+		return nil, fmt.Errorf("generate client secret: %w", err)
+	}
+
+	secretHash, err := s.hasher.Hash(rawSecret)
+	if err != nil {
+		return nil, fmt.Errorf("hash client secret: %w", err)
+	}
+
+	now := time.Now().UTC()
+	client := &domain.Client{
+		ID:             uuid.New(),
+		Name:           req.Name,
+		ClientType:     domain.ClientType(req.ClientType),
+		SecretHash:     secretHash,
+		Scopes:         req.Scopes,
+		Status:         domain.ClientStatusActive,
+		AccessTokenTTL: defaultAccessTokenTTL,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	created, err := s.repo.Create(ctx, client)
+	if err != nil {
+		if errors.Is(err, storage.ErrDuplicateEmail) {
+			return nil, fmt.Errorf("client name %q already exists: %w", req.Name, api.ErrConflict)
+		}
+		return nil, fmt.Errorf("create client: %w", err)
+	}
+
+	return &api.AdminClientWithSecret{
+		AdminClient:  domainClientToAdminClient(created),
+		ClientSecret: rawSecret,
+	}, nil
+}
+
+// UpdateClient applies partial field updates to an existing OAuth2 client.
+func (s *ClientService) UpdateClient(ctx context.Context, clientID string, req *api.UpdateClientRequest) (*api.AdminClient, error) {
+	client, err := s.repo.FindByID(ctx, clientID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("client %s: %w", clientID, api.ErrNotFound)
+		}
+		return nil, fmt.Errorf("get client for update: %w", err)
+	}
+
+	if req.Name != nil {
+		client.Name = *req.Name
+	}
+	if req.Scopes != nil {
+		client.Scopes = req.Scopes
+	}
+	client.UpdatedAt = time.Now().UTC()
+
+	updated, err := s.repo.Update(ctx, client)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("client %s: %w", clientID, api.ErrNotFound)
+		}
+		return nil, fmt.Errorf("update client: %w", err)
+	}
+
+	result := domainClientToAdminClient(updated)
+	return &result, nil
+}
+
+// DeleteClient revokes (soft-deletes) an OAuth2 client.
+func (s *ClientService) DeleteClient(ctx context.Context, clientID string) error {
+	if err := s.repo.Revoke(ctx, clientID); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return fmt.Errorf("client %s: %w", clientID, api.ErrNotFound)
+		}
+		return fmt.Errorf("delete client: %w", err)
+	}
+	return nil
+}
+
+// RotateSecret generates a new client secret, replaces the stored hash, and returns
+// the new plaintext secret with a grace period end timestamp.
+func (s *ClientService) RotateSecret(ctx context.Context, clientID string) (*api.AdminClientWithSecret, error) {
+	client, err := s.repo.FindByID(ctx, clientID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("client %s: %w", clientID, api.ErrNotFound)
+		}
+		return nil, fmt.Errorf("get client for rotation: %w", err)
+	}
+
+	rawSecret, err := generateClientSecret()
+	if err != nil {
+		return nil, fmt.Errorf("generate client secret: %w", err)
+	}
+
+	secretHash, err := s.hasher.Hash(rawSecret)
+	if err != nil {
+		return nil, fmt.Errorf("hash client secret: %w", err)
+	}
+
+	client.SecretHash = secretHash
+	client.UpdatedAt = time.Now().UTC()
+
+	updated, err := s.repo.Update(ctx, client)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("client %s: %w", clientID, api.ErrNotFound)
+		}
+		return nil, fmt.Errorf("update client secret: %w", err)
+	}
+
+	graceEnd := time.Now().UTC().Add(secretRotationGracePeriod)
+	return &api.AdminClientWithSecret{
+		AdminClient:     domainClientToAdminClient(updated),
+		ClientSecret:    rawSecret,
+		GracePeriodEnds: &graceEnd,
+	}, nil
+}
+
+// generateClientSecret generates a cryptographically random client secret.
+func generateClientSecret() (string, error) {
+	b := make([]byte, clientSecretBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("crypto/rand: %w", err)
+	}
+	return clientSecretPrefix + hex.EncodeToString(b), nil
+}
+
+// domainClientToAdminClient maps a domain.Client to the api.AdminClient response type.
+func domainClientToAdminClient(c *domain.Client) api.AdminClient {
+	return api.AdminClient{
+		ID:         c.ID.String(),
+		Name:       c.Name,
+		ClientType: string(c.ClientType),
+		Scopes:     c.Scopes,
+		CreatedAt:  c.CreatedAt,
+		UpdatedAt:  c.UpdatedAt,
+	}
+}
+
+// Compile-time assertion.
+var _ api.AdminClientService = (*ClientService)(nil)

--- a/internal/admin/client_service_test.go
+++ b/internal/admin/client_service_test.go
@@ -1,0 +1,558 @@
+package admin_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/admin"
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+// --- Mock ClientRepository ---
+
+type mockClientRepo struct {
+	findByIDFn func(ctx context.Context, id string) (*domain.Client, error)
+	findAllFn  func(ctx context.Context, offset, limit int, includeDeleted bool) ([]*domain.Client, int64, error)
+	createFn   func(ctx context.Context, client *domain.Client) (*domain.Client, error)
+	updateFn   func(ctx context.Context, client *domain.Client) (*domain.Client, error)
+	revokeFn   func(ctx context.Context, id string) error
+}
+
+func (m *mockClientRepo) FindByID(ctx context.Context, id string) (*domain.Client, error) {
+	if m.findByIDFn != nil {
+		return m.findByIDFn(ctx, id)
+	}
+	return nil, storage.ErrNotFound
+}
+
+func (m *mockClientRepo) FindAll(ctx context.Context, offset, limit int, includeDeleted bool) ([]*domain.Client, int64, error) {
+	if m.findAllFn != nil {
+		return m.findAllFn(ctx, offset, limit, includeDeleted)
+	}
+	return []*domain.Client{}, 0, nil
+}
+
+func (m *mockClientRepo) Create(ctx context.Context, client *domain.Client) (*domain.Client, error) {
+	if m.createFn != nil {
+		return m.createFn(ctx, client)
+	}
+	return client, nil
+}
+
+func (m *mockClientRepo) Update(ctx context.Context, client *domain.Client) (*domain.Client, error) {
+	if m.updateFn != nil {
+		return m.updateFn(ctx, client)
+	}
+	return client, nil
+}
+
+func (m *mockClientRepo) Revoke(ctx context.Context, id string) error {
+	if m.revokeFn != nil {
+		return m.revokeFn(ctx, id)
+	}
+	return nil
+}
+
+// --- Helpers ---
+
+func newClientSvc(repo admin.ClientRepository) *admin.ClientService {
+	return admin.NewClientService(repo, &mockHasher{})
+}
+
+func makeClient(id string) *domain.Client {
+	now := time.Now().UTC()
+	uid := uuid.MustParse(id)
+	return &domain.Client{
+		ID:             uid,
+		Name:           "test-client",
+		ClientType:     domain.ClientTypeService,
+		SecretHash:     "hashed:secret",
+		Scopes:         []string{"read:users"},
+		Status:         domain.ClientStatusActive,
+		AccessTokenTTL: 3600,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+}
+
+const testClientID = "00000000-0000-0000-0000-000000000001"
+
+// --- ListClients ---
+
+func TestClientService_ListClients(t *testing.T) {
+	tests := []struct {
+		name        string
+		page        int
+		perPage     int
+		setupRepo   func(*mockClientRepo)
+		wantLen     int
+		wantTotal   int
+		wantPage    int
+		wantPerPage int
+		wantErr     bool
+	}{
+		{
+			name:    "returns empty list",
+			page:    1,
+			perPage: 20,
+			setupRepo: func(r *mockClientRepo) {
+				r.findAllFn = func(_ context.Context, _, _ int, _ bool) ([]*domain.Client, int64, error) {
+					return []*domain.Client{}, 0, nil
+				}
+			},
+			wantLen:     0,
+			wantTotal:   0,
+			wantPage:    1,
+			wantPerPage: 20,
+		},
+		{
+			name:    "returns clients with correct metadata",
+			page:    1,
+			perPage: 10,
+			setupRepo: func(r *mockClientRepo) {
+				r.findAllFn = func(_ context.Context, _, _ int, _ bool) ([]*domain.Client, int64, error) {
+					return []*domain.Client{makeClient(testClientID)}, 1, nil
+				}
+			},
+			wantLen:     1,
+			wantTotal:   1,
+			wantPage:    1,
+			wantPerPage: 10,
+		},
+		{
+			name:    "computes correct offset for page 3",
+			page:    3,
+			perPage: 10,
+			setupRepo: func(r *mockClientRepo) {
+				r.findAllFn = func(_ context.Context, offset, limit int, _ bool) ([]*domain.Client, int64, error) {
+					assert.Equal(t, 20, offset)
+					assert.Equal(t, 10, limit)
+					return []*domain.Client{}, 30, nil
+				}
+			},
+			wantTotal: 30,
+			wantPage:  3,
+		},
+		{
+			name:    "propagates repository error",
+			page:    1,
+			perPage: 20,
+			setupRepo: func(r *mockClientRepo) {
+				r.findAllFn = func(_ context.Context, _, _ int, _ bool) ([]*domain.Client, int64, error) {
+					return nil, 0, errors.New("database unavailable")
+				}
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockClientRepo{}
+			if tt.setupRepo != nil {
+				tt.setupRepo(repo)
+			}
+
+			result, err := newClientSvc(repo).ListClients(context.Background(), tt.page, tt.perPage, false)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, result.Clients, tt.wantLen)
+			assert.Equal(t, tt.wantTotal, result.Total)
+			if tt.wantPage != 0 {
+				assert.Equal(t, tt.wantPage, result.Page)
+			}
+		})
+	}
+}
+
+// --- GetClient ---
+
+func TestClientService_GetClient(t *testing.T) {
+	tests := []struct {
+		name      string
+		clientID  string
+		setupRepo func(*mockClientRepo)
+		wantErrIs error
+	}{
+		{
+			name:     "returns client when found",
+			clientID: testClientID,
+			setupRepo: func(r *mockClientRepo) {
+				r.findByIDFn = func(_ context.Context, id string) (*domain.Client, error) {
+					return makeClient(id), nil
+				}
+			},
+		},
+		{
+			name:     "returns ErrNotFound for missing client",
+			clientID: testClientID,
+			setupRepo: func(r *mockClientRepo) {
+				r.findByIDFn = func(_ context.Context, _ string) (*domain.Client, error) {
+					return nil, storage.ErrNotFound
+				}
+			},
+			wantErrIs: api.ErrNotFound,
+		},
+		{
+			name:     "propagates unexpected repository error",
+			clientID: testClientID,
+			setupRepo: func(r *mockClientRepo) {
+				r.findByIDFn = func(_ context.Context, _ string) (*domain.Client, error) {
+					return nil, errors.New("connection error")
+				}
+			},
+			wantErrIs: errors.New("any"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockClientRepo{}
+			if tt.setupRepo != nil {
+				tt.setupRepo(repo)
+			}
+
+			result, err := newClientSvc(repo).GetClient(context.Background(), tt.clientID)
+
+			if tt.wantErrIs != nil {
+				require.Error(t, err)
+				if errors.Is(tt.wantErrIs, api.ErrNotFound) {
+					assert.ErrorIs(t, err, api.ErrNotFound)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.clientID, result.ID)
+		})
+	}
+}
+
+// --- CreateClient ---
+
+func TestClientService_CreateClient(t *testing.T) {
+	validReq := &api.CreateClientRequest{
+		Name:       "my-service",
+		ClientType: "service",
+		Scopes:     []string{"read:users"},
+	}
+
+	tests := []struct {
+		name      string
+		req       *api.CreateClientRequest
+		setupRepo func(*mockClientRepo)
+		wantErrIs error
+		check     func(*api.AdminClientWithSecret)
+	}{
+		{
+			name: "creates client and returns plaintext secret",
+			req:  validReq,
+			setupRepo: func(r *mockClientRepo) {
+				r.createFn = func(_ context.Context, c *domain.Client) (*domain.Client, error) {
+					return c, nil
+				}
+			},
+			check: func(c *api.AdminClientWithSecret) {
+				assert.Equal(t, "my-service", c.Name)
+				assert.Equal(t, "service", c.ClientType)
+				assert.Equal(t, []string{"read:users"}, c.Scopes)
+				assert.NotEmpty(t, c.ClientSecret)
+				assert.True(t, len(c.ClientSecret) > 10, "secret should be non-trivial length")
+				assert.Contains(t, c.ClientSecret, "qf_cs_", "secret must carry the qf_cs_ prefix")
+				assert.NotEmpty(t, c.ID)
+				assert.Nil(t, c.GracePeriodEnds, "no grace period on initial creation")
+			},
+		},
+		{
+			name: "creates agent-type client",
+			req:  &api.CreateClientRequest{Name: "my-agent", ClientType: "agent", Scopes: []string{"read:users"}},
+			setupRepo: func(r *mockClientRepo) {
+				r.createFn = func(_ context.Context, c *domain.Client) (*domain.Client, error) {
+					return c, nil
+				}
+			},
+			check: func(c *api.AdminClientWithSecret) {
+				assert.Equal(t, "agent", c.ClientType)
+			},
+		},
+		{
+			name: "returns ErrConflict on duplicate name",
+			req:  validReq,
+			setupRepo: func(r *mockClientRepo) {
+				r.createFn = func(_ context.Context, _ *domain.Client) (*domain.Client, error) {
+					return nil, storage.ErrDuplicateEmail
+				}
+			},
+			wantErrIs: api.ErrConflict,
+		},
+		{
+			name: "propagates hasher error",
+			req:  validReq,
+			wantErrIs: errors.New("any"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockClientRepo{}
+			if tt.setupRepo != nil {
+				tt.setupRepo(repo)
+			}
+
+			svc := admin.NewClientService(repo, &mockHasher{})
+			if tt.name == "propagates hasher error" {
+				svc = admin.NewClientService(repo, &mockHasher{
+					hashFn: func(_ string) (string, error) {
+						return "", errors.New("argon2 failed")
+					},
+				})
+			}
+
+			result, err := svc.CreateClient(context.Background(), tt.req)
+
+			if tt.wantErrIs != nil {
+				require.Error(t, err)
+				if errors.Is(tt.wantErrIs, api.ErrConflict) {
+					assert.ErrorIs(t, err, api.ErrConflict)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			if tt.check != nil {
+				tt.check(result)
+			}
+		})
+	}
+}
+
+// --- UpdateClient ---
+
+func TestClientService_UpdateClient(t *testing.T) {
+	newName := "updated-name"
+	newScopes := []string{"read:users", "write:users"}
+
+	tests := []struct {
+		name      string
+		clientID  string
+		req       *api.UpdateClientRequest
+		setupRepo func(*mockClientRepo)
+		wantErrIs error
+		check     func(*api.AdminClient)
+	}{
+		{
+			name:     "updates client name",
+			clientID: testClientID,
+			req:      &api.UpdateClientRequest{Name: &newName},
+			setupRepo: func(r *mockClientRepo) {
+				r.findByIDFn = func(_ context.Context, id string) (*domain.Client, error) {
+					return makeClient(id), nil
+				}
+				r.updateFn = func(_ context.Context, c *domain.Client) (*domain.Client, error) {
+					return c, nil
+				}
+			},
+			check: func(c *api.AdminClient) {
+				assert.Equal(t, newName, c.Name)
+			},
+		},
+		{
+			name:     "updates client scopes",
+			clientID: testClientID,
+			req:      &api.UpdateClientRequest{Scopes: newScopes},
+			setupRepo: func(r *mockClientRepo) {
+				r.findByIDFn = func(_ context.Context, id string) (*domain.Client, error) {
+					return makeClient(id), nil
+				}
+				r.updateFn = func(_ context.Context, c *domain.Client) (*domain.Client, error) {
+					return c, nil
+				}
+			},
+			check: func(c *api.AdminClient) {
+				assert.Equal(t, newScopes, c.Scopes)
+			},
+		},
+		{
+			name:     "returns ErrNotFound when client missing",
+			clientID: testClientID,
+			req:      &api.UpdateClientRequest{Name: &newName},
+			setupRepo: func(r *mockClientRepo) {
+				r.findByIDFn = func(_ context.Context, _ string) (*domain.Client, error) {
+					return nil, storage.ErrNotFound
+				}
+			},
+			wantErrIs: api.ErrNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockClientRepo{}
+			if tt.setupRepo != nil {
+				tt.setupRepo(repo)
+			}
+
+			result, err := newClientSvc(repo).UpdateClient(context.Background(), tt.clientID, tt.req)
+
+			if tt.wantErrIs != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErrIs)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			if tt.check != nil {
+				tt.check(result)
+			}
+		})
+	}
+}
+
+// --- DeleteClient ---
+
+func TestClientService_DeleteClient(t *testing.T) {
+	tests := []struct {
+		name      string
+		clientID  string
+		setupRepo func(*mockClientRepo)
+		wantErrIs error
+	}{
+		{
+			name:     "revokes client successfully",
+			clientID: testClientID,
+			setupRepo: func(r *mockClientRepo) {
+				r.revokeFn = func(_ context.Context, _ string) error {
+					return nil
+				}
+			},
+		},
+		{
+			name:     "returns ErrNotFound for missing client",
+			clientID: testClientID,
+			setupRepo: func(r *mockClientRepo) {
+				r.revokeFn = func(_ context.Context, _ string) error {
+					return storage.ErrNotFound
+				}
+			},
+			wantErrIs: api.ErrNotFound,
+		},
+		{
+			name:     "propagates repository error",
+			clientID: testClientID,
+			setupRepo: func(r *mockClientRepo) {
+				r.revokeFn = func(_ context.Context, _ string) error {
+					return errors.New("db error")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockClientRepo{}
+			if tt.setupRepo != nil {
+				tt.setupRepo(repo)
+			}
+
+			err := newClientSvc(repo).DeleteClient(context.Background(), tt.clientID)
+
+			if tt.wantErrIs != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErrIs)
+				return
+			}
+		})
+	}
+}
+
+// --- RotateSecret ---
+
+func TestClientService_RotateSecret(t *testing.T) {
+	tests := []struct {
+		name      string
+		clientID  string
+		setupRepo func(*mockClientRepo)
+		wantErrIs error
+		check     func(*api.AdminClientWithSecret)
+	}{
+		{
+			name:     "rotates secret and returns new plaintext with grace period",
+			clientID: testClientID,
+			setupRepo: func(r *mockClientRepo) {
+				r.findByIDFn = func(_ context.Context, id string) (*domain.Client, error) {
+					return makeClient(id), nil
+				}
+				r.updateFn = func(_ context.Context, c *domain.Client) (*domain.Client, error) {
+					return c, nil
+				}
+			},
+			check: func(c *api.AdminClientWithSecret) {
+				assert.NotEmpty(t, c.ClientSecret)
+				assert.Contains(t, c.ClientSecret, "qf_cs_", "new secret must have qf_cs_ prefix")
+				assert.NotNil(t, c.GracePeriodEnds, "grace period must be set after rotation")
+				assert.True(t, c.GracePeriodEnds.After(time.Now()), "grace period must be in the future")
+			},
+		},
+		{
+			name:     "returns ErrNotFound when client missing",
+			clientID: testClientID,
+			setupRepo: func(r *mockClientRepo) {
+				r.findByIDFn = func(_ context.Context, _ string) (*domain.Client, error) {
+					return nil, storage.ErrNotFound
+				}
+			},
+			wantErrIs: api.ErrNotFound,
+		},
+		{
+			name:     "propagates update error after successful fetch",
+			clientID: testClientID,
+			setupRepo: func(r *mockClientRepo) {
+				r.findByIDFn = func(_ context.Context, id string) (*domain.Client, error) {
+					return makeClient(id), nil
+				}
+				r.updateFn = func(_ context.Context, _ *domain.Client) (*domain.Client, error) {
+					return nil, errors.New("db error")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockClientRepo{}
+			if tt.setupRepo != nil {
+				tt.setupRepo(repo)
+			}
+
+			result, err := newClientSvc(repo).RotateSecret(context.Background(), tt.clientID)
+
+			if tt.wantErrIs != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErrIs)
+				return
+			}
+
+			if tt.check != nil {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				tt.check(result)
+			}
+		})
+	}
+}

--- a/internal/admin/repositories.go
+++ b/internal/admin/repositories.go
@@ -1,0 +1,67 @@
+// Package admin implements the admin service layer for user, client, and token management.
+// Services depend on repository interfaces defined here — concrete implementations live in storage/.
+package admin
+
+import (
+	"context"
+	"time"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// UserRepository defines the persistence operations required by the admin user service.
+// Implementations should use storage.ErrNotFound for missing entities and
+// storage.ErrDuplicateEmail for email uniqueness violations.
+type UserRepository interface {
+	// FindByID returns a user by ID (including soft-deleted). Returns storage.ErrNotFound if absent.
+	FindByID(ctx context.Context, id string) (*domain.User, error)
+
+	// FindAll returns a paginated slice of users and the total count.
+	// When includeDeleted is true, soft-deleted users are included.
+	FindAll(ctx context.Context, offset, limit int, includeDeleted bool) ([]*domain.User, int64, error)
+
+	// Create inserts a new user. Returns storage.ErrDuplicateEmail on email collision.
+	Create(ctx context.Context, user *domain.User) (*domain.User, error)
+
+	// Update persists field changes to an existing user. Returns storage.ErrNotFound if absent.
+	Update(ctx context.Context, user *domain.User) (*domain.User, error)
+
+	// SoftDelete marks a user as deleted by setting deleted_at. Returns storage.ErrNotFound if absent.
+	SoftDelete(ctx context.Context, id string) error
+
+	// SetLocked updates the locked state, reason, and timestamp for a user.
+	// Pass locked=false and a nil lockedAt to unlock. Returns storage.ErrNotFound if absent.
+	SetLocked(ctx context.Context, id string, locked bool, reason string, lockedAt *time.Time) error
+}
+
+// ClientRepository defines the persistence operations required by the admin client service.
+// Implementations should use storage.ErrNotFound for missing entities.
+type ClientRepository interface {
+	// FindByID returns a client by ID. Returns storage.ErrNotFound if absent.
+	FindByID(ctx context.Context, id string) (*domain.Client, error)
+
+	// FindAll returns a paginated slice of clients and the total count.
+	// When includeDeleted is true, revoked clients are included.
+	FindAll(ctx context.Context, offset, limit int, includeDeleted bool) ([]*domain.Client, int64, error)
+
+	// Create inserts a new client. Returns storage.ErrDuplicateEmail on name uniqueness violation.
+	Create(ctx context.Context, client *domain.Client) (*domain.Client, error)
+
+	// Update persists field changes to an existing client. Returns storage.ErrNotFound if absent.
+	Update(ctx context.Context, client *domain.Client) (*domain.Client, error)
+
+	// Revoke marks a client as revoked (soft delete equivalent). Returns storage.ErrNotFound if absent.
+	Revoke(ctx context.Context, id string) error
+}
+
+// TokenValidator validates a raw JWT access token (qf_at_ prefix already stripped)
+// and returns its parsed claims. Implemented by token.Service.
+type TokenValidator interface {
+	ValidateToken(ctx context.Context, rawToken string) (*domain.TokenClaims, error)
+}
+
+// RefreshTokenFinder looks up a stored refresh token record by its full token string.
+// Implemented by storage.PostgresRefreshTokenRepository.
+type RefreshTokenFinder interface {
+	FindBySignature(ctx context.Context, signature string) (*domain.RefreshTokenRecord, error)
+}

--- a/internal/admin/token_service.go
+++ b/internal/admin/token_service.go
@@ -1,0 +1,91 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+const (
+	accessTokenPrefix  = "qf_at_"
+	refreshTokenPrefix = "qf_rt_"
+)
+
+// TokenService implements api.AdminTokenService for RFC 7662 token introspection.
+type TokenService struct {
+	validator     TokenValidator
+	refreshFinder RefreshTokenFinder
+}
+
+// NewTokenService creates a new admin TokenService.
+func NewTokenService(validator TokenValidator, refreshFinder RefreshTokenFinder) *TokenService {
+	return &TokenService{validator: validator, refreshFinder: refreshFinder}
+}
+
+// Introspect determines whether a token is active and returns its metadata.
+// Access tokens (qf_at_) are introspected via JWT decode.
+// Refresh tokens (qf_rt_) are introspected via database lookup.
+// Unknown token formats return {active: false} per RFC 7662.
+func (s *TokenService) Introspect(ctx context.Context, token string) (*api.IntrospectionResponse, error) {
+	switch {
+	case strings.HasPrefix(token, accessTokenPrefix):
+		return s.introspectAccessToken(ctx, strings.TrimPrefix(token, accessTokenPrefix))
+	case strings.HasPrefix(token, refreshTokenPrefix):
+		return s.introspectRefreshToken(ctx, token)
+	default:
+		return &api.IntrospectionResponse{Active: false}, nil
+	}
+}
+
+// introspectAccessToken validates the raw JWT and maps claims to an IntrospectionResponse.
+// Per RFC 7662, an invalid or expired token returns {active: false} without an error.
+func (s *TokenService) introspectAccessToken(ctx context.Context, rawJWT string) (*api.IntrospectionResponse, error) {
+	claims, err := s.validator.ValidateToken(ctx, rawJWT)
+	if err != nil {
+		// Invalid, expired, or malformed — return inactive per RFC 7662 §2.2.
+		return &api.IntrospectionResponse{Active: false}, nil
+	}
+
+	return &api.IntrospectionResponse{
+		Active:     true,
+		Sub:        claims.Subject,
+		ClientType: string(claims.ClientType),
+		TokenType:  "access_token",
+		Scope:      strings.Join(claims.Scopes, " "),
+		Jti:        claims.TokenID,
+	}, nil
+}
+
+// introspectRefreshToken looks up the full refresh token string in the database
+// and returns its active status and metadata.
+func (s *TokenService) introspectRefreshToken(ctx context.Context, token string) (*api.IntrospectionResponse, error) {
+	rec, err := s.refreshFinder.FindBySignature(ctx, token)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return &api.IntrospectionResponse{Active: false, TokenType: "refresh_token"}, nil
+		}
+		return nil, fmt.Errorf("lookup refresh token: %w", err)
+	}
+
+	active := !rec.IsRevoked() && !rec.IsExpired()
+
+	resp := &api.IntrospectionResponse{
+		Active:    active,
+		TokenType: "refresh_token",
+	}
+
+	if active {
+		resp.Sub = rec.UserID
+		resp.Exp = rec.ExpiresAt.Unix()
+		resp.Iat = rec.CreatedAt.Unix()
+	}
+
+	return resp, nil
+}
+
+// Compile-time assertion.
+var _ api.AdminTokenService = (*TokenService)(nil)

--- a/internal/admin/token_service_test.go
+++ b/internal/admin/token_service_test.go
@@ -1,0 +1,310 @@
+package admin_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/admin"
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+// --- Mock TokenValidator ---
+
+type mockTokenValidator struct {
+	validateFn func(ctx context.Context, rawToken string) (*domain.TokenClaims, error)
+}
+
+func (m *mockTokenValidator) ValidateToken(ctx context.Context, rawToken string) (*domain.TokenClaims, error) {
+	if m.validateFn != nil {
+		return m.validateFn(ctx, rawToken)
+	}
+	return nil, errors.New("token invalid")
+}
+
+// --- Mock RefreshTokenFinder ---
+
+type mockRefreshFinder struct {
+	findFn func(ctx context.Context, signature string) (*domain.RefreshTokenRecord, error)
+}
+
+func (m *mockRefreshFinder) FindBySignature(ctx context.Context, signature string) (*domain.RefreshTokenRecord, error) {
+	if m.findFn != nil {
+		return m.findFn(ctx, signature)
+	}
+	return nil, storage.ErrNotFound
+}
+
+// --- Helpers ---
+
+func newTokenSvc(validator admin.TokenValidator, finder admin.RefreshTokenFinder) *admin.TokenService {
+	return admin.NewTokenService(validator, finder)
+}
+
+func validClaims() *domain.TokenClaims {
+	return &domain.TokenClaims{
+		Subject:    "user-42",
+		Roles:      []string{"user"},
+		Scopes:     []string{"read:users", "write:users"},
+		ClientType: domain.ClientTypeUser,
+		TokenID:    "jti-abc-123",
+	}
+}
+
+// --- Introspect ---
+
+func TestTokenService_Introspect_AccessToken(t *testing.T) {
+	tests := []struct {
+		name        string
+		token       string
+		validateFn  func(ctx context.Context, rawToken string) (*domain.TokenClaims, error)
+		wantActive  bool
+		wantSub     string
+		wantJti     string
+		wantScope   string
+		wantType    string
+		wantErr     bool
+	}{
+		{
+			name:  "valid access token returns active with claims",
+			token: "qf_at_valid.jwt.here",
+			validateFn: func(_ context.Context, rawToken string) (*domain.TokenClaims, error) {
+				assert.Equal(t, "valid.jwt.here", rawToken, "prefix must be stripped before calling validator")
+				return validClaims(), nil
+			},
+			wantActive: true,
+			wantSub:    "user-42",
+			wantJti:    "jti-abc-123",
+			wantScope:  "read:users write:users",
+			wantType:   "access_token",
+		},
+		{
+			name:  "expired access token returns inactive without error",
+			token: "qf_at_expired.jwt",
+			validateFn: func(_ context.Context, _ string) (*domain.TokenClaims, error) {
+				return nil, errors.New("token is expired")
+			},
+			wantActive: false,
+		},
+		{
+			name:  "invalid JWT returns inactive without error",
+			token: "qf_at_not_a_real_jwt",
+			validateFn: func(_ context.Context, _ string) (*domain.TokenClaims, error) {
+				return nil, errors.New("invalid token")
+			},
+			wantActive: false,
+		},
+		{
+			name:  "empty scopes produces empty scope string",
+			token: "qf_at_noscope.jwt",
+			validateFn: func(_ context.Context, _ string) (*domain.TokenClaims, error) {
+				c := validClaims()
+				c.Scopes = nil
+				return c, nil
+			},
+			wantActive: true,
+			wantSub:    "user-42",
+			wantJti:    "jti-abc-123",
+			wantScope:  "",
+			wantType:   "access_token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := &mockTokenValidator{validateFn: tt.validateFn}
+			finder := &mockRefreshFinder{}
+
+			result, err := newTokenSvc(validator, finder).Introspect(context.Background(), tt.token)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.wantActive, result.Active)
+
+			if tt.wantActive {
+				assert.Equal(t, tt.wantSub, result.Sub)
+				assert.Equal(t, tt.wantJti, result.Jti)
+				assert.Equal(t, tt.wantScope, result.Scope)
+				assert.Equal(t, tt.wantType, result.TokenType)
+			} else {
+				assert.Empty(t, result.Sub, "inactive token must not expose claims")
+			}
+		})
+	}
+}
+
+func TestTokenService_Introspect_RefreshToken(t *testing.T) {
+	futureExpiry := time.Now().Add(24 * time.Hour)
+	pastExpiry := time.Now().Add(-1 * time.Hour)
+	revokedAt := time.Now().Add(-30 * time.Minute)
+
+	tests := []struct {
+		name       string
+		token      string
+		findFn     func(ctx context.Context, signature string) (*domain.RefreshTokenRecord, error)
+		wantActive bool
+		wantSub    string
+		wantType   string
+		wantErr    bool
+	}{
+		{
+			name:  "active refresh token returns active with subject",
+			token: "qf_rt_key.sig",
+			findFn: func(_ context.Context, sig string) (*domain.RefreshTokenRecord, error) {
+				assert.Equal(t, "qf_rt_key.sig", sig, "full token must be passed to finder")
+				return &domain.RefreshTokenRecord{
+					Signature: sig,
+					UserID:    "user-99",
+					ExpiresAt: futureExpiry,
+					CreatedAt: time.Now().Add(-1 * time.Hour),
+				}, nil
+			},
+			wantActive: true,
+			wantSub:    "user-99",
+			wantType:   "refresh_token",
+		},
+		{
+			name:  "revoked refresh token returns inactive",
+			token: "qf_rt_revoked.sig",
+			findFn: func(_ context.Context, _ string) (*domain.RefreshTokenRecord, error) {
+				return &domain.RefreshTokenRecord{
+					Signature: "qf_rt_revoked.sig",
+					UserID:    "user-10",
+					ExpiresAt: futureExpiry,
+					CreatedAt: time.Now().Add(-2 * time.Hour),
+					RevokedAt: &revokedAt,
+				}, nil
+			},
+			wantActive: false,
+		},
+		{
+			name:  "expired refresh token returns inactive",
+			token: "qf_rt_expired.sig",
+			findFn: func(_ context.Context, _ string) (*domain.RefreshTokenRecord, error) {
+				return &domain.RefreshTokenRecord{
+					Signature: "qf_rt_expired.sig",
+					UserID:    "user-11",
+					ExpiresAt: pastExpiry,
+					CreatedAt: time.Now().Add(-48 * time.Hour),
+				}, nil
+			},
+			wantActive: false,
+		},
+		{
+			name:  "unknown refresh token returns inactive without error",
+			token: "qf_rt_unknown.sig",
+			findFn: func(_ context.Context, _ string) (*domain.RefreshTokenRecord, error) {
+				return nil, storage.ErrNotFound
+			},
+			wantActive: false,
+		},
+		{
+			name:  "database error returns error",
+			token: "qf_rt_dbfail.sig",
+			findFn: func(_ context.Context, _ string) (*domain.RefreshTokenRecord, error) {
+				return nil, errors.New("connection lost")
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := &mockTokenValidator{}
+			finder := &mockRefreshFinder{findFn: tt.findFn}
+
+			result, err := newTokenSvc(validator, finder).Introspect(context.Background(), tt.token)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.wantActive, result.Active)
+			assert.Equal(t, "refresh_token", result.TokenType)
+
+			if tt.wantActive {
+				assert.Equal(t, tt.wantSub, result.Sub)
+				assert.Greater(t, result.Exp, int64(0))
+				assert.Greater(t, result.Iat, int64(0))
+			} else {
+				assert.Empty(t, result.Sub, "inactive token must not expose subject")
+			}
+		})
+	}
+}
+
+func TestTokenService_Introspect_UnknownPrefix(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+	}{
+		{name: "bare JWT without prefix", token: "eyJhbGciOiJFUzI1NiJ9.payload.sig"},
+		{name: "empty string", token: ""},
+		{name: "random string", token: "not-a-token-at-all"},
+		{name: "partial prefix", token: "qf_raw_data"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := &mockTokenValidator{}
+			finder := &mockRefreshFinder{}
+
+			result, err := newTokenSvc(validator, finder).Introspect(context.Background(), tt.token)
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.False(t, result.Active)
+		})
+	}
+}
+
+func TestTokenService_Introspect_ActiveRefreshToken_ExposesTimestamps(t *testing.T) {
+	issued := time.Now().Add(-30 * time.Minute).UTC().Truncate(time.Second)
+	expires := time.Now().Add(30 * time.Minute).UTC().Truncate(time.Second)
+
+	finder := &mockRefreshFinder{
+		findFn: func(_ context.Context, _ string) (*domain.RefreshTokenRecord, error) {
+			return &domain.RefreshTokenRecord{
+				Signature: "qf_rt_test.sig",
+				UserID:    "user-ts",
+				ExpiresAt: expires,
+				CreatedAt: issued,
+			}, nil
+		},
+	}
+
+	result, err := newTokenSvc(&mockTokenValidator{}, finder).Introspect(context.Background(), "qf_rt_test.sig")
+
+	require.NoError(t, err)
+	assert.True(t, result.Active)
+	assert.Equal(t, expires.Unix(), result.Exp)
+	assert.Equal(t, issued.Unix(), result.Iat)
+}
+
+// --- Compile-time interface check ---
+
+func TestTokenService_ImplementsInterface(t *testing.T) {
+	var _ api.AdminTokenService = (*admin.TokenService)(nil)
+}
+
+func TestUserService_ImplementsInterface(t *testing.T) {
+	var _ api.AdminUserService = (*admin.UserService)(nil)
+}
+
+func TestClientService_ImplementsInterface(t *testing.T) {
+	var _ api.AdminClientService = (*admin.ClientService)(nil)
+}

--- a/internal/admin/user_service.go
+++ b/internal/admin/user_service.go
@@ -1,0 +1,219 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/password"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+// UserService implements api.AdminUserService for admin user management.
+type UserService struct {
+	repo   UserRepository
+	hasher password.Hasher
+}
+
+// NewUserService creates a new admin UserService.
+func NewUserService(repo UserRepository, hasher password.Hasher) *UserService {
+	return &UserService{repo: repo, hasher: hasher}
+}
+
+// ListUsers returns a paginated list of users.
+func (s *UserService) ListUsers(ctx context.Context, page, perPage int, includeDeleted bool) (*api.AdminUserList, error) {
+	if page < 1 {
+		page = 1
+	}
+	if perPage < 1 {
+		perPage = 20
+	}
+
+	offset := (page - 1) * perPage
+
+	users, total, err := s.repo.FindAll(ctx, offset, perPage, includeDeleted)
+	if err != nil {
+		return nil, fmt.Errorf("list users: %w", err)
+	}
+
+	result := make([]api.AdminUser, len(users))
+	for i, u := range users {
+		result[i] = domainUserToAdminUser(u)
+	}
+
+	return &api.AdminUserList{
+		Users:   result,
+		Total:   int(total),
+		Page:    page,
+		PerPage: perPage,
+	}, nil
+}
+
+// GetUser returns a single user by ID.
+func (s *UserService) GetUser(ctx context.Context, userID string) (*api.AdminUser, error) {
+	user, err := s.repo.FindByID(ctx, userID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("user %s: %w", userID, api.ErrNotFound)
+		}
+		return nil, fmt.Errorf("get user: %w", err)
+	}
+
+	result := domainUserToAdminUser(user)
+	return &result, nil
+}
+
+// CreateUser creates a new user with a hashed password.
+func (s *UserService) CreateUser(ctx context.Context, req *api.CreateUserRequest) (*api.AdminUser, error) {
+	hash, err := s.hasher.Hash(req.Password)
+	if err != nil {
+		return nil, fmt.Errorf("hash password: %w", err)
+	}
+
+	roles := req.Roles
+	if len(roles) == 0 {
+		roles = []string{"user"}
+	}
+
+	now := time.Now().UTC()
+	user := &domain.User{
+		ID:           uuid.New().String(),
+		Email:        req.Email,
+		PasswordHash: hash,
+		Name:         req.Name,
+		Roles:        roles,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+
+	created, err := s.repo.Create(ctx, user)
+	if err != nil {
+		if errors.Is(err, storage.ErrDuplicateEmail) {
+			return nil, fmt.Errorf("email %s already exists: %w", req.Email, api.ErrConflict)
+		}
+		return nil, fmt.Errorf("create user: %w", err)
+	}
+
+	result := domainUserToAdminUser(created)
+	return &result, nil
+}
+
+// UpdateUser applies partial field updates to an existing user.
+func (s *UserService) UpdateUser(ctx context.Context, userID string, req *api.UpdateUserRequest) (*api.AdminUser, error) {
+	user, err := s.repo.FindByID(ctx, userID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("user %s: %w", userID, api.ErrNotFound)
+		}
+		return nil, fmt.Errorf("get user for update: %w", err)
+	}
+
+	if req.Email != nil {
+		user.Email = *req.Email
+	}
+	if req.Name != nil {
+		user.Name = *req.Name
+	}
+	if req.Roles != nil {
+		user.Roles = req.Roles
+	}
+	user.UpdatedAt = time.Now().UTC()
+
+	updated, err := s.repo.Update(ctx, user)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("user %s: %w", userID, api.ErrNotFound)
+		}
+		return nil, fmt.Errorf("update user: %w", err)
+	}
+
+	result := domainUserToAdminUser(updated)
+	return &result, nil
+}
+
+// DeleteUser soft-deletes a user by setting their deleted_at timestamp.
+// Returns api.ErrConflict if the user is already deleted.
+func (s *UserService) DeleteUser(ctx context.Context, userID string) error {
+	user, err := s.repo.FindByID(ctx, userID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return fmt.Errorf("user %s: %w", userID, api.ErrNotFound)
+		}
+		return fmt.Errorf("get user for delete: %w", err)
+	}
+
+	if user.DeletedAt != nil {
+		return fmt.Errorf("user %s already deleted: %w", userID, api.ErrConflict)
+	}
+
+	if err := s.repo.SoftDelete(ctx, userID); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return fmt.Errorf("user %s: %w", userID, api.ErrNotFound)
+		}
+		return fmt.Errorf("delete user: %w", err)
+	}
+
+	return nil
+}
+
+// LockUser locks a user account with the given reason.
+func (s *UserService) LockUser(ctx context.Context, userID string, reason string) (*api.AdminUser, error) {
+	now := time.Now().UTC()
+
+	if err := s.repo.SetLocked(ctx, userID, true, reason, &now); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("user %s: %w", userID, api.ErrNotFound)
+		}
+		return nil, fmt.Errorf("lock user: %w", err)
+	}
+
+	user, err := s.repo.FindByID(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get user after lock: %w", err)
+	}
+
+	result := domainUserToAdminUser(user)
+	return &result, nil
+}
+
+// UnlockUser removes the lock on a user account.
+func (s *UserService) UnlockUser(ctx context.Context, userID string) (*api.AdminUser, error) {
+	if err := s.repo.SetLocked(ctx, userID, false, "", nil); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("user %s: %w", userID, api.ErrNotFound)
+		}
+		return nil, fmt.Errorf("unlock user: %w", err)
+	}
+
+	user, err := s.repo.FindByID(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get user after unlock: %w", err)
+	}
+
+	result := domainUserToAdminUser(user)
+	return &result, nil
+}
+
+// domainUserToAdminUser maps a domain.User to the api.AdminUser response type.
+func domainUserToAdminUser(u *domain.User) api.AdminUser {
+	return api.AdminUser{
+		ID:           u.ID,
+		Email:        u.Email,
+		Name:         u.Name,
+		Roles:        u.Roles,
+		Locked:       u.Locked,
+		LockedAt:     u.LockedAt,
+		LockedReason: u.LockedReason,
+		CreatedAt:    u.CreatedAt,
+		UpdatedAt:    u.UpdatedAt,
+		DeletedAt:    u.DeletedAt,
+	}
+}
+
+// Compile-time assertion.
+var _ api.AdminUserService = (*UserService)(nil)

--- a/internal/admin/user_service_test.go
+++ b/internal/admin/user_service_test.go
@@ -1,0 +1,705 @@
+package admin_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/admin"
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+// --- Mock UserRepository ---
+
+type mockUserRepo struct {
+	findByIDFn   func(ctx context.Context, id string) (*domain.User, error)
+	findAllFn    func(ctx context.Context, offset, limit int, includeDeleted bool) ([]*domain.User, int64, error)
+	createFn     func(ctx context.Context, user *domain.User) (*domain.User, error)
+	updateFn     func(ctx context.Context, user *domain.User) (*domain.User, error)
+	softDeleteFn func(ctx context.Context, id string) error
+	setLockedFn  func(ctx context.Context, id string, locked bool, reason string, lockedAt *time.Time) error
+}
+
+func (m *mockUserRepo) FindByID(ctx context.Context, id string) (*domain.User, error) {
+	if m.findByIDFn != nil {
+		return m.findByIDFn(ctx, id)
+	}
+	return nil, storage.ErrNotFound
+}
+
+func (m *mockUserRepo) FindAll(ctx context.Context, offset, limit int, includeDeleted bool) ([]*domain.User, int64, error) {
+	if m.findAllFn != nil {
+		return m.findAllFn(ctx, offset, limit, includeDeleted)
+	}
+	return []*domain.User{}, 0, nil
+}
+
+func (m *mockUserRepo) Create(ctx context.Context, user *domain.User) (*domain.User, error) {
+	if m.createFn != nil {
+		return m.createFn(ctx, user)
+	}
+	return user, nil
+}
+
+func (m *mockUserRepo) Update(ctx context.Context, user *domain.User) (*domain.User, error) {
+	if m.updateFn != nil {
+		return m.updateFn(ctx, user)
+	}
+	return user, nil
+}
+
+func (m *mockUserRepo) SoftDelete(ctx context.Context, id string) error {
+	if m.softDeleteFn != nil {
+		return m.softDeleteFn(ctx, id)
+	}
+	return nil
+}
+
+func (m *mockUserRepo) SetLocked(ctx context.Context, id string, locked bool, reason string, lockedAt *time.Time) error {
+	if m.setLockedFn != nil {
+		return m.setLockedFn(ctx, id, locked, reason, lockedAt)
+	}
+	return nil
+}
+
+// --- Mock Hasher ---
+
+type mockHasher struct {
+	hashFn func(password string) (string, error)
+}
+
+func (m *mockHasher) Hash(password string) (string, error) {
+	if m.hashFn != nil {
+		return m.hashFn(password)
+	}
+	return "hashed:" + password, nil
+}
+
+func (m *mockHasher) Verify(password, hash string) (bool, error) {
+	return hash == "hashed:"+password, nil
+}
+
+// --- Helpers ---
+
+func newUserSvc(repo admin.UserRepository) *admin.UserService {
+	return admin.NewUserService(repo, &mockHasher{})
+}
+
+func makeUser(id string) *domain.User {
+	now := time.Now().UTC()
+	return &domain.User{
+		ID:        id,
+		Email:     id + "@example.com",
+		Name:      "Test User",
+		Roles:     []string{"user"},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+// --- ListUsers ---
+
+func TestUserService_ListUsers(t *testing.T) {
+	tests := []struct {
+		name           string
+		page           int
+		perPage        int
+		includeDeleted bool
+		setupRepo      func(*mockUserRepo)
+		wantLen        int
+		wantTotal      int
+		wantPage       int
+		wantPerPage    int
+		wantErr        bool
+	}{
+		{
+			name:    "returns empty list",
+			page:    1,
+			perPage: 20,
+			setupRepo: func(r *mockUserRepo) {
+				r.findAllFn = func(_ context.Context, _, _ int, _ bool) ([]*domain.User, int64, error) {
+					return []*domain.User{}, 0, nil
+				}
+			},
+			wantLen:     0,
+			wantTotal:   0,
+			wantPage:    1,
+			wantPerPage: 20,
+		},
+		{
+			name:    "returns users with correct page metadata",
+			page:    1,
+			perPage: 20,
+			setupRepo: func(r *mockUserRepo) {
+				r.findAllFn = func(_ context.Context, _, _ int, _ bool) ([]*domain.User, int64, error) {
+					return []*domain.User{makeUser("u1"), makeUser("u2")}, 2, nil
+				}
+			},
+			wantLen:     2,
+			wantTotal:   2,
+			wantPage:    1,
+			wantPerPage: 20,
+		},
+		{
+			name:    "computes correct offset for page 2",
+			page:    2,
+			perPage: 5,
+			setupRepo: func(r *mockUserRepo) {
+				r.findAllFn = func(_ context.Context, offset, limit int, _ bool) ([]*domain.User, int64, error) {
+					assert.Equal(t, 5, offset, "offset should be (page-1)*perPage")
+					assert.Equal(t, 5, limit)
+					return []*domain.User{makeUser("u6")}, 6, nil
+				}
+			},
+			wantLen:     1,
+			wantTotal:   6,
+			wantPage:    2,
+			wantPerPage: 5,
+		},
+		{
+			name:    "passes includeDeleted flag through",
+			page:    1,
+			perPage: 20,
+			includeDeleted: true,
+			setupRepo: func(r *mockUserRepo) {
+				r.findAllFn = func(_ context.Context, _, _ int, includeDeleted bool) ([]*domain.User, int64, error) {
+					assert.True(t, includeDeleted)
+					return []*domain.User{}, 0, nil
+				}
+			},
+		},
+		{
+			name:    "defaults page 0 to 1",
+			page:    0,
+			perPage: 10,
+			setupRepo: func(r *mockUserRepo) {
+				r.findAllFn = func(_ context.Context, offset, _ int, _ bool) ([]*domain.User, int64, error) {
+					assert.Equal(t, 0, offset, "page 0 should be treated as page 1")
+					return []*domain.User{}, 0, nil
+				}
+			},
+			wantPage: 1,
+		},
+		{
+			name:    "propagates repository error",
+			page:    1,
+			perPage: 20,
+			setupRepo: func(r *mockUserRepo) {
+				r.findAllFn = func(_ context.Context, _, _ int, _ bool) ([]*domain.User, int64, error) {
+					return nil, 0, errors.New("database unavailable")
+				}
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockUserRepo{}
+			if tt.setupRepo != nil {
+				tt.setupRepo(repo)
+			}
+
+			result, err := newUserSvc(repo).ListUsers(context.Background(), tt.page, tt.perPage, tt.includeDeleted)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, result.Users, tt.wantLen)
+			assert.Equal(t, tt.wantTotal, result.Total)
+			if tt.wantPage != 0 {
+				assert.Equal(t, tt.wantPage, result.Page)
+			}
+		})
+	}
+}
+
+// --- GetUser ---
+
+func TestUserService_GetUser(t *testing.T) {
+	tests := []struct {
+		name      string
+		userID    string
+		setupRepo func(*mockUserRepo)
+		wantErrIs error
+	}{
+		{
+			name:   "returns user when found",
+			userID: "u1",
+			setupRepo: func(r *mockUserRepo) {
+				r.findByIDFn = func(_ context.Context, id string) (*domain.User, error) {
+					return makeUser(id), nil
+				}
+			},
+		},
+		{
+			name:   "returns ErrNotFound for missing user",
+			userID: "missing",
+			setupRepo: func(r *mockUserRepo) {
+				r.findByIDFn = func(_ context.Context, _ string) (*domain.User, error) {
+					return nil, storage.ErrNotFound
+				}
+			},
+			wantErrIs: api.ErrNotFound,
+		},
+		{
+			name:   "propagates unexpected repository error",
+			userID: "u1",
+			setupRepo: func(r *mockUserRepo) {
+				r.findByIDFn = func(_ context.Context, _ string) (*domain.User, error) {
+					return nil, errors.New("db connection lost")
+				}
+			},
+			wantErrIs: nil, // any error
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockUserRepo{}
+			if tt.setupRepo != nil {
+				tt.setupRepo(repo)
+			}
+
+			result, err := newUserSvc(repo).GetUser(context.Background(), tt.userID)
+
+			if tt.wantErrIs != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErrIs)
+				return
+			}
+			if result == nil && err != nil {
+				// any error case when wantErrIs is nil
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.userID, result.ID)
+		})
+	}
+}
+
+// --- CreateUser ---
+
+func TestUserService_CreateUser(t *testing.T) {
+	validReq := &api.CreateUserRequest{
+		Email:    "alice@example.com",
+		Password: "super-secure-password-123",
+		Name:     "Alice",
+		Roles:    []string{"admin"},
+	}
+
+	tests := []struct {
+		name      string
+		req       *api.CreateUserRequest
+		setupRepo func(*mockUserRepo)
+		wantErrIs error
+		check     func(*api.AdminUser)
+	}{
+		{
+			name: "creates user with provided roles",
+			req:  validReq,
+			setupRepo: func(r *mockUserRepo) {
+				r.createFn = func(_ context.Context, u *domain.User) (*domain.User, error) {
+					return u, nil
+				}
+			},
+			check: func(u *api.AdminUser) {
+				assert.Equal(t, "alice@example.com", u.Email)
+				assert.Equal(t, "Alice", u.Name)
+				assert.Equal(t, []string{"admin"}, u.Roles)
+				assert.NotEmpty(t, u.ID)
+			},
+		},
+		{
+			name: "defaults to role user when roles not provided",
+			req:  &api.CreateUserRequest{Email: "bob@example.com", Password: "super-secure-password-123", Name: "Bob"},
+			setupRepo: func(r *mockUserRepo) {
+				r.createFn = func(_ context.Context, u *domain.User) (*domain.User, error) {
+					return u, nil
+				}
+			},
+			check: func(u *api.AdminUser) {
+				assert.Equal(t, []string{"user"}, u.Roles)
+			},
+		},
+		{
+			name: "returns ErrConflict on duplicate email",
+			req:  validReq,
+			setupRepo: func(r *mockUserRepo) {
+				r.createFn = func(_ context.Context, _ *domain.User) (*domain.User, error) {
+					return nil, storage.ErrDuplicateEmail
+				}
+			},
+			wantErrIs: api.ErrConflict,
+		},
+		{
+			name: "propagates hasher error",
+			req:  validReq,
+			setupRepo: func(_ *mockUserRepo) {
+				// hasher error handled below via custom hasher
+			},
+			wantErrIs: errors.New("any"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockUserRepo{}
+			if tt.setupRepo != nil {
+				tt.setupRepo(repo)
+			}
+
+			svc := admin.NewUserService(repo, &mockHasher{})
+			if tt.name == "propagates hasher error" {
+				svc = admin.NewUserService(repo, &mockHasher{
+					hashFn: func(_ string) (string, error) {
+						return "", errors.New("argon2 failed")
+					},
+				})
+			}
+
+			result, err := svc.CreateUser(context.Background(), tt.req)
+
+			if tt.wantErrIs != nil {
+				require.Error(t, err)
+				if errors.Is(tt.wantErrIs, api.ErrConflict) {
+					assert.ErrorIs(t, err, api.ErrConflict)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			if tt.check != nil {
+				tt.check(result)
+			}
+		})
+	}
+}
+
+// --- UpdateUser ---
+
+func TestUserService_UpdateUser(t *testing.T) {
+	newName := "Updated Name"
+	newEmail := "updated@example.com"
+
+	tests := []struct {
+		name      string
+		userID    string
+		req       *api.UpdateUserRequest
+		setupRepo func(*mockUserRepo)
+		wantErrIs error
+		check     func(*api.AdminUser)
+	}{
+		{
+			name:   "updates name",
+			userID: "u1",
+			req:    &api.UpdateUserRequest{Name: &newName},
+			setupRepo: func(r *mockUserRepo) {
+				r.findByIDFn = func(_ context.Context, id string) (*domain.User, error) {
+					return makeUser(id), nil
+				}
+				r.updateFn = func(_ context.Context, u *domain.User) (*domain.User, error) {
+					return u, nil
+				}
+			},
+			check: func(u *api.AdminUser) {
+				assert.Equal(t, newName, u.Name)
+			},
+		},
+		{
+			name:   "updates email",
+			userID: "u1",
+			req:    &api.UpdateUserRequest{Email: &newEmail},
+			setupRepo: func(r *mockUserRepo) {
+				r.findByIDFn = func(_ context.Context, id string) (*domain.User, error) {
+					return makeUser(id), nil
+				}
+				r.updateFn = func(_ context.Context, u *domain.User) (*domain.User, error) {
+					return u, nil
+				}
+			},
+			check: func(u *api.AdminUser) {
+				assert.Equal(t, newEmail, u.Email)
+			},
+		},
+		{
+			name:   "updates roles",
+			userID: "u1",
+			req:    &api.UpdateUserRequest{Roles: []string{"admin"}},
+			setupRepo: func(r *mockUserRepo) {
+				r.findByIDFn = func(_ context.Context, id string) (*domain.User, error) {
+					return makeUser(id), nil
+				}
+				r.updateFn = func(_ context.Context, u *domain.User) (*domain.User, error) {
+					return u, nil
+				}
+			},
+			check: func(u *api.AdminUser) {
+				assert.Equal(t, []string{"admin"}, u.Roles)
+			},
+		},
+		{
+			name:   "returns ErrNotFound when user missing",
+			userID: "missing",
+			req:    &api.UpdateUserRequest{Name: &newName},
+			setupRepo: func(r *mockUserRepo) {
+				r.findByIDFn = func(_ context.Context, _ string) (*domain.User, error) {
+					return nil, storage.ErrNotFound
+				}
+			},
+			wantErrIs: api.ErrNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockUserRepo{}
+			if tt.setupRepo != nil {
+				tt.setupRepo(repo)
+			}
+
+			result, err := newUserSvc(repo).UpdateUser(context.Background(), tt.userID, tt.req)
+
+			if tt.wantErrIs != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErrIs)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			if tt.check != nil {
+				tt.check(result)
+			}
+		})
+	}
+}
+
+// --- DeleteUser ---
+
+func TestUserService_DeleteUser(t *testing.T) {
+	now := time.Now().UTC()
+
+	tests := []struct {
+		name      string
+		userID    string
+		setupRepo func(*mockUserRepo)
+		wantErrIs error
+	}{
+		{
+			name:   "soft-deletes active user",
+			userID: "u1",
+			setupRepo: func(r *mockUserRepo) {
+				r.findByIDFn = func(_ context.Context, id string) (*domain.User, error) {
+					return makeUser(id), nil
+				}
+				r.softDeleteFn = func(_ context.Context, _ string) error {
+					return nil
+				}
+			},
+		},
+		{
+			name:   "returns ErrNotFound for missing user",
+			userID: "missing",
+			setupRepo: func(r *mockUserRepo) {
+				r.findByIDFn = func(_ context.Context, _ string) (*domain.User, error) {
+					return nil, storage.ErrNotFound
+				}
+			},
+			wantErrIs: api.ErrNotFound,
+		},
+		{
+			name:   "returns ErrConflict when user already deleted",
+			userID: "u1",
+			setupRepo: func(r *mockUserRepo) {
+				r.findByIDFn = func(_ context.Context, id string) (*domain.User, error) {
+					u := makeUser(id)
+					u.DeletedAt = &now
+					return u, nil
+				}
+			},
+			wantErrIs: api.ErrConflict,
+		},
+		{
+			name:   "propagates soft delete repository error",
+			userID: "u1",
+			setupRepo: func(r *mockUserRepo) {
+				r.findByIDFn = func(_ context.Context, id string) (*domain.User, error) {
+					return makeUser(id), nil
+				}
+				r.softDeleteFn = func(_ context.Context, _ string) error {
+					return errors.New("db error")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockUserRepo{}
+			if tt.setupRepo != nil {
+				tt.setupRepo(repo)
+			}
+
+			err := newUserSvc(repo).DeleteUser(context.Background(), tt.userID)
+
+			if tt.wantErrIs != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErrIs)
+				return
+			}
+		})
+	}
+}
+
+// --- LockUser ---
+
+func TestUserService_LockUser(t *testing.T) {
+	tests := []struct {
+		name      string
+		userID    string
+		reason    string
+		setupRepo func(*mockUserRepo)
+		wantErrIs error
+		check     func(*api.AdminUser)
+	}{
+		{
+			name:   "locks user and returns updated record",
+			userID: "u1",
+			reason: "suspicious activity",
+			setupRepo: func(r *mockUserRepo) {
+				r.setLockedFn = func(_ context.Context, id string, locked bool, reason string, lockedAt *time.Time) error {
+					assert.True(t, locked)
+					assert.Equal(t, "suspicious activity", reason)
+					assert.NotNil(t, lockedAt)
+					return nil
+				}
+				r.findByIDFn = func(_ context.Context, id string) (*domain.User, error) {
+					u := makeUser(id)
+					now := time.Now().UTC()
+					u.Locked = true
+					u.LockedAt = &now
+					u.LockedReason = "suspicious activity"
+					return u, nil
+				}
+			},
+			check: func(u *api.AdminUser) {
+				assert.True(t, u.Locked)
+				assert.NotNil(t, u.LockedAt)
+				assert.Equal(t, "suspicious activity", u.LockedReason)
+			},
+		},
+		{
+			name:   "returns ErrNotFound when user missing",
+			userID: "missing",
+			reason: "test",
+			setupRepo: func(r *mockUserRepo) {
+				r.setLockedFn = func(_ context.Context, _ string, _ bool, _ string, _ *time.Time) error {
+					return storage.ErrNotFound
+				}
+			},
+			wantErrIs: api.ErrNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockUserRepo{}
+			if tt.setupRepo != nil {
+				tt.setupRepo(repo)
+			}
+
+			result, err := newUserSvc(repo).LockUser(context.Background(), tt.userID, tt.reason)
+
+			if tt.wantErrIs != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErrIs)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			if tt.check != nil {
+				tt.check(result)
+			}
+		})
+	}
+}
+
+// --- UnlockUser ---
+
+func TestUserService_UnlockUser(t *testing.T) {
+	tests := []struct {
+		name      string
+		userID    string
+		setupRepo func(*mockUserRepo)
+		wantErrIs error
+		check     func(*api.AdminUser)
+	}{
+		{
+			name:   "unlocks user and returns updated record",
+			userID: "u1",
+			setupRepo: func(r *mockUserRepo) {
+				r.setLockedFn = func(_ context.Context, _ string, locked bool, reason string, lockedAt *time.Time) error {
+					assert.False(t, locked)
+					assert.Empty(t, reason)
+					assert.Nil(t, lockedAt)
+					return nil
+				}
+				r.findByIDFn = func(_ context.Context, id string) (*domain.User, error) {
+					u := makeUser(id)
+					u.Locked = false
+					return u, nil
+				}
+			},
+			check: func(u *api.AdminUser) {
+				assert.False(t, u.Locked)
+			},
+		},
+		{
+			name:   "returns ErrNotFound when user missing",
+			userID: "missing",
+			setupRepo: func(r *mockUserRepo) {
+				r.setLockedFn = func(_ context.Context, _ string, _ bool, _ string, _ *time.Time) error {
+					return storage.ErrNotFound
+				}
+			},
+			wantErrIs: api.ErrNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockUserRepo{}
+			if tt.setupRepo != nil {
+				tt.setupRepo(repo)
+			}
+
+			result, err := newUserSvc(repo).UnlockUser(context.Background(), tt.userID)
+
+			if tt.wantErrIs != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErrIs)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			if tt.check != nil {
+				tt.check(result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-127.

Closes #127

## Changes

GitHub Issue #127: Admin service implementations (`internal/admin/`) - Create a new `internal/ad...

Parent: GH-13

JWT decode for access tokens, DB lookup for refresh tokens). Each service takes repository interfaces as dependencies. Include comprehensive unit tests with mocked repositories (table-driven, testify).