### PR TITLE
GH-137: Password policy + registration implementation (`internal/auth/`)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -81,7 +81,7 @@ func run(log *zap.Logger) error {
 	if err != nil {
 		return fmt.Errorf("token service init failed: %w", err)
 	}
-	authSvc := auth.NewService(redisClient, log, userRepo, refreshTokenRepo, tokenSvc, hasher)
+	authSvc := auth.NewService(redisClient, log, userRepo, refreshTokenRepo, tokenSvc, hasher, nil)
 
 	services := &api.Services{
 		Auth:  authSvc,

--- a/internal/auth/password_policy.go
+++ b/internal/auth/password_policy.go
@@ -1,0 +1,67 @@
+package auth
+
+import (
+	"context"
+	"unicode/utf8"
+)
+
+const (
+	// minPasswordLength is the minimum password length per NIST SP 800-63-4.
+	// Uses rune count to correctly handle Unicode.
+	minPasswordLength = 15
+
+	// maxPasswordLength is the maximum password length to prevent DoS via hashing.
+	maxPasswordLength = 128
+)
+
+// BreachChecker determines whether a password has appeared in known data breaches.
+type BreachChecker interface {
+	IsBreached(ctx context.Context, password string) (bool, error)
+}
+
+// ValidationError represents a single password policy violation.
+type ValidationError struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+// ValidatePasswordPolicy checks a password against NIST SP 800-63-4 policy:
+// - Minimum 15 characters (rune count for Unicode)
+// - Maximum 128 characters
+// - No composition rules (uppercase, symbols, etc.)
+// - Rejects passwords found in breach databases
+func ValidatePasswordPolicy(ctx context.Context, password string, checker BreachChecker) ([]ValidationError, error) {
+	var errs []ValidationError
+
+	runeCount := utf8.RuneCountInString(password)
+
+	if runeCount < minPasswordLength {
+		errs = append(errs, ValidationError{
+			Field:   "password",
+			Message: "must be at least 15 characters",
+		})
+	}
+
+	if runeCount > maxPasswordLength {
+		errs = append(errs, ValidationError{
+			Field:   "password",
+			Message: "must be at most 128 characters",
+		})
+	}
+
+	// Only check breach database if length constraints pass.
+	if len(errs) == 0 && checker != nil {
+		breached, err := checker.IsBreached(ctx, password)
+		if err != nil {
+			return nil, err
+		}
+		if breached {
+			errs = append(errs, ValidationError{
+				Field:   "password",
+				Message: "this password has appeared in a data breach and cannot be used",
+			})
+		}
+	}
+
+	return errs, nil
+}

--- a/internal/auth/password_policy_test.go
+++ b/internal/auth/password_policy_test.go
@@ -1,0 +1,146 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockBreachChecker implements BreachChecker for testing.
+type mockBreachChecker struct {
+	isBreachedFn func(ctx context.Context, password string) (bool, error)
+}
+
+func (m *mockBreachChecker) IsBreached(ctx context.Context, password string) (bool, error) {
+	if m.isBreachedFn != nil {
+		return m.isBreachedFn(ctx, password)
+	}
+	return false, nil
+}
+
+func TestValidatePasswordPolicy(t *testing.T) {
+	safeChecker := &mockBreachChecker{}
+	breachedChecker := &mockBreachChecker{
+		isBreachedFn: func(_ context.Context, _ string) (bool, error) {
+			return true, nil
+		},
+	}
+	errorChecker := &mockBreachChecker{
+		isBreachedFn: func(_ context.Context, _ string) (bool, error) {
+			return false, fmt.Errorf("HIBP API unavailable")
+		},
+	}
+
+	tests := []struct {
+		name       string
+		password   string
+		checker    BreachChecker
+		wantErrs   int
+		wantMsg    string
+		wantGoErr  bool
+	}{
+		{
+			name:     "valid password",
+			password: "a-very-secure-password-here",
+			checker:  safeChecker,
+			wantErrs: 0,
+		},
+		{
+			name:     "exactly 15 characters",
+			password: "123456789012345",
+			checker:  safeChecker,
+			wantErrs: 0,
+		},
+		{
+			name:     "too short - 14 chars",
+			password: "12345678901234",
+			checker:  safeChecker,
+			wantErrs: 1,
+			wantMsg:  "at least 15",
+		},
+		{
+			name:     "empty password",
+			password: "",
+			checker:  safeChecker,
+			wantErrs: 1,
+			wantMsg:  "at least 15",
+		},
+		{
+			name:     "too long - over 128 chars",
+			password: strings.Repeat("a", 129),
+			checker:  safeChecker,
+			wantErrs: 1,
+			wantMsg:  "at most 128",
+		},
+		{
+			name:     "exactly 128 characters",
+			password: strings.Repeat("a", 128),
+			checker:  safeChecker,
+			wantErrs: 0,
+		},
+		{
+			name:     "unicode characters counted as runes",
+			password: "пароль-длинный!!", // 16 runes, but more bytes
+			checker:  safeChecker,
+			wantErrs: 0,
+		},
+		{
+			name:     "unicode too short by rune count",
+			password: "пароль-коротки", // 14 runes
+			checker:  safeChecker,
+			wantErrs: 1,
+			wantMsg:  "at least 15",
+		},
+		{
+			name:     "emoji characters counted correctly",
+			password: "🔐🔐🔐🔐🔐🔐🔐🔐🔐🔐🔐🔐🔐🔐🔐", // 15 runes
+			checker:  safeChecker,
+			wantErrs: 0,
+		},
+		{
+			name:     "breached password rejected",
+			password: "a-very-secure-password-here",
+			checker:  breachedChecker,
+			wantErrs: 1,
+			wantMsg:  "data breach",
+		},
+		{
+			name:      "breach checker error propagates",
+			password:  "a-very-secure-password-here",
+			checker:   errorChecker,
+			wantGoErr: true,
+		},
+		{
+			name:     "nil checker skips breach check",
+			password: "a-very-secure-password-here",
+			checker:  nil,
+			wantErrs: 0,
+		},
+		{
+			name:     "breach check skipped when too short",
+			password: "short",
+			checker:  breachedChecker,
+			wantErrs: 1,
+			wantMsg:  "at least 15",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs, err := ValidatePasswordPolicy(context.Background(), tt.password, tt.checker)
+			if tt.wantGoErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, errs, tt.wantErrs)
+			if tt.wantMsg != "" && len(errs) > 0 {
+				assert.Contains(t, errs[0].Message, tt.wantMsg)
+			}
+		})
+	}
+}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 
@@ -46,6 +47,7 @@ type Service struct {
 	tokens    storage.RefreshTokenRepository
 	issuer    TokenIssuer
 	hasher    password.Hasher
+	breaches  BreachChecker
 }
 
 // NewService creates a new auth Service.
@@ -56,25 +58,58 @@ func NewService(
 	tokens storage.RefreshTokenRepository,
 	issuer TokenIssuer,
 	hasher password.Hasher,
+	breaches BreachChecker,
 ) *Service {
 	return &Service{
-		redis:  redisClient,
-		logger: logger,
-		users:  users,
-		tokens: tokens,
-		issuer: issuer,
-		hasher: hasher,
+		redis:    redisClient,
+		logger:   logger,
+		users:    users,
+		tokens:   tokens,
+		issuer:   issuer,
+		hasher:   hasher,
+		breaches: breaches,
 	}
 }
 
-// Register creates a new user account.
-// Stub: full implementation depends on PostgreSQL user repository (future issue).
-func (s *Service) Register(_ context.Context, email, _, name string) (*api.UserInfo, error) {
-	// TODO(GH-XX): wire PostgreSQL user repository for persistence.
+// Register creates a new user account after validating password policy.
+func (s *Service) Register(ctx context.Context, email, pwd, name string) (*api.UserInfo, error) {
+	// Validate password against NIST SP 800-63-4 policy.
+	policyErrs, err := ValidatePasswordPolicy(ctx, pwd, s.breaches)
+	if err != nil {
+		s.logger.Error("breach check failed during registration", zap.Error(err))
+		return nil, fmt.Errorf("password policy check: %w", err)
+	}
+	if len(policyErrs) > 0 {
+		return nil, fmt.Errorf("%s: %w", policyErrs[0].Message, api.ErrConflict)
+	}
+
+	hash, err := s.hasher.Hash(pwd)
+	if err != nil {
+		s.logger.Error("failed to hash password", zap.Error(err))
+		return nil, fmt.Errorf("hash password: %w", err)
+	}
+
+	user := &domain.User{
+		ID:           uuid.New().String(),
+		Email:        email,
+		PasswordHash: hash,
+		Name:         name,
+		Roles:        []string{"user"},
+	}
+
+	created, err := s.users.Create(ctx, user)
+	if err != nil {
+		if errors.Is(err, storage.ErrDuplicateEmail) {
+			return nil, fmt.Errorf("email already in use: %w", api.ErrConflict)
+		}
+		s.logger.Error("failed to create user", zap.Error(err))
+		return nil, fmt.Errorf("create user: %w", err)
+	}
+
 	return &api.UserInfo{
-		ID:    "stub-user-id",
-		Email: email,
-		Name:  name,
+		ID:    created.ID,
+		Email: created.Email,
+		Name:  created.Name,
 	}, nil
 }
 

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -21,10 +21,14 @@ import (
 type mockUserRepository struct {
 	findByEmailFn   func(ctx context.Context, email string) (*domain.User, error)
 	updateLastLogin func(ctx context.Context, userID string, ts time.Time) error
+	createFn        func(ctx context.Context, user *domain.User) (*domain.User, error)
 }
 
-func (m *mockUserRepository) Create(_ context.Context, _ *domain.User) (*domain.User, error) {
-	return nil, fmt.Errorf("not implemented")
+func (m *mockUserRepository) Create(ctx context.Context, user *domain.User) (*domain.User, error) {
+	if m.createFn != nil {
+		return m.createFn(ctx, user)
+	}
+	return user, nil
 }
 
 func (m *mockUserRepository) FindByID(_ context.Context, _ string) (*domain.User, error) {
@@ -97,10 +101,14 @@ func (m *mockTokenIssuer) Revoke(ctx context.Context, token string) error {
 }
 
 type mockHasher struct {
+	hashFn   func(password string) (string, error)
 	verifyFn func(password, hash string) (bool, error)
 }
 
-func (m *mockHasher) Hash(_ string) (string, error) {
+func (m *mockHasher) Hash(password string) (string, error) {
+	if m.hashFn != nil {
+		return m.hashFn(password)
+	}
 	return "$argon2id$v=19$m=19456,t=2,p=1$dGVzdHNhbHQ$dGVzdGhhc2g", nil
 }
 
@@ -115,10 +123,17 @@ func (m *mockHasher) Verify(password, hash string) (bool, error) {
 
 // newUnitService creates a Service with a nil Redis client for pure unit tests
 // that don't exercise password-reset (Redis-dependent) code paths.
-func newUnitService(t *testing.T, users *mockUserRepository, tokens *mockRefreshTokenRepository, issuer *mockTokenIssuer, hasher *mockHasher) *Service {
+// An optional BreachChecker can be passed; if omitted a safe no-op checker is used.
+func newUnitService(t *testing.T, users *mockUserRepository, tokens *mockRefreshTokenRepository, issuer *mockTokenIssuer, hasher *mockHasher, checkers ...BreachChecker) *Service {
 	t.Helper()
 	logger, _ := zap.NewDevelopment()
-	return NewService(nil, logger, users, tokens, issuer, hasher)
+	var checker BreachChecker
+	if len(checkers) > 0 {
+		checker = checkers[0]
+	} else {
+		checker = &mockBreachChecker{}
+	}
+	return NewService(nil, logger, users, tokens, issuer, hasher, checker)
 }
 
 // newRedisClient creates a Redis client for integration tests (password reset).
@@ -154,7 +169,7 @@ func newIntegrationService(t *testing.T) *Service {
 	t.Helper()
 	client := newRedisClient(t)
 	logger, _ := zap.NewDevelopment()
-	return NewService(client, logger, &mockUserRepository{}, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, &mockHasher{})
+	return NewService(client, logger, &mockUserRepository{}, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, &mockHasher{}, &mockBreachChecker{})
 }
 
 // ── Login Tests ──────────────────────────────────────────────────────────────
@@ -562,13 +577,158 @@ func TestGenerateResetToken_Uniqueness(t *testing.T) {
 	}
 }
 
-func TestRegister_ReturnsStub(t *testing.T) {
-	svc := newUnitService(t, &mockUserRepository{}, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, &mockHasher{})
-	user, err := svc.Register(context.Background(), "test@example.com", "password123456789", "Test")
+func TestRegister(t *testing.T) {
+	tests := []struct {
+		name      string
+		email     string
+		password  string
+		userName  string
+		users     *mockUserRepository
+		hasher    *mockHasher
+		checker   BreachChecker
+		wantErr   bool
+		errTarget error
+	}{
+		{
+			name:     "success",
+			email:    "test@example.com",
+			password: "a-very-secure-password",
+			userName: "Test User",
+			users:    &mockUserRepository{},
+			hasher:   &mockHasher{},
+			checker:  &mockBreachChecker{},
+			wantErr:  false,
+		},
+		{
+			name:     "password too short",
+			email:    "test@example.com",
+			password: "short",
+			userName: "Test User",
+			users:    &mockUserRepository{},
+			hasher:   &mockHasher{},
+			checker:  &mockBreachChecker{},
+			wantErr:  true,
+		},
+		{
+			name:     "breached password rejected",
+			email:    "test@example.com",
+			password: "a-very-secure-password",
+			userName: "Test User",
+			users:    &mockUserRepository{},
+			hasher:   &mockHasher{},
+			checker: &mockBreachChecker{
+				isBreachedFn: func(_ context.Context, _ string) (bool, error) {
+					return true, nil
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:     "duplicate email returns conflict",
+			email:    "existing@example.com",
+			password: "a-very-secure-password",
+			userName: "Test User",
+			users: &mockUserRepository{
+				createFn: func(_ context.Context, _ *domain.User) (*domain.User, error) {
+					return nil, storage.ErrDuplicateEmail
+				},
+			},
+			hasher:    &mockHasher{},
+			checker:   &mockBreachChecker{},
+			wantErr:   true,
+			errTarget: api.ErrConflict,
+		},
+		{
+			name:     "hash failure propagates",
+			email:    "test@example.com",
+			password: "a-very-secure-password",
+			userName: "Test User",
+			users:    &mockUserRepository{},
+			hasher: &mockHasher{
+				hashFn: func(_ string) (string, error) {
+					return "", fmt.Errorf("hash error")
+				},
+			},
+			checker: &mockBreachChecker{},
+			wantErr: true,
+		},
+		{
+			name:     "repository error propagates",
+			email:    "test@example.com",
+			password: "a-very-secure-password",
+			userName: "Test User",
+			users: &mockUserRepository{
+				createFn: func(_ context.Context, _ *domain.User) (*domain.User, error) {
+					return nil, fmt.Errorf("db connection lost")
+				},
+			},
+			hasher:  &mockHasher{},
+			checker: &mockBreachChecker{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newUnitService(t, tt.users, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, tt.hasher, tt.checker)
+			result, err := svc.Register(context.Background(), tt.email, tt.password, tt.userName)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errTarget != nil {
+					assert.ErrorIs(t, err, tt.errTarget)
+				}
+				assert.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				assert.Equal(t, tt.email, result.Email)
+				assert.Equal(t, tt.userName, result.Name)
+				assert.NotEmpty(t, result.ID)
+			}
+		})
+	}
+}
+
+func TestRegister_AssignsDefaultRole(t *testing.T) {
+	var createdUser *domain.User
+	users := &mockUserRepository{
+		createFn: func(_ context.Context, user *domain.User) (*domain.User, error) {
+			createdUser = user
+			return user, nil
+		},
+	}
+
+	svc := newUnitService(t, users, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, &mockHasher{})
+	_, err := svc.Register(context.Background(), "test@example.com", "a-very-secure-password", "Test")
 	require.NoError(t, err)
-	assert.Equal(t, "test@example.com", user.Email)
-	assert.Equal(t, "Test", user.Name)
-	assert.NotEmpty(t, user.ID)
+	require.NotNil(t, createdUser)
+	assert.Equal(t, []string{"user"}, createdUser.Roles)
+}
+
+func TestRegister_HashesPassword(t *testing.T) {
+	var createdUser *domain.User
+	users := &mockUserRepository{
+		createFn: func(_ context.Context, user *domain.User) (*domain.User, error) {
+			createdUser = user
+			return user, nil
+		},
+	}
+
+	svc := newUnitService(t, users, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, &mockHasher{})
+	_, err := svc.Register(context.Background(), "test@example.com", "a-very-secure-password", "Test")
+	require.NoError(t, err)
+	require.NotNil(t, createdUser)
+	assert.NotEqual(t, "a-very-secure-password", createdUser.PasswordHash, "password should be hashed")
+	assert.Contains(t, createdUser.PasswordHash, "$argon2id$", "hash should be argon2id format")
+}
+
+func TestRegister_DoesNotReturnPasswordHash(t *testing.T) {
+	svc := newUnitService(t, &mockUserRepository{}, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, &mockHasher{})
+	result, err := svc.Register(context.Background(), "test@example.com", "a-very-secure-password", "Test")
+	require.NoError(t, err)
+	// api.UserInfo has no PasswordHash field — this test verifies the return type is correct.
+	assert.Equal(t, "test@example.com", result.Email)
+	assert.Equal(t, "Test", result.Name)
 }
 
 func TestGetMe_ReturnsStub(t *testing.T) {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-137.

Closes #137

## Changes

GitHub Issue #137: Password policy + registration implementation (`internal/auth/`)

Parent: GH-6

All auth-package work — policy validation and the real `Register` method:
- New `password_policy.go`: `ValidatePasswordPolicy(ctx, password) []ValidationError` — min 15 chars (rune count for Unicode), max at least 64, no composition rules, calls `BreachChecker` to reject breached passwords
- Update `service.go`: replace the stub `Register` (line 72) with real logic — validate password policy, hash via `s.hasher.Hash()`, generate UUID, create `domain.User`, call `s.users.Create()`, map `storage.ErrDuplicateEmail` → `api.ErrConflict`, return `api.UserInfo` without password hash
- Add `BreachChecker` as a new `Service` dependency (update `NewService` constructor)
- New `password_policy_test.go`: table-driven tests for min length, max length, Unicode acceptance, breached password rejection (mock BreachChecker)
- Update `service_test.go`: replace `TestRegister_ReturnsStub` with real tests — success, duplicate email, weak password, breached password, mock the new BreachChecker dependency