### PR TITLE
GH-153: Repository mock implementations (`internal/storage/mocks/`)

### DIFF
--- a/internal/storage/mocks/admin_user_repository.go
+++ b/internal/storage/mocks/admin_user_repository.go
@@ -1,0 +1,53 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// MockAdminUserRepository is a configurable mock for storage.AdminUserRepository.
+type MockAdminUserRepository struct {
+	ListFn       func(ctx context.Context, limit, offset int, includeDeleted bool) ([]*domain.User, int, error)
+	FindByIDFn   func(ctx context.Context, id string) (*domain.User, error)
+	CreateFn     func(ctx context.Context, user *domain.User) (*domain.User, error)
+	UpdateFn     func(ctx context.Context, user *domain.User) (*domain.User, error)
+	SoftDeleteFn func(ctx context.Context, id string) error
+	LockFn       func(ctx context.Context, id, reason string) (*domain.User, error)
+	UnlockFn     func(ctx context.Context, id string) (*domain.User, error)
+}
+
+// List delegates to ListFn.
+func (m *MockAdminUserRepository) List(ctx context.Context, limit, offset int, includeDeleted bool) ([]*domain.User, int, error) {
+	return m.ListFn(ctx, limit, offset, includeDeleted)
+}
+
+// FindByID delegates to FindByIDFn.
+func (m *MockAdminUserRepository) FindByID(ctx context.Context, id string) (*domain.User, error) {
+	return m.FindByIDFn(ctx, id)
+}
+
+// Create delegates to CreateFn.
+func (m *MockAdminUserRepository) Create(ctx context.Context, user *domain.User) (*domain.User, error) {
+	return m.CreateFn(ctx, user)
+}
+
+// Update delegates to UpdateFn.
+func (m *MockAdminUserRepository) Update(ctx context.Context, user *domain.User) (*domain.User, error) {
+	return m.UpdateFn(ctx, user)
+}
+
+// SoftDelete delegates to SoftDeleteFn.
+func (m *MockAdminUserRepository) SoftDelete(ctx context.Context, id string) error {
+	return m.SoftDeleteFn(ctx, id)
+}
+
+// Lock delegates to LockFn.
+func (m *MockAdminUserRepository) Lock(ctx context.Context, id, reason string) (*domain.User, error) {
+	return m.LockFn(ctx, id, reason)
+}
+
+// Unlock delegates to UnlockFn.
+func (m *MockAdminUserRepository) Unlock(ctx context.Context, id string) (*domain.User, error) {
+	return m.UnlockFn(ctx, id)
+}

--- a/internal/storage/mocks/client_repository.go
+++ b/internal/storage/mocks/client_repository.go
@@ -1,0 +1,62 @@
+package mocks
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// MockClientRepository is a configurable mock for storage.ClientRepository.
+type MockClientRepository struct {
+	ListFn             func(ctx context.Context, limit, offset int, includeRevoked bool) ([]*domain.Client, int, error)
+	FindByIDFn         func(ctx context.Context, id uuid.UUID) (*domain.Client, error)
+	FindByNameFn       func(ctx context.Context, name string) (*domain.Client, error)
+	CreateFn           func(ctx context.Context, client *domain.Client) (*domain.Client, error)
+	UpdateFn           func(ctx context.Context, client *domain.Client) (*domain.Client, error)
+	UpdateSecretHashFn func(ctx context.Context, id uuid.UUID, secretHash string) error
+	RotateSecretFn     func(ctx context.Context, id uuid.UUID, newSecretHash string, gracePeriodEnds time.Time) error
+	SoftDeleteFn       func(ctx context.Context, id uuid.UUID) error
+}
+
+// List delegates to ListFn.
+func (m *MockClientRepository) List(ctx context.Context, limit, offset int, includeRevoked bool) ([]*domain.Client, int, error) {
+	return m.ListFn(ctx, limit, offset, includeRevoked)
+}
+
+// FindByID delegates to FindByIDFn.
+func (m *MockClientRepository) FindByID(ctx context.Context, id uuid.UUID) (*domain.Client, error) {
+	return m.FindByIDFn(ctx, id)
+}
+
+// FindByName delegates to FindByNameFn.
+func (m *MockClientRepository) FindByName(ctx context.Context, name string) (*domain.Client, error) {
+	return m.FindByNameFn(ctx, name)
+}
+
+// Create delegates to CreateFn.
+func (m *MockClientRepository) Create(ctx context.Context, client *domain.Client) (*domain.Client, error) {
+	return m.CreateFn(ctx, client)
+}
+
+// Update delegates to UpdateFn.
+func (m *MockClientRepository) Update(ctx context.Context, client *domain.Client) (*domain.Client, error) {
+	return m.UpdateFn(ctx, client)
+}
+
+// UpdateSecretHash delegates to UpdateSecretHashFn.
+func (m *MockClientRepository) UpdateSecretHash(ctx context.Context, id uuid.UUID, secretHash string) error {
+	return m.UpdateSecretHashFn(ctx, id, secretHash)
+}
+
+// RotateSecret delegates to RotateSecretFn.
+func (m *MockClientRepository) RotateSecret(ctx context.Context, id uuid.UUID, newSecretHash string, gracePeriodEnds time.Time) error {
+	return m.RotateSecretFn(ctx, id, newSecretHash, gracePeriodEnds)
+}
+
+// SoftDelete delegates to SoftDeleteFn.
+func (m *MockClientRepository) SoftDelete(ctx context.Context, id uuid.UUID) error {
+	return m.SoftDeleteFn(ctx, id)
+}

--- a/internal/storage/mocks/mocks_test.go
+++ b/internal/storage/mocks/mocks_test.go
@@ -1,0 +1,16 @@
+package mocks_test
+
+import (
+	"testing"
+
+	"github.com/qf-studio/auth-service/internal/storage"
+	"github.com/qf-studio/auth-service/internal/storage/mocks"
+)
+
+func TestInterfaceCompliance(t *testing.T) {
+	// Compile-time checks that mocks satisfy their interfaces.
+	var _ storage.UserRepository = (*mocks.MockUserRepository)(nil)
+	var _ storage.AdminUserRepository = (*mocks.MockAdminUserRepository)(nil)
+	var _ storage.ClientRepository = (*mocks.MockClientRepository)(nil)
+	var _ storage.RefreshTokenRepository = (*mocks.MockRefreshTokenRepository)(nil)
+}

--- a/internal/storage/mocks/refresh_token_repository.go
+++ b/internal/storage/mocks/refresh_token_repository.go
@@ -1,0 +1,36 @@
+package mocks
+
+import (
+	"context"
+	"time"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// MockRefreshTokenRepository is a configurable mock for storage.RefreshTokenRepository.
+type MockRefreshTokenRepository struct {
+	StoreFn            func(ctx context.Context, signature, userID string, expiresAt time.Time) error
+	FindBySignatureFn  func(ctx context.Context, signature string) (*domain.RefreshTokenRecord, error)
+	RevokeFn           func(ctx context.Context, signature string) error
+	RevokeAllForUserFn func(ctx context.Context, userID string) error
+}
+
+// Store delegates to StoreFn.
+func (m *MockRefreshTokenRepository) Store(ctx context.Context, signature, userID string, expiresAt time.Time) error {
+	return m.StoreFn(ctx, signature, userID, expiresAt)
+}
+
+// FindBySignature delegates to FindBySignatureFn.
+func (m *MockRefreshTokenRepository) FindBySignature(ctx context.Context, signature string) (*domain.RefreshTokenRecord, error) {
+	return m.FindBySignatureFn(ctx, signature)
+}
+
+// Revoke delegates to RevokeFn.
+func (m *MockRefreshTokenRepository) Revoke(ctx context.Context, signature string) error {
+	return m.RevokeFn(ctx, signature)
+}
+
+// RevokeAllForUser delegates to RevokeAllForUserFn.
+func (m *MockRefreshTokenRepository) RevokeAllForUser(ctx context.Context, userID string) error {
+	return m.RevokeAllForUserFn(ctx, userID)
+}

--- a/internal/storage/mocks/user_repository.go
+++ b/internal/storage/mocks/user_repository.go
@@ -1,0 +1,36 @@
+package mocks
+
+import (
+	"context"
+	"time"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// MockUserRepository is a configurable mock for storage.UserRepository.
+type MockUserRepository struct {
+	CreateFn          func(ctx context.Context, user *domain.User) (*domain.User, error)
+	FindByIDFn        func(ctx context.Context, id string) (*domain.User, error)
+	FindByEmailFn     func(ctx context.Context, email string) (*domain.User, error)
+	UpdateLastLoginFn func(ctx context.Context, userID string, timestamp time.Time) error
+}
+
+// Create delegates to CreateFn.
+func (m *MockUserRepository) Create(ctx context.Context, user *domain.User) (*domain.User, error) {
+	return m.CreateFn(ctx, user)
+}
+
+// FindByID delegates to FindByIDFn.
+func (m *MockUserRepository) FindByID(ctx context.Context, id string) (*domain.User, error) {
+	return m.FindByIDFn(ctx, id)
+}
+
+// FindByEmail delegates to FindByEmailFn.
+func (m *MockUserRepository) FindByEmail(ctx context.Context, email string) (*domain.User, error) {
+	return m.FindByEmailFn(ctx, email)
+}
+
+// UpdateLastLogin delegates to UpdateLastLoginFn.
+func (m *MockUserRepository) UpdateLastLogin(ctx context.Context, userID string, timestamp time.Time) error {
+	return m.UpdateLastLoginFn(ctx, userID, timestamp)
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-153.

Closes #153

## Changes

Create mock implementations of `UserRepository`, `AdminUserRepository`, `ClientRepository`, and `RefreshTokenRepository` interfaces in the `mocks` sub-package. These are needed by downstream issues (#5–#9) for unit-testing auth, token, and middleware packages without hitting a real database. Use simple struct-based mocks with configurable function fields (no codegen dependency like mockery needed for this scope).