### PR TITLE
GH-126: Repository layer extensions (`internal/storage/`)

### DIFF
--- a/.agent/tasks/gh-126.md
+++ b/.agent/tasks/gh-126.md
@@ -1,0 +1,14 @@
+# GH-126
+
+**Created:** 2026-04-03
+
+## Problem
+
+GitHub Issue #126: Repository layer extensions (`internal/storage/`)
+
+Parent: GH-13
+
+Extend repository interfaces and Postgres implementations to support admin operations. UserRepository needs: `List` (paginated, with `include_deleted`), `Update` (roles, name, email), `SoftDelete`, `Lock`, `Unlock`. ClientRepository needs: `List` (paginated), `GetByID`, `Update` (scopes, status), `SoftDelete`, `RotateSecret` (with 24h grace period on old secret). RefreshTokenRepository needs: `FindBySignature` for token introspection lookups. All implementations go into the existing Postgres repository files. Include unit tests for new repository methods.
+
+## Acceptance Criteria
+

--- a/internal/admin/client_service.go
+++ b/internal/admin/client_service.go
@@ -213,7 +213,9 @@ func (s *ClientService) RotateSecret(ctx context.Context, clientID string) (*api
 		return nil, fmt.Errorf("rotate secret: %w", api.ErrInternalError)
 	}
 
-	if err := s.repo.UpdateSecretHash(ctx, id, hash); err != nil {
+	graceEnd := time.Now().UTC().Add(gracePeriodDuration)
+
+	if err := s.repo.RotateSecret(ctx, id, hash, graceEnd); err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, fmt.Errorf("client %s: %w", clientID, api.ErrNotFound)
 		}
@@ -227,8 +229,6 @@ func (s *ClientService) RotateSecret(ctx context.Context, clientID string) (*api
 		s.logger.Error("re-read client after rotation failed", zap.String("client_id", clientID), zap.Error(err))
 		return nil, fmt.Errorf("rotate secret: %w", api.ErrInternalError)
 	}
-
-	graceEnd := time.Now().UTC().Add(gracePeriodDuration)
 	return &api.AdminClientWithSecret{
 		AdminClient:     domainClientToAdmin(client),
 		ClientSecret:    secret,

--- a/internal/admin/client_service_test.go
+++ b/internal/admin/client_service_test.go
@@ -25,6 +25,7 @@ type mockClientRepo struct {
 	createFn           func(ctx context.Context, client *domain.Client) (*domain.Client, error)
 	updateFn           func(ctx context.Context, client *domain.Client) (*domain.Client, error)
 	updateSecretHashFn func(ctx context.Context, id uuid.UUID, secretHash string) error
+	rotateSecretFn     func(ctx context.Context, id uuid.UUID, newSecretHash string, gracePeriodEnds time.Time) error
 	softDeleteFn       func(ctx context.Context, id uuid.UUID) error
 }
 
@@ -70,6 +71,13 @@ func (m *mockClientRepo) Update(ctx context.Context, client *domain.Client) (*do
 func (m *mockClientRepo) UpdateSecretHash(ctx context.Context, id uuid.UUID, secretHash string) error {
 	if m.updateSecretHashFn != nil {
 		return m.updateSecretHashFn(ctx, id, secretHash)
+	}
+	return nil
+}
+
+func (m *mockClientRepo) RotateSecret(ctx context.Context, id uuid.UUID, newSecretHash string, gracePeriodEnds time.Time) error {
+	if m.rotateSecretFn != nil {
+		return m.rotateSecretFn(ctx, id, newSecretHash, gracePeriodEnds)
 	}
 	return nil
 }
@@ -284,7 +292,7 @@ func TestClientService_RotateSecret(t *testing.T) {
 
 func TestClientService_RotateSecret_NotFound(t *testing.T) {
 	repo := &mockClientRepo{
-		updateSecretHashFn: func(_ context.Context, _ uuid.UUID, _ string) error {
+		rotateSecretFn: func(_ context.Context, _ uuid.UUID, _ string, _ time.Time) error {
 			return fmt.Errorf("not found: %w", storage.ErrNotFound)
 		},
 	}

--- a/internal/domain/client.go
+++ b/internal/domain/client.go
@@ -30,17 +30,19 @@ const (
 
 // Client represents an OAuth2 client (service or AI agent) in the system.
 type Client struct {
-	ID             uuid.UUID  `json:"id"               db:"id"`
-	Name           string     `json:"name"             db:"name"`
-	ClientType     ClientType `json:"client_type"      db:"client_type"`
-	SecretHash     string     `json:"-"                db:"secret_hash"`
-	Scopes         []string   `json:"scopes"           db:"scopes"`
-	Owner          string     `json:"owner"            db:"owner"`
-	AccessTokenTTL int        `json:"access_token_ttl" db:"access_token_ttl"` // seconds
-	Status         string     `json:"status"           db:"status"`
-	CreatedAt      time.Time  `json:"created_at"       db:"created_at"`
-	UpdatedAt      time.Time  `json:"updated_at"       db:"updated_at"`
-	LastUsedAt     *time.Time `json:"last_used_at"     db:"last_used_at"`
+	ID                       uuid.UUID  `json:"id"                          db:"id"`
+	Name                     string     `json:"name"                        db:"name"`
+	ClientType               ClientType `json:"client_type"                 db:"client_type"`
+	SecretHash               string     `json:"-"                           db:"secret_hash"`
+	PreviousSecretHash       string     `json:"-"                           db:"previous_secret_hash"`
+	PreviousSecretExpiresAt  *time.Time `json:"-"                           db:"previous_secret_expires_at"`
+	Scopes                   []string   `json:"scopes"                      db:"scopes"`
+	Owner                    string     `json:"owner"                       db:"owner"`
+	AccessTokenTTL           int        `json:"access_token_ttl"            db:"access_token_ttl"` // seconds
+	Status                   string     `json:"status"                      db:"status"`
+	CreatedAt                time.Time  `json:"created_at"                  db:"created_at"`
+	UpdatedAt                time.Time  `json:"updated_at"                  db:"updated_at"`
+	LastUsedAt               *time.Time `json:"last_used_at"                db:"last_used_at"`
 }
 
 // AccessTokenDuration returns the access token TTL as a time.Duration.

--- a/internal/storage/client_repository.go
+++ b/internal/storage/client_repository.go
@@ -22,6 +22,7 @@ type ClientRepository interface {
 	Create(ctx context.Context, client *domain.Client) (*domain.Client, error)
 	Update(ctx context.Context, client *domain.Client) (*domain.Client, error)
 	UpdateSecretHash(ctx context.Context, id uuid.UUID, secretHash string) error
+	RotateSecret(ctx context.Context, id uuid.UUID, newSecretHash string, gracePeriodEnds time.Time) error
 	SoftDelete(ctx context.Context, id uuid.UUID) error
 }
 
@@ -35,13 +36,14 @@ func NewPostgresClientRepository(pool *pgxpool.Pool) *PostgresClientRepository {
 	return &PostgresClientRepository{pool: pool}
 }
 
-const clientColumns = `id, name, client_type, secret_hash, scopes, owner, access_token_ttl, status, created_at, updated_at, last_used_at`
+const clientColumns = `id, name, client_type, secret_hash, previous_secret_hash, previous_secret_expires_at, scopes, owner, access_token_ttl, status, created_at, updated_at, last_used_at`
 
 func scanClient(row pgx.Row) (*domain.Client, error) {
 	c := &domain.Client{}
 	err := row.Scan(
-		&c.ID, &c.Name, &c.ClientType, &c.SecretHash, &c.Scopes,
-		&c.Owner, &c.AccessTokenTTL, &c.Status,
+		&c.ID, &c.Name, &c.ClientType, &c.SecretHash,
+		&c.PreviousSecretHash, &c.PreviousSecretExpiresAt,
+		&c.Scopes, &c.Owner, &c.AccessTokenTTL, &c.Status,
 		&c.CreatedAt, &c.UpdatedAt, &c.LastUsedAt,
 	)
 	if err != nil {
@@ -78,8 +80,9 @@ func (r *PostgresClientRepository) List(ctx context.Context, limit, offset int, 
 	for rows.Next() {
 		c := &domain.Client{}
 		if err := rows.Scan(
-			&c.ID, &c.Name, &c.ClientType, &c.SecretHash, &c.Scopes,
-			&c.Owner, &c.AccessTokenTTL, &c.Status,
+			&c.ID, &c.Name, &c.ClientType, &c.SecretHash,
+			&c.PreviousSecretHash, &c.PreviousSecretExpiresAt,
+			&c.Scopes, &c.Owner, &c.AccessTokenTTL, &c.Status,
 			&c.CreatedAt, &c.UpdatedAt, &c.LastUsedAt,
 		); err != nil {
 			return nil, 0, fmt.Errorf("scan client: %w", err)
@@ -164,6 +167,28 @@ func (r *PostgresClientRepository) UpdateSecretHash(ctx context.Context, id uuid
 	tag, err := r.pool.Exec(ctx, query, secretHash, time.Now().UTC(), id)
 	if err != nil {
 		return fmt.Errorf("update secret hash: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("client %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
+// RotateSecret moves the current secret to previous_secret_hash with a grace period,
+// then sets the new secret hash. Both secrets are valid until the grace period expires.
+func (r *PostgresClientRepository) RotateSecret(ctx context.Context, id uuid.UUID, newSecretHash string, gracePeriodEnds time.Time) error {
+	query := `
+		UPDATE clients
+		SET previous_secret_hash = secret_hash,
+		    previous_secret_expires_at = $1,
+		    secret_hash = $2,
+		    updated_at = $3
+		WHERE id = $4 AND status != 'revoked'`
+
+	now := time.Now().UTC()
+	tag, err := r.pool.Exec(ctx, query, gracePeriodEnds, newSecretHash, now, id)
+	if err != nil {
+		return fmt.Errorf("rotate secret: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
 		return fmt.Errorf("client %s: %w", id, ErrNotFound)

--- a/internal/storage/repository_integration_test.go
+++ b/internal/storage/repository_integration_test.go
@@ -69,11 +69,33 @@ func createTables(t *testing.T, pool *pgxpool.Pool) {
 			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 			revoked_at TIMESTAMPTZ
 		);
+
+		DO $$ BEGIN
+			CREATE TYPE client_type AS ENUM ('service', 'agent');
+		EXCEPTION
+			WHEN duplicate_object THEN NULL;
+		END $$;
+
+		CREATE TABLE IF NOT EXISTS clients (
+			id                          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+			name                        TEXT        NOT NULL UNIQUE,
+			client_type                 client_type NOT NULL,
+			secret_hash                 TEXT        NOT NULL,
+			previous_secret_hash        TEXT        NOT NULL DEFAULT '',
+			previous_secret_expires_at  TIMESTAMPTZ,
+			scopes                      TEXT[]      NOT NULL DEFAULT '{}',
+			owner                       TEXT        NOT NULL,
+			access_token_ttl            INTEGER     NOT NULL DEFAULT 900,
+			status                      TEXT        NOT NULL DEFAULT 'active',
+			created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			last_used_at                TIMESTAMPTZ
+		);
 	`)
 	require.NoError(t, err)
 
 	// Clean tables before each test file run.
-	_, err = pool.Exec(ctx, `TRUNCATE users, refresh_tokens`)
+	_, err = pool.Exec(ctx, `TRUNCATE users, refresh_tokens, clients`)
 	require.NoError(t, err)
 }
 
@@ -324,4 +346,597 @@ func TestPostgresRefreshTokenRepository_RevokeAllForUser_NoTokens(t *testing.T) 
 	// Should not error even if user has no tokens.
 	err := repo.RevokeAllForUser(ctx, uuid.New().String())
 	require.NoError(t, err)
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// AdminUserRepository tests
+// ────────────────────────────────────────────────────────────────────────────
+
+func TestPostgresAdminUserRepository_List(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAdminUserRepository(pool)
+	userRepo := storage.NewPostgresUserRepository(pool)
+	ctx := context.Background()
+
+	// Create 3 users.
+	for i := 0; i < 3; i++ {
+		_, err := userRepo.Create(ctx, newTestUser())
+		require.NoError(t, err)
+	}
+
+	users, total, err := repo.List(ctx, 10, 0, false)
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+	assert.Len(t, users, 3)
+}
+
+func TestPostgresAdminUserRepository_List_Pagination(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAdminUserRepository(pool)
+	userRepo := storage.NewPostgresUserRepository(pool)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		_, err := userRepo.Create(ctx, newTestUser())
+		require.NoError(t, err)
+	}
+
+	users, total, err := repo.List(ctx, 2, 0, false)
+	require.NoError(t, err)
+	assert.Equal(t, 5, total)
+	assert.Len(t, users, 2)
+
+	users, total, err = repo.List(ctx, 2, 4, false)
+	require.NoError(t, err)
+	assert.Equal(t, 5, total)
+	assert.Len(t, users, 1)
+}
+
+func TestPostgresAdminUserRepository_List_IncludeDeleted(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAdminUserRepository(pool)
+	userRepo := storage.NewPostgresUserRepository(pool)
+	ctx := context.Background()
+
+	u := newTestUser()
+	_, err := userRepo.Create(ctx, u)
+	require.NoError(t, err)
+
+	err = repo.SoftDelete(ctx, u.ID)
+	require.NoError(t, err)
+
+	// Without includeDeleted, should be empty.
+	users, total, err := repo.List(ctx, 10, 0, false)
+	require.NoError(t, err)
+	assert.Equal(t, 0, total)
+	assert.Empty(t, users)
+
+	// With includeDeleted, should find the deleted user.
+	users, total, err = repo.List(ctx, 10, 0, true)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	assert.Len(t, users, 1)
+}
+
+func TestPostgresAdminUserRepository_FindByID(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAdminUserRepository(pool)
+	userRepo := storage.NewPostgresUserRepository(pool)
+	ctx := context.Background()
+
+	u := newTestUser()
+	_, err := userRepo.Create(ctx, u)
+	require.NoError(t, err)
+
+	found, err := repo.FindByID(ctx, u.ID)
+	require.NoError(t, err)
+	assert.Equal(t, u.Email, found.Email)
+}
+
+func TestPostgresAdminUserRepository_FindByID_NotFound(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAdminUserRepository(pool)
+	ctx := context.Background()
+
+	_, err := repo.FindByID(ctx, "nonexistent-id")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresAdminUserRepository_Create(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAdminUserRepository(pool)
+	ctx := context.Background()
+
+	u := newTestUser()
+	created, err := repo.Create(ctx, u)
+	require.NoError(t, err)
+	assert.Equal(t, u.ID, created.ID)
+	assert.Equal(t, u.Email, created.Email)
+}
+
+func TestPostgresAdminUserRepository_Create_DuplicateEmail(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAdminUserRepository(pool)
+	ctx := context.Background()
+
+	u := newTestUser()
+	_, err := repo.Create(ctx, u)
+	require.NoError(t, err)
+
+	dup := newTestUser()
+	dup.Email = u.Email
+	_, err = repo.Create(ctx, dup)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrDuplicateEmail)
+}
+
+func TestPostgresAdminUserRepository_Update(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAdminUserRepository(pool)
+	ctx := context.Background()
+
+	u := newTestUser()
+	_, err := repo.Create(ctx, u)
+	require.NoError(t, err)
+
+	u.Name = "Updated Name"
+	u.Roles = []string{"admin"}
+	updated, err := repo.Update(ctx, u)
+	require.NoError(t, err)
+	assert.Equal(t, "Updated Name", updated.Name)
+	assert.Equal(t, []string{"admin"}, updated.Roles)
+}
+
+func TestPostgresAdminUserRepository_Update_NotFound(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAdminUserRepository(pool)
+	ctx := context.Background()
+
+	u := newTestUser()
+	_, err := repo.Update(ctx, u)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresAdminUserRepository_Update_DuplicateEmail(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAdminUserRepository(pool)
+	ctx := context.Background()
+
+	u1 := newTestUser()
+	_, err := repo.Create(ctx, u1)
+	require.NoError(t, err)
+
+	u2 := newTestUser()
+	_, err = repo.Create(ctx, u2)
+	require.NoError(t, err)
+
+	u2.Email = u1.Email
+	_, err = repo.Update(ctx, u2)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrDuplicateEmail)
+}
+
+func TestPostgresAdminUserRepository_SoftDelete(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAdminUserRepository(pool)
+	ctx := context.Background()
+
+	u := newTestUser()
+	_, err := repo.Create(ctx, u)
+	require.NoError(t, err)
+
+	err = repo.SoftDelete(ctx, u.ID)
+	require.NoError(t, err)
+
+	found, err := repo.FindByID(ctx, u.ID)
+	require.NoError(t, err)
+	assert.NotNil(t, found.DeletedAt)
+}
+
+func TestPostgresAdminUserRepository_SoftDelete_NotFound(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAdminUserRepository(pool)
+	ctx := context.Background()
+
+	err := repo.SoftDelete(ctx, "nonexistent-id")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresAdminUserRepository_SoftDelete_AlreadyDeleted(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAdminUserRepository(pool)
+	ctx := context.Background()
+
+	u := newTestUser()
+	_, err := repo.Create(ctx, u)
+	require.NoError(t, err)
+
+	err = repo.SoftDelete(ctx, u.ID)
+	require.NoError(t, err)
+
+	err = repo.SoftDelete(ctx, u.ID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrAlreadyDeleted)
+}
+
+func TestPostgresAdminUserRepository_Lock(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAdminUserRepository(pool)
+	ctx := context.Background()
+
+	u := newTestUser()
+	_, err := repo.Create(ctx, u)
+	require.NoError(t, err)
+
+	locked, err := repo.Lock(ctx, u.ID, "suspicious activity")
+	require.NoError(t, err)
+	assert.True(t, locked.Locked)
+	assert.NotNil(t, locked.LockedAt)
+	assert.Equal(t, "suspicious activity", locked.LockedReason)
+}
+
+func TestPostgresAdminUserRepository_Lock_NotFound(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAdminUserRepository(pool)
+	ctx := context.Background()
+
+	_, err := repo.Lock(ctx, "nonexistent-id", "reason")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresAdminUserRepository_Unlock(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAdminUserRepository(pool)
+	ctx := context.Background()
+
+	u := newTestUser()
+	_, err := repo.Create(ctx, u)
+	require.NoError(t, err)
+
+	_, err = repo.Lock(ctx, u.ID, "suspicious activity")
+	require.NoError(t, err)
+
+	unlocked, err := repo.Unlock(ctx, u.ID)
+	require.NoError(t, err)
+	assert.False(t, unlocked.Locked)
+	assert.Nil(t, unlocked.LockedAt)
+	assert.Equal(t, "", unlocked.LockedReason)
+}
+
+func TestPostgresAdminUserRepository_Unlock_NotFound(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAdminUserRepository(pool)
+	ctx := context.Background()
+
+	_, err := repo.Unlock(ctx, "nonexistent-id")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// ClientRepository tests
+// ────────────────────────────────────────────────────────────────────────────
+
+func newTestClient() *domain.Client {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	return &domain.Client{
+		ID:             uuid.New(),
+		Name:           "test-client-" + uuid.New().String()[:8],
+		ClientType:     domain.ClientTypeService,
+		SecretHash:     "$argon2id$v=19$m=19456,t=2,p=1$salt$hash",
+		Scopes:         []string{"read:users"},
+		Owner:          "admin",
+		AccessTokenTTL: 900,
+		Status:         domain.ClientStatusActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+}
+
+func TestPostgresClientRepository_Create(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresClientRepository(pool)
+	ctx := context.Background()
+
+	c := newTestClient()
+	created, err := repo.Create(ctx, c)
+	require.NoError(t, err)
+	assert.Equal(t, c.ID, created.ID)
+	assert.Equal(t, c.Name, created.Name)
+	assert.Equal(t, c.SecretHash, created.SecretHash)
+	assert.Equal(t, c.Scopes, created.Scopes)
+	assert.Equal(t, domain.ClientStatusActive, created.Status)
+}
+
+func TestPostgresClientRepository_Create_DuplicateName(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresClientRepository(pool)
+	ctx := context.Background()
+
+	c := newTestClient()
+	_, err := repo.Create(ctx, c)
+	require.NoError(t, err)
+
+	dup := newTestClient()
+	dup.Name = c.Name
+	_, err = repo.Create(ctx, dup)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrDuplicateClient)
+}
+
+func TestPostgresClientRepository_FindByID(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresClientRepository(pool)
+	ctx := context.Background()
+
+	c := newTestClient()
+	_, err := repo.Create(ctx, c)
+	require.NoError(t, err)
+
+	found, err := repo.FindByID(ctx, c.ID)
+	require.NoError(t, err)
+	assert.Equal(t, c.Name, found.Name)
+}
+
+func TestPostgresClientRepository_FindByID_NotFound(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresClientRepository(pool)
+	ctx := context.Background()
+
+	_, err := repo.FindByID(ctx, uuid.New())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresClientRepository_FindByName(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresClientRepository(pool)
+	ctx := context.Background()
+
+	c := newTestClient()
+	_, err := repo.Create(ctx, c)
+	require.NoError(t, err)
+
+	found, err := repo.FindByName(ctx, c.Name)
+	require.NoError(t, err)
+	assert.Equal(t, c.ID, found.ID)
+}
+
+func TestPostgresClientRepository_FindByName_NotFound(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresClientRepository(pool)
+	ctx := context.Background()
+
+	_, err := repo.FindByName(ctx, "nonexistent-client")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresClientRepository_List(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresClientRepository(pool)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		_, err := repo.Create(ctx, newTestClient())
+		require.NoError(t, err)
+	}
+
+	clients, total, err := repo.List(ctx, 10, 0, false)
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+	assert.Len(t, clients, 3)
+}
+
+func TestPostgresClientRepository_List_Pagination(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresClientRepository(pool)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		_, err := repo.Create(ctx, newTestClient())
+		require.NoError(t, err)
+	}
+
+	clients, total, err := repo.List(ctx, 2, 0, false)
+	require.NoError(t, err)
+	assert.Equal(t, 5, total)
+	assert.Len(t, clients, 2)
+}
+
+func TestPostgresClientRepository_List_IncludeRevoked(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresClientRepository(pool)
+	ctx := context.Background()
+
+	c := newTestClient()
+	_, err := repo.Create(ctx, c)
+	require.NoError(t, err)
+
+	err = repo.SoftDelete(ctx, c.ID)
+	require.NoError(t, err)
+
+	// Without includeRevoked.
+	clients, total, err := repo.List(ctx, 10, 0, false)
+	require.NoError(t, err)
+	assert.Equal(t, 0, total)
+	assert.Empty(t, clients)
+
+	// With includeRevoked.
+	clients, total, err = repo.List(ctx, 10, 0, true)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	assert.Len(t, clients, 1)
+}
+
+func TestPostgresClientRepository_Update(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresClientRepository(pool)
+	ctx := context.Background()
+
+	c := newTestClient()
+	_, err := repo.Create(ctx, c)
+	require.NoError(t, err)
+
+	c.Name = "updated-name-" + uuid.New().String()[:8]
+	c.Scopes = []string{"read:users", "write:users"}
+	updated, err := repo.Update(ctx, c)
+	require.NoError(t, err)
+	assert.Equal(t, c.Name, updated.Name)
+	assert.Equal(t, []string{"read:users", "write:users"}, updated.Scopes)
+}
+
+func TestPostgresClientRepository_Update_NotFound(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresClientRepository(pool)
+	ctx := context.Background()
+
+	c := newTestClient()
+	_, err := repo.Update(ctx, c)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresClientRepository_Update_DuplicateName(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresClientRepository(pool)
+	ctx := context.Background()
+
+	c1 := newTestClient()
+	_, err := repo.Create(ctx, c1)
+	require.NoError(t, err)
+
+	c2 := newTestClient()
+	_, err = repo.Create(ctx, c2)
+	require.NoError(t, err)
+
+	c2.Name = c1.Name
+	_, err = repo.Update(ctx, c2)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrDuplicateClient)
+}
+
+func TestPostgresClientRepository_UpdateSecretHash(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresClientRepository(pool)
+	ctx := context.Background()
+
+	c := newTestClient()
+	_, err := repo.Create(ctx, c)
+	require.NoError(t, err)
+
+	err = repo.UpdateSecretHash(ctx, c.ID, "new-hash")
+	require.NoError(t, err)
+
+	found, err := repo.FindByID(ctx, c.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "new-hash", found.SecretHash)
+}
+
+func TestPostgresClientRepository_UpdateSecretHash_NotFound(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresClientRepository(pool)
+	ctx := context.Background()
+
+	err := repo.UpdateSecretHash(ctx, uuid.New(), "new-hash")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresClientRepository_RotateSecret(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresClientRepository(pool)
+	ctx := context.Background()
+
+	c := newTestClient()
+	_, err := repo.Create(ctx, c)
+	require.NoError(t, err)
+
+	graceEnd := time.Now().Add(24 * time.Hour).UTC().Truncate(time.Microsecond)
+	err = repo.RotateSecret(ctx, c.ID, "new-secret-hash", graceEnd)
+	require.NoError(t, err)
+
+	found, err := repo.FindByID(ctx, c.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "new-secret-hash", found.SecretHash)
+	assert.Equal(t, c.SecretHash, found.PreviousSecretHash)
+	require.NotNil(t, found.PreviousSecretExpiresAt)
+	assert.Equal(t, graceEnd, found.PreviousSecretExpiresAt.Truncate(time.Microsecond))
+}
+
+func TestPostgresClientRepository_RotateSecret_NotFound(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresClientRepository(pool)
+	ctx := context.Background()
+
+	graceEnd := time.Now().Add(24 * time.Hour).UTC()
+	err := repo.RotateSecret(ctx, uuid.New(), "new-hash", graceEnd)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresClientRepository_RotateSecret_RevokedClient(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresClientRepository(pool)
+	ctx := context.Background()
+
+	c := newTestClient()
+	_, err := repo.Create(ctx, c)
+	require.NoError(t, err)
+
+	err = repo.SoftDelete(ctx, c.ID)
+	require.NoError(t, err)
+
+	graceEnd := time.Now().Add(24 * time.Hour).UTC()
+	err = repo.RotateSecret(ctx, c.ID, "new-hash", graceEnd)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresClientRepository_SoftDelete(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresClientRepository(pool)
+	ctx := context.Background()
+
+	c := newTestClient()
+	_, err := repo.Create(ctx, c)
+	require.NoError(t, err)
+
+	err = repo.SoftDelete(ctx, c.ID)
+	require.NoError(t, err)
+
+	found, err := repo.FindByID(ctx, c.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.ClientStatusRevoked, found.Status)
+}
+
+func TestPostgresClientRepository_SoftDelete_NotFound(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresClientRepository(pool)
+	ctx := context.Background()
+
+	err := repo.SoftDelete(ctx, uuid.New())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresClientRepository_SoftDelete_AlreadyDeleted(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresClientRepository(pool)
+	ctx := context.Background()
+
+	c := newTestClient()
+	_, err := repo.Create(ctx, c)
+	require.NoError(t, err)
+
+	err = repo.SoftDelete(ctx, c.ID)
+	require.NoError(t, err)
+
+	err = repo.SoftDelete(ctx, c.ID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrAlreadyDeleted)
 }

--- a/migrations/000002_add_client_secret_rotation.down.sql
+++ b/migrations/000002_add_client_secret_rotation.down.sql
@@ -1,0 +1,5 @@
+-- 000002_add_client_secret_rotation.down.sql
+
+ALTER TABLE clients
+    DROP COLUMN IF EXISTS previous_secret_hash,
+    DROP COLUMN IF EXISTS previous_secret_expires_at;

--- a/migrations/000002_add_client_secret_rotation.up.sql
+++ b/migrations/000002_add_client_secret_rotation.up.sql
@@ -1,0 +1,6 @@
+-- 000002_add_client_secret_rotation.up.sql
+-- Adds columns for secret rotation with a 24-hour grace period on the old secret.
+
+ALTER TABLE clients
+    ADD COLUMN previous_secret_hash       TEXT NOT NULL DEFAULT '',
+    ADD COLUMN previous_secret_expires_at TIMESTAMPTZ;


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-126.

Closes #126

## Changes

GitHub Issue #126: Repository layer extensions (`internal/storage/`)

Parent: GH-13

Extend repository interfaces and Postgres implementations to support admin operations. UserRepository needs: `List` (paginated, with `include_deleted`), `Update` (roles, name, email), `SoftDelete`, `Lock`, `Unlock`. ClientRepository needs: `List` (paginated), `GetByID`, `Update` (scopes, status), `SoftDelete`, `RotateSecret` (with 24h grace period on old secret). RefreshTokenRepository needs: `FindBySignature` for token introspection lookups. All implementations go into the existing Postgres repository files. Include unit tests for new repository methods.