### PR TITLE
GH-144: Domain DTOs and repository layer (`internal/domain/` + `internal/storage/`)

### DIFF
--- a/internal/admin/client_service.go
+++ b/internal/admin/client_service.go
@@ -43,10 +43,10 @@ func NewClientService(repo storage.ClientRepository, hasher password.Hasher, log
 }
 
 // ListClients returns a paginated list of OAuth2 clients.
-func (s *ClientService) ListClients(ctx context.Context, page, perPage int, includeDeleted bool) (*api.AdminClientList, error) {
+func (s *ClientService) ListClients(ctx context.Context, page, perPage int, clientType string, includeRevoked bool) (*api.AdminClientList, error) {
 	offset := (page - 1) * perPage
 
-	clients, total, err := s.repo.List(ctx, perPage, offset, includeDeleted)
+	clients, total, err := s.repo.List(ctx, perPage, offset, clientType, includeRevoked)
 	if err != nil {
 		s.logger.Error("list clients failed", zap.Error(err))
 		return nil, fmt.Errorf("list clients: %w", api.ErrInternalError)

--- a/internal/admin/client_service_test.go
+++ b/internal/admin/client_service_test.go
@@ -19,7 +19,7 @@ import (
 // --- Mock ClientRepository ---
 
 type mockClientRepo struct {
-	listFn             func(ctx context.Context, limit, offset int, includeRevoked bool) ([]*domain.Client, int, error)
+	listFn             func(ctx context.Context, limit, offset int, clientType string, includeRevoked bool) ([]*domain.Client, int, error)
 	findByIDFn         func(ctx context.Context, id uuid.UUID) (*domain.Client, error)
 	findByNameFn       func(ctx context.Context, name string) (*domain.Client, error)
 	createFn           func(ctx context.Context, client *domain.Client) (*domain.Client, error)
@@ -29,9 +29,9 @@ type mockClientRepo struct {
 	softDeleteFn       func(ctx context.Context, id uuid.UUID) error
 }
 
-func (m *mockClientRepo) List(ctx context.Context, limit, offset int, includeRevoked bool) ([]*domain.Client, int, error) {
+func (m *mockClientRepo) List(ctx context.Context, limit, offset int, clientType string, includeRevoked bool) ([]*domain.Client, int, error) {
 	if m.listFn != nil {
-		return m.listFn(ctx, limit, offset, includeRevoked)
+		return m.listFn(ctx, limit, offset, clientType, includeRevoked)
 	}
 	return []*domain.Client{testClient()}, 1, nil
 }
@@ -116,7 +116,7 @@ func newTestClientService(repo *mockClientRepo) *ClientService {
 func TestClientService_ListClients(t *testing.T) {
 	svc := newTestClientService(&mockClientRepo{})
 
-	result, err := svc.ListClients(context.Background(), 1, 20, false)
+	result, err := svc.ListClients(context.Background(), 1, 20, "", false)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Total)
 	assert.Len(t, result.Clients, 1)
@@ -124,13 +124,13 @@ func TestClientService_ListClients(t *testing.T) {
 
 func TestClientService_ListClients_Error(t *testing.T) {
 	repo := &mockClientRepo{
-		listFn: func(_ context.Context, _, _ int, _ bool) ([]*domain.Client, int, error) {
+		listFn: func(_ context.Context, _, _ int, _ string, _ bool) ([]*domain.Client, int, error) {
 			return nil, 0, fmt.Errorf("db error")
 		},
 	}
 	svc := newTestClientService(repo)
 
-	_, err := svc.ListClients(context.Background(), 1, 20, false)
+	_, err := svc.ListClients(context.Background(), 1, 20, "", false)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, api.ErrInternalError)
 }

--- a/internal/admin/user_service.go
+++ b/internal/admin/user_service.go
@@ -33,11 +33,11 @@ func NewUserService(repo storage.AdminUserRepository, hasher password.Hasher, lo
 	}
 }
 
-// ListUsers returns a paginated list of users.
-func (s *UserService) ListUsers(ctx context.Context, page, perPage int, includeDeleted bool) (*api.AdminUserList, error) {
+// ListUsers returns a paginated list of users filtered by status.
+func (s *UserService) ListUsers(ctx context.Context, page, perPage int, status string) (*api.AdminUserList, error) {
 	offset := (page - 1) * perPage
 
-	users, total, err := s.repo.List(ctx, perPage, offset, includeDeleted)
+	users, total, err := s.repo.List(ctx, perPage, offset, status)
 	if err != nil {
 		s.logger.Error("list users failed", zap.Error(err))
 		return nil, fmt.Errorf("list users: %w", api.ErrInternalError)

--- a/internal/admin/user_service_test.go
+++ b/internal/admin/user_service_test.go
@@ -18,7 +18,7 @@ import (
 // --- Mock AdminUserRepository ---
 
 type mockAdminUserRepo struct {
-	listFn       func(ctx context.Context, limit, offset int, includeDeleted bool) ([]*domain.User, int, error)
+	listFn       func(ctx context.Context, limit, offset int, status string) ([]*domain.User, int, error)
 	findByIDFn   func(ctx context.Context, id string) (*domain.User, error)
 	createFn     func(ctx context.Context, user *domain.User) (*domain.User, error)
 	updateFn     func(ctx context.Context, user *domain.User) (*domain.User, error)
@@ -27,9 +27,9 @@ type mockAdminUserRepo struct {
 	unlockFn     func(ctx context.Context, id string) (*domain.User, error)
 }
 
-func (m *mockAdminUserRepo) List(ctx context.Context, limit, offset int, includeDeleted bool) ([]*domain.User, int, error) {
+func (m *mockAdminUserRepo) List(ctx context.Context, limit, offset int, status string) ([]*domain.User, int, error) {
 	if m.listFn != nil {
-		return m.listFn(ctx, limit, offset, includeDeleted)
+		return m.listFn(ctx, limit, offset, status)
 	}
 	return []*domain.User{testUser()}, 1, nil
 }
@@ -130,16 +130,16 @@ func newTestUserService(repo *mockAdminUserRepo) *UserService {
 
 func TestUserService_ListUsers(t *testing.T) {
 	repo := &mockAdminUserRepo{
-		listFn: func(_ context.Context, limit, offset int, includeDeleted bool) ([]*domain.User, int, error) {
+		listFn: func(_ context.Context, limit, offset int, status string) ([]*domain.User, int, error) {
 			assert.Equal(t, 20, limit)
 			assert.Equal(t, 0, offset)
-			assert.False(t, includeDeleted)
+			assert.Equal(t, "", status)
 			return []*domain.User{testUser()}, 1, nil
 		},
 	}
 	svc := newTestUserService(repo)
 
-	result, err := svc.ListUsers(context.Background(), 1, 20, false)
+	result, err := svc.ListUsers(context.Background(), 1, 20, "")
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Total)
 	assert.Len(t, result.Users, 1)
@@ -149,7 +149,7 @@ func TestUserService_ListUsers(t *testing.T) {
 
 func TestUserService_ListUsers_Pagination(t *testing.T) {
 	repo := &mockAdminUserRepo{
-		listFn: func(_ context.Context, limit, offset int, _ bool) ([]*domain.User, int, error) {
+		listFn: func(_ context.Context, limit, offset int, _ string) ([]*domain.User, int, error) {
 			assert.Equal(t, 10, limit)
 			assert.Equal(t, 20, offset) // page 3 * perPage 10 - 10 = 20
 			return []*domain.User{}, 50, nil
@@ -157,7 +157,7 @@ func TestUserService_ListUsers_Pagination(t *testing.T) {
 	}
 	svc := newTestUserService(repo)
 
-	result, err := svc.ListUsers(context.Background(), 3, 10, false)
+	result, err := svc.ListUsers(context.Background(), 3, 10, "")
 	require.NoError(t, err)
 	assert.Equal(t, 50, result.Total)
 	assert.Equal(t, 3, result.Page)
@@ -165,13 +165,13 @@ func TestUserService_ListUsers_Pagination(t *testing.T) {
 
 func TestUserService_ListUsers_Error(t *testing.T) {
 	repo := &mockAdminUserRepo{
-		listFn: func(_ context.Context, _, _ int, _ bool) ([]*domain.User, int, error) {
+		listFn: func(_ context.Context, _, _ int, _ string) ([]*domain.User, int, error) {
 			return nil, 0, fmt.Errorf("db error")
 		},
 	}
 	svc := newTestUserService(repo)
 
-	_, err := svc.ListUsers(context.Background(), 1, 20, false)
+	_, err := svc.ListUsers(context.Background(), 1, 20, "")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, api.ErrInternalError)
 }

--- a/internal/api/admin_client_handlers.go
+++ b/internal/api/admin_client_handlers.go
@@ -20,12 +20,13 @@ func NewAdminClientHandlers(clients AdminClientService) *AdminClientHandlers {
 }
 
 // List handles GET /admin/clients.
-// Query params: page (default 1), per_page (default 20), include_deleted (default false).
+// Query params: page (default 1), per_page (default 20), client_type (service|agent), include_revoked (default false).
 func (h *AdminClientHandlers) List(c *gin.Context) {
 	page, perPage := parsePagination(c)
-	includeDeleted, _ := strconv.ParseBool(c.DefaultQuery("include_deleted", "false"))
+	clientType := c.DefaultQuery("client_type", "")
+	includeRevoked, _ := strconv.ParseBool(c.DefaultQuery("include_revoked", "false"))
 
-	result, err := h.clients.ListClients(c.Request.Context(), page, perPage, includeDeleted)
+	result, err := h.clients.ListClients(c.Request.Context(), page, perPage, clientType, includeRevoked)
 	if err != nil {
 		handleServiceError(c, err)
 		return

--- a/internal/api/admin_client_handlers_test.go
+++ b/internal/api/admin_client_handlers_test.go
@@ -19,7 +19,7 @@ import (
 // --- Mock AdminClientService ---
 
 type mockAdminClientService struct {
-	listClientsFn  func(ctx context.Context, page, perPage int, includeDeleted bool) (*api.AdminClientList, error)
+	listClientsFn  func(ctx context.Context, page, perPage int, clientType string, includeRevoked bool) (*api.AdminClientList, error)
 	getClientFn    func(ctx context.Context, clientID string) (*api.AdminClient, error)
 	createClientFn func(ctx context.Context, req *api.CreateClientRequest) (*api.AdminClientWithSecret, error)
 	updateClientFn func(ctx context.Context, clientID string, req *api.UpdateClientRequest) (*api.AdminClient, error)
@@ -27,9 +27,9 @@ type mockAdminClientService struct {
 	rotateSecretFn func(ctx context.Context, clientID string) (*api.AdminClientWithSecret, error)
 }
 
-func (m *mockAdminClientService) ListClients(ctx context.Context, page, perPage int, includeDeleted bool) (*api.AdminClientList, error) {
+func (m *mockAdminClientService) ListClients(ctx context.Context, page, perPage int, clientType string, includeRevoked bool) (*api.AdminClientList, error) {
 	if m.listClientsFn != nil {
-		return m.listClientsFn(ctx, page, perPage, includeDeleted)
+		return m.listClientsFn(ctx, page, perPage, clientType, includeRevoked)
 	}
 	return &api.AdminClientList{
 		Clients: []api.AdminClient{{ID: "c1", Name: "test-client", ClientType: "service", Scopes: []string{"read:users"}, CreatedAt: time.Now(), UpdatedAt: time.Now()}},
@@ -123,10 +123,11 @@ func TestAdminListClients_Success(t *testing.T) {
 
 func TestAdminListClients_Pagination(t *testing.T) {
 	svc := &mockAdminClientService{
-		listClientsFn: func(_ context.Context, page, perPage int, includeDeleted bool) (*api.AdminClientList, error) {
+		listClientsFn: func(_ context.Context, page, perPage int, clientType string, includeRevoked bool) (*api.AdminClientList, error) {
 			assert.Equal(t, 3, page)
 			assert.Equal(t, 5, perPage)
-			assert.False(t, includeDeleted)
+			assert.Equal(t, "", clientType)
+			assert.False(t, includeRevoked)
 			return &api.AdminClientList{Clients: []api.AdminClient{}, Total: 50, Page: page, PerPage: perPage}, nil
 		},
 	}
@@ -345,7 +346,7 @@ func TestAdminDeleteClient_AlreadyDeleted(t *testing.T) {
 
 func TestAdminListClients_PerPageCapped(t *testing.T) {
 	svc := &mockAdminClientService{
-		listClientsFn: func(_ context.Context, page, perPage int, _ bool) (*api.AdminClientList, error) {
+		listClientsFn: func(_ context.Context, page, perPage int, _ string, _ bool) (*api.AdminClientList, error) {
 			assert.Equal(t, 1, page)
 			assert.Equal(t, 100, perPage) // Capped at 100
 			return &api.AdminClientList{Clients: []api.AdminClient{}, Total: 0, Page: page, PerPage: perPage}, nil

--- a/internal/api/admin_services.go
+++ b/internal/api/admin_services.go
@@ -116,7 +116,7 @@ type IntrospectRequest struct {
 
 // AdminUserService defines admin operations for user management.
 type AdminUserService interface {
-	ListUsers(ctx context.Context, page, perPage int, includeDeleted bool) (*AdminUserList, error)
+	ListUsers(ctx context.Context, page, perPage int, status string) (*AdminUserList, error)
 	GetUser(ctx context.Context, userID string) (*AdminUser, error)
 	CreateUser(ctx context.Context, req *CreateUserRequest) (*AdminUser, error)
 	UpdateUser(ctx context.Context, userID string, req *UpdateUserRequest) (*AdminUser, error)
@@ -127,7 +127,7 @@ type AdminUserService interface {
 
 // AdminClientService defines admin operations for OAuth2 client management.
 type AdminClientService interface {
-	ListClients(ctx context.Context, page, perPage int, includeDeleted bool) (*AdminClientList, error)
+	ListClients(ctx context.Context, page, perPage int, clientType string, includeRevoked bool) (*AdminClientList, error)
 	GetClient(ctx context.Context, clientID string) (*AdminClient, error)
 	CreateClient(ctx context.Context, req *CreateClientRequest) (*AdminClientWithSecret, error)
 	UpdateClient(ctx context.Context, clientID string, req *UpdateClientRequest) (*AdminClient, error)

--- a/internal/api/admin_user_handlers.go
+++ b/internal/api/admin_user_handlers.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 
@@ -20,12 +19,12 @@ func NewAdminUserHandlers(users AdminUserService) *AdminUserHandlers {
 }
 
 // List handles GET /admin/users.
-// Query params: page (default 1), per_page (default 20), include_deleted (default false).
+// Query params: page (default 1), per_page (default 20), status (active|locked|deleted, default empty = all non-deleted).
 func (h *AdminUserHandlers) List(c *gin.Context) {
 	page, perPage := parsePagination(c)
-	includeDeleted, _ := strconv.ParseBool(c.DefaultQuery("include_deleted", "false"))
+	status := c.DefaultQuery("status", "")
 
-	result, err := h.users.ListUsers(c.Request.Context(), page, perPage, includeDeleted)
+	result, err := h.users.ListUsers(c.Request.Context(), page, perPage, status)
 	if err != nil {
 		handleServiceError(c, err)
 		return

--- a/internal/api/admin_user_handlers_test.go
+++ b/internal/api/admin_user_handlers_test.go
@@ -19,7 +19,7 @@ import (
 // --- Mock AdminUserService ---
 
 type mockAdminUserService struct {
-	listUsersFn  func(ctx context.Context, page, perPage int, includeDeleted bool) (*api.AdminUserList, error)
+	listUsersFn  func(ctx context.Context, page, perPage int, status string) (*api.AdminUserList, error)
 	getUserFn    func(ctx context.Context, userID string) (*api.AdminUser, error)
 	createUserFn func(ctx context.Context, req *api.CreateUserRequest) (*api.AdminUser, error)
 	updateUserFn func(ctx context.Context, userID string, req *api.UpdateUserRequest) (*api.AdminUser, error)
@@ -28,9 +28,9 @@ type mockAdminUserService struct {
 	unlockUserFn func(ctx context.Context, userID string) (*api.AdminUser, error)
 }
 
-func (m *mockAdminUserService) ListUsers(ctx context.Context, page, perPage int, includeDeleted bool) (*api.AdminUserList, error) {
+func (m *mockAdminUserService) ListUsers(ctx context.Context, page, perPage int, status string) (*api.AdminUserList, error) {
 	if m.listUsersFn != nil {
-		return m.listUsersFn(ctx, page, perPage, includeDeleted)
+		return m.listUsersFn(ctx, page, perPage, status)
 	}
 	return &api.AdminUserList{
 		Users:   []api.AdminUser{{ID: "u1", Email: "a@b.com", Name: "Alice", Roles: []string{"user"}, CreatedAt: time.Now(), UpdatedAt: time.Now()}},
@@ -113,15 +113,15 @@ func TestAdminListUsers_Success(t *testing.T) {
 
 func TestAdminListUsers_Pagination(t *testing.T) {
 	svc := &mockAdminUserService{
-		listUsersFn: func(_ context.Context, page, perPage int, includeDeleted bool) (*api.AdminUserList, error) {
+		listUsersFn: func(_ context.Context, page, perPage int, status string) (*api.AdminUserList, error) {
 			assert.Equal(t, 2, page)
 			assert.Equal(t, 10, perPage)
-			assert.True(t, includeDeleted)
+			assert.Equal(t, "deleted", status)
 			return &api.AdminUserList{Users: []api.AdminUser{}, Total: 25, Page: page, PerPage: perPage}, nil
 		},
 	}
 	r := newAdminUserRouter(svc)
-	w := doRequest(r, http.MethodGet, "/admin/users?page=2&per_page=10&include_deleted=true", nil)
+	w := doRequest(r, http.MethodGet, "/admin/users?page=2&per_page=10&status=deleted", nil)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
@@ -134,7 +134,7 @@ func TestAdminListUsers_Pagination(t *testing.T) {
 
 func TestAdminListUsers_ServiceError(t *testing.T) {
 	svc := &mockAdminUserService{
-		listUsersFn: func(_ context.Context, _, _ int, _ bool) (*api.AdminUserList, error) {
+		listUsersFn: func(_ context.Context, _, _ int, _ string) (*api.AdminUserList, error) {
 			return nil, fmt.Errorf("db down: %w", api.ErrInternalError)
 		},
 	}
@@ -368,7 +368,7 @@ func TestAdminLockUser_InvalidJSON(t *testing.T) {
 
 func TestAdminListUsers_NegativePage(t *testing.T) {
 	svc := &mockAdminUserService{
-		listUsersFn: func(_ context.Context, page, perPage int, _ bool) (*api.AdminUserList, error) {
+		listUsersFn: func(_ context.Context, page, perPage int, _ string) (*api.AdminUserList, error) {
 			assert.Equal(t, 1, page) // Clamped to 1
 			return &api.AdminUserList{Users: []api.AdminUser{}, Total: 0, Page: page, PerPage: perPage}, nil
 		},

--- a/internal/storage/admin_user_repository.go
+++ b/internal/storage/admin_user_repository.go
@@ -15,7 +15,10 @@ import (
 
 // AdminUserRepository defines persistence operations for admin user management.
 type AdminUserRepository interface {
-	List(ctx context.Context, limit, offset int, includeDeleted bool) ([]*domain.User, int, error)
+	// List returns a paginated list of users, filtered by status.
+	// Valid status values: "" (all non-deleted), "active" (non-locked, non-deleted),
+	// "locked" (locked, non-deleted), "deleted" (soft-deleted only).
+	List(ctx context.Context, limit, offset int, status string) ([]*domain.User, int, error)
 	FindByID(ctx context.Context, id string) (*domain.User, error)
 	Create(ctx context.Context, user *domain.User) (*domain.User, error)
 	Update(ctx context.Context, user *domain.User) (*domain.User, error)
@@ -52,10 +55,18 @@ func scanUser(row pgx.Row) (*domain.User, error) {
 	return u, nil
 }
 
-// List returns a paginated list of users. When includeDeleted is false, soft-deleted users are excluded.
-func (r *PostgresAdminUserRepository) List(ctx context.Context, limit, offset int, includeDeleted bool) ([]*domain.User, int, error) {
-	whereClause := ""
-	if !includeDeleted {
+// List returns a paginated list of users filtered by status.
+// Status values: "" (all non-deleted), "active", "locked", "deleted".
+func (r *PostgresAdminUserRepository) List(ctx context.Context, limit, offset int, status string) ([]*domain.User, int, error) {
+	var whereClause string
+	switch status {
+	case "active":
+		whereClause = "WHERE deleted_at IS NULL AND locked = false"
+	case "locked":
+		whereClause = "WHERE deleted_at IS NULL AND locked = true"
+	case "deleted":
+		whereClause = "WHERE deleted_at IS NOT NULL"
+	default:
 		whereClause = "WHERE deleted_at IS NULL"
 	}
 

--- a/internal/storage/client_repository.go
+++ b/internal/storage/client_repository.go
@@ -16,7 +16,9 @@ import (
 
 // ClientRepository defines persistence operations for OAuth2 client management.
 type ClientRepository interface {
-	List(ctx context.Context, limit, offset int, includeRevoked bool) ([]*domain.Client, int, error)
+	// List returns a paginated list of clients. clientType filters by type (empty = all).
+	// When includeRevoked is false, revoked clients are excluded.
+	List(ctx context.Context, limit, offset int, clientType string, includeRevoked bool) ([]*domain.Client, int, error)
 	FindByID(ctx context.Context, id uuid.UUID) (*domain.Client, error)
 	FindByName(ctx context.Context, name string) (*domain.Client, error)
 	Create(ctx context.Context, client *domain.Client) (*domain.Client, error)
@@ -55,22 +57,40 @@ func scanClient(row pgx.Row) (*domain.Client, error) {
 	return c, nil
 }
 
-// List returns a paginated list of clients. When includeRevoked is false,
-// revoked clients are excluded.
-func (r *PostgresClientRepository) List(ctx context.Context, limit, offset int, includeRevoked bool) ([]*domain.Client, int, error) {
-	whereClause := ""
+// List returns a paginated list of clients. clientType filters by type (empty = all).
+// When includeRevoked is false, revoked clients are excluded.
+func (r *PostgresClientRepository) List(ctx context.Context, limit, offset int, clientType string, includeRevoked bool) ([]*domain.Client, int, error) {
+	conditions := []string{}
+	args := []interface{}{}
+
 	if !includeRevoked {
-		whereClause = "WHERE status != 'revoked'"
+		conditions = append(conditions, "status != 'revoked'")
+	}
+	if clientType != "" {
+		args = append(args, clientType)
+		conditions = append(conditions, fmt.Sprintf("client_type = $%d", len(args)))
+	}
+
+	whereClause := ""
+	if len(conditions) > 0 {
+		whereClause = "WHERE " + conditions[0]
+		for _, c := range conditions[1:] {
+			whereClause += " AND " + c
+		}
 	}
 
 	countQuery := fmt.Sprintf(`SELECT COUNT(*) FROM clients %s`, whereClause)
 	var total int
-	if err := r.pool.QueryRow(ctx, countQuery).Scan(&total); err != nil {
+	if err := r.pool.QueryRow(ctx, countQuery, args...).Scan(&total); err != nil {
 		return nil, 0, fmt.Errorf("count clients: %w", err)
 	}
 
-	query := fmt.Sprintf(`SELECT %s FROM clients %s ORDER BY created_at DESC LIMIT $1 OFFSET $2`, clientColumns, whereClause)
-	rows, err := r.pool.Query(ctx, query, limit, offset)
+	// Pagination params follow any filter params.
+	paginationOffset := len(args)
+	args = append(args, limit, offset)
+	query := fmt.Sprintf(`SELECT %s FROM clients %s ORDER BY created_at DESC LIMIT $%d OFFSET $%d`,
+		clientColumns, whereClause, paginationOffset+1, paginationOffset+2)
+	rows, err := r.pool.Query(ctx, query, args...)
 	if err != nil {
 		return nil, 0, fmt.Errorf("list clients: %w", err)
 	}

--- a/internal/storage/repository_integration_test.go
+++ b/internal/storage/repository_integration_test.go
@@ -364,7 +364,7 @@ func TestPostgresAdminUserRepository_List(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	users, total, err := repo.List(ctx, 10, 0, false)
+	users, total, err := repo.List(ctx, 10, 0, "")
 	require.NoError(t, err)
 	assert.Equal(t, 3, total)
 	assert.Len(t, users, 3)
@@ -381,41 +381,68 @@ func TestPostgresAdminUserRepository_List_Pagination(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	users, total, err := repo.List(ctx, 2, 0, false)
+	users, total, err := repo.List(ctx, 2, 0, "")
 	require.NoError(t, err)
 	assert.Equal(t, 5, total)
 	assert.Len(t, users, 2)
 
-	users, total, err = repo.List(ctx, 2, 4, false)
+	users, total, err = repo.List(ctx, 2, 4, "")
 	require.NoError(t, err)
 	assert.Equal(t, 5, total)
 	assert.Len(t, users, 1)
 }
 
-func TestPostgresAdminUserRepository_List_IncludeDeleted(t *testing.T) {
+func TestPostgresAdminUserRepository_List_StatusFilter(t *testing.T) {
 	pool := testPool(t)
 	repo := storage.NewPostgresAdminUserRepository(pool)
 	userRepo := storage.NewPostgresUserRepository(pool)
 	ctx := context.Background()
 
-	u := newTestUser()
-	_, err := userRepo.Create(ctx, u)
+	// Create an active user.
+	active := newTestUser()
+	_, err := userRepo.Create(ctx, active)
 	require.NoError(t, err)
 
-	err = repo.SoftDelete(ctx, u.ID)
+	// Create a locked user.
+	locked := newTestUser()
+	_, err = userRepo.Create(ctx, locked)
+	require.NoError(t, err)
+	_, err = repo.Lock(ctx, locked.ID, "test lock")
 	require.NoError(t, err)
 
-	// Without includeDeleted, should be empty.
-	users, total, err := repo.List(ctx, 10, 0, false)
+	// Create a deleted user.
+	deleted := newTestUser()
+	_, err = userRepo.Create(ctx, deleted)
 	require.NoError(t, err)
-	assert.Equal(t, 0, total)
-	assert.Empty(t, users)
+	err = repo.SoftDelete(ctx, deleted.ID)
+	require.NoError(t, err)
 
-	// With includeDeleted, should find the deleted user.
-	users, total, err = repo.List(ctx, 10, 0, true)
+	// Default (empty) returns all non-deleted (active + locked).
+	users, total, err := repo.List(ctx, 10, 0, "")
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	assert.Len(t, users, 2)
+
+	// "active" returns only non-locked, non-deleted.
+	users, total, err = repo.List(ctx, 10, 0, "active")
 	require.NoError(t, err)
 	assert.Equal(t, 1, total)
 	assert.Len(t, users, 1)
+	assert.Equal(t, active.ID, users[0].ID)
+
+	// "locked" returns only locked users.
+	users, total, err = repo.List(ctx, 10, 0, "locked")
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	assert.Len(t, users, 1)
+	assert.Equal(t, locked.ID, users[0].ID)
+
+	// "deleted" returns only soft-deleted users.
+	users, total, err = repo.List(ctx, 10, 0, "deleted")
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	assert.Len(t, users, 1)
+	assert.Equal(t, deleted.ID, users[0].ID)
 }
 
 func TestPostgresAdminUserRepository_FindByID(t *testing.T) {
@@ -726,7 +753,7 @@ func TestPostgresClientRepository_List(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	clients, total, err := repo.List(ctx, 10, 0, false)
+	clients, total, err := repo.List(ctx, 10, 0, "", false)
 	require.NoError(t, err)
 	assert.Equal(t, 3, total)
 	assert.Len(t, clients, 3)
@@ -742,7 +769,7 @@ func TestPostgresClientRepository_List_Pagination(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	clients, total, err := repo.List(ctx, 2, 0, false)
+	clients, total, err := repo.List(ctx, 2, 0, "", false)
 	require.NoError(t, err)
 	assert.Equal(t, 5, total)
 	assert.Len(t, clients, 2)
@@ -761,16 +788,54 @@ func TestPostgresClientRepository_List_IncludeRevoked(t *testing.T) {
 	require.NoError(t, err)
 
 	// Without includeRevoked.
-	clients, total, err := repo.List(ctx, 10, 0, false)
+	clients, total, err := repo.List(ctx, 10, 0, "", false)
 	require.NoError(t, err)
 	assert.Equal(t, 0, total)
 	assert.Empty(t, clients)
 
 	// With includeRevoked.
-	clients, total, err = repo.List(ctx, 10, 0, true)
+	clients, total, err = repo.List(ctx, 10, 0, "", true)
 	require.NoError(t, err)
 	assert.Equal(t, 1, total)
 	assert.Len(t, clients, 1)
+}
+
+func TestPostgresClientRepository_List_ClientTypeFilter(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresClientRepository(pool)
+	ctx := context.Background()
+
+	// Create a service client.
+	svc := newTestClient()
+	svc.ClientType = domain.ClientTypeService
+	_, err := repo.Create(ctx, svc)
+	require.NoError(t, err)
+
+	// Create an agent client.
+	agent := newTestClient()
+	agent.ClientType = domain.ClientTypeAgent
+	_, err = repo.Create(ctx, agent)
+	require.NoError(t, err)
+
+	// No filter returns all.
+	clients, total, err := repo.List(ctx, 10, 0, "", false)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	assert.Len(t, clients, 2)
+
+	// Filter by service.
+	clients, total, err = repo.List(ctx, 10, 0, "service", false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	assert.Len(t, clients, 1)
+	assert.Equal(t, domain.ClientTypeService, clients[0].ClientType)
+
+	// Filter by agent.
+	clients, total, err = repo.List(ctx, 10, 0, "agent", false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	assert.Len(t, clients, 1)
+	assert.Equal(t, domain.ClientTypeAgent, clients[0].ClientType)
 }
 
 func TestPostgresClientRepository_Update(t *testing.T) {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-144.

Closes #144

## Changes

Admin request/response DTOs with validation in `internal/domain/admin.go` (CreateUserRequest, UpdateUserRequest, CreateClientRequest, UpdateClientRequest, IntrospectTokenRequest, response types, pagination). Admin user repository interface and PostgreSQL implementation in `internal/storage/admin_user_repository.go` (List, FindByID, Create, Update, SoftDelete, Lock, Unlock). Extend client repository in `internal/storage/client_repository.go` with List, RotateSecret, SoftDelete if not already present. Include domain validation tests and repository integration tests.