### PR TITLE
GH-138: Server wiring and verification (`cmd/server/main.go`)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/qf-studio/auth-service/internal/admin"
 	"github.com/qf-studio/auth-service/internal/api"
 	"github.com/qf-studio/auth-service/internal/auth"
+	"github.com/qf-studio/auth-service/internal/hibp"
 	"github.com/qf-studio/auth-service/internal/config"
 	"github.com/qf-studio/auth-service/internal/health"
 	"github.com/qf-studio/auth-service/internal/httpserver"
@@ -81,7 +82,8 @@ func run(log *zap.Logger) error {
 	if err != nil {
 		return fmt.Errorf("token service init failed: %w", err)
 	}
-	authSvc := auth.NewService(redisClient, log, userRepo, refreshTokenRepo, tokenSvc, hasher)
+	hibpClient := hibp.NewClient(http.DefaultClient)
+	authSvc := auth.NewService(redisClient, log, userRepo, refreshTokenRepo, tokenSvc, hasher, hibpClient)
 
 	services := &api.Services{
 		Auth:  authSvc,

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/qf-studio/auth-service/internal/api"
 	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/hibp"
 	"github.com/qf-studio/auth-service/internal/password"
 	"github.com/qf-studio/auth-service/internal/storage"
 )
@@ -46,6 +47,7 @@ type Service struct {
 	tokens    storage.RefreshTokenRepository
 	issuer    TokenIssuer
 	hasher    password.Hasher
+	breaches  hibp.BreachChecker
 }
 
 // NewService creates a new auth Service.
@@ -56,14 +58,16 @@ func NewService(
 	tokens storage.RefreshTokenRepository,
 	issuer TokenIssuer,
 	hasher password.Hasher,
+	breaches hibp.BreachChecker,
 ) *Service {
 	return &Service{
-		redis:  redisClient,
-		logger: logger,
-		users:  users,
-		tokens: tokens,
-		issuer: issuer,
-		hasher: hasher,
+		redis:    redisClient,
+		logger:   logger,
+		users:    users,
+		tokens:   tokens,
+		issuer:   issuer,
+		hasher:   hasher,
+		breaches: breaches,
 	}
 }
 

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -96,6 +96,17 @@ func (m *mockTokenIssuer) Revoke(ctx context.Context, token string) error {
 	return nil
 }
 
+type mockBreachChecker struct {
+	isBreachedFn func(ctx context.Context, password string) (bool, error)
+}
+
+func (m *mockBreachChecker) IsBreached(ctx context.Context, password string) (bool, error) {
+	if m.isBreachedFn != nil {
+		return m.isBreachedFn(ctx, password)
+	}
+	return false, nil
+}
+
 type mockHasher struct {
 	verifyFn func(password, hash string) (bool, error)
 }
@@ -118,7 +129,7 @@ func (m *mockHasher) Verify(password, hash string) (bool, error) {
 func newUnitService(t *testing.T, users *mockUserRepository, tokens *mockRefreshTokenRepository, issuer *mockTokenIssuer, hasher *mockHasher) *Service {
 	t.Helper()
 	logger, _ := zap.NewDevelopment()
-	return NewService(nil, logger, users, tokens, issuer, hasher)
+	return NewService(nil, logger, users, tokens, issuer, hasher, &mockBreachChecker{})
 }
 
 // newRedisClient creates a Redis client for integration tests (password reset).
@@ -154,7 +165,7 @@ func newIntegrationService(t *testing.T) *Service {
 	t.Helper()
 	client := newRedisClient(t)
 	logger, _ := zap.NewDevelopment()
-	return NewService(client, logger, &mockUserRepository{}, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, &mockHasher{})
+	return NewService(client, logger, &mockUserRepository{}, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, &mockHasher{}, &mockBreachChecker{})
 }
 
 // ── Login Tests ──────────────────────────────────────────────────────────────

--- a/internal/hibp/hibp.go
+++ b/internal/hibp/hibp.go
@@ -1,0 +1,83 @@
+// Package hibp implements the HaveIBeenPwned k-anonymity API for
+// checking whether a password has appeared in known data breaches.
+package hibp
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha1" //#nosec G505 — SHA-1 is required by the HIBP API protocol, not used for security
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+const apiURL = "https://api.pwnedpasswords.com/range/"
+
+// BreachChecker determines whether a password has appeared in a data breach.
+type BreachChecker interface {
+	IsBreached(ctx context.Context, password string) (bool, error)
+}
+
+// Client checks passwords against the HIBP Pwned Passwords API using
+// the k-anonymity model: only the first 5 characters of the SHA-1 hash
+// are sent to the API.
+type Client struct {
+	httpClient *http.Client
+	apiURL     string
+}
+
+// NewClient creates a new HIBP client with the given HTTP client.
+func NewClient(httpClient *http.Client) *Client {
+	return &Client{
+		httpClient: httpClient,
+		apiURL:     apiURL,
+	}
+}
+
+// IsBreached checks whether the given password appears in the HIBP database.
+// It uses the k-anonymity range API: SHA-1 hash the password, send the first
+// 5 hex chars as prefix, then compare the returned suffixes.
+func (c *Client) IsBreached(ctx context.Context, password string) (bool, error) {
+	hash := fmt.Sprintf("%X", sha1.Sum([]byte(password))) //#nosec G401
+	prefix := hash[:5]
+	suffix := hash[5:]
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.apiURL+prefix, nil)
+	if err != nil {
+		return false, fmt.Errorf("hibp: create request: %w", err)
+	}
+	req.Header.Set("User-Agent", "qf-studio-auth-service")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("hibp: request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("hibp: unexpected status %d", resp.StatusCode)
+	}
+
+	return matchesSuffix(resp.Body, suffix)
+}
+
+// matchesSuffix scans the HIBP response body for a matching hash suffix.
+// Each line is formatted as "SUFFIX:COUNT".
+func matchesSuffix(body io.Reader, suffix string) (bool, error) {
+	scanner := bufio.NewScanner(body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		if strings.EqualFold(parts[0], suffix) {
+			return true, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return false, fmt.Errorf("hibp: scan response: %w", err)
+	}
+	return false, nil
+}

--- a/internal/hibp/hibp_test.go
+++ b/internal/hibp/hibp_test.go
@@ -1,0 +1,95 @@
+package hibp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// SHA-1("password") = 5BAA61E4C9B93F3F0682250B6CF8331B7EE68FD8
+// prefix = 5BAA6, suffix = 1E4C9B93F3F0682250B6CF8331B7EE68FD8
+
+func TestIsBreached_FoundInResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/range/5BAA6", r.URL.Path)
+		assert.Equal(t, "qf-studio-auth-service", r.Header.Get("User-Agent"))
+		_, _ = w.Write([]byte("0018A45C4D1DEF81644B54AB7F969B88D65:2\r\n1E4C9B93F3F0682250B6CF8331B7EE68FD8:10000000\r\n003D68EB55068C33ACE09247EE4C639306B:3\r\n"))
+	}))
+	defer srv.Close()
+
+	c := &Client{httpClient: srv.Client(), apiURL: srv.URL + "/range/"}
+	breached, err := c.IsBreached(context.Background(), "password")
+	require.NoError(t, err)
+	assert.True(t, breached)
+}
+
+func TestIsBreached_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("0018A45C4D1DEF81644B54AB7F969B88D65:2\r\n003D68EB55068C33ACE09247EE4C639306B:3\r\n"))
+	}))
+	defer srv.Close()
+
+	c := &Client{httpClient: srv.Client(), apiURL: srv.URL + "/range/"}
+	breached, err := c.IsBreached(context.Background(), "password")
+	require.NoError(t, err)
+	assert.False(t, breached)
+}
+
+func TestIsBreached_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	c := &Client{httpClient: srv.Client(), apiURL: srv.URL + "/range/"}
+	_, err := c.IsBreached(context.Background(), "password")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected status 503")
+}
+
+func TestMatchesSuffix(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		suffix  string
+		want    bool
+	}{
+		{
+			name:   "match",
+			body:   "ABC:1\r\nDEF:2\r\n",
+			suffix: "DEF",
+			want:   true,
+		},
+		{
+			name:   "no match",
+			body:   "ABC:1\r\nDEF:2\r\n",
+			suffix: "GHI",
+			want:   false,
+		},
+		{
+			name:   "case insensitive",
+			body:   "abc:1\r\n",
+			suffix: "ABC",
+			want:   true,
+		},
+		{
+			name:   "empty body",
+			body:   "",
+			suffix: "ABC",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := matchesSuffix(strings.NewReader(tt.body), tt.suffix)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-138.

Closes #138

## Changes

GitHub Issue #138: Server wiring and verification (`cmd/server/main.go`)

Parent: GH-6

Wire the new HIBP dependency into the auth service:
- Create HIBP client (`hibp.NewClient(http.DefaultClient)` or similar)
- Pass it to `auth.NewService(...)` updated constructor
- Verify `go build ./...` and `go test ./internal/auth/ -v -cover -race` pass
- Run `go test ./internal/auth/ -bench=BenchmarkArgon2id` to confirm ~250ms target (benchmark may already exist in `internal/password/` tests)