### PR TITLE
GH-157: Go module, directory structure, and entry point stubs

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -1,0 +1,24 @@
+// Command migrate runs database migrations for the auth service.
+// Usage: go run cmd/migrate/main.go [up|down|version]
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "usage: migrate <up|down|version>\n")
+		os.Exit(1)
+	}
+
+	cmd := os.Args[1]
+	switch cmd {
+	case "up", "down", "version":
+		fmt.Printf("migrate %s: not yet implemented\n", cmd)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n", cmd)
+		os.Exit(1)
+	}
+}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -1,0 +1,2 @@
+// Package audit provides structured audit logging (Phase 2).
+package audit

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,0 +1,2 @@
+// Package client provides OAuth2 client management for services and agents.
+package client

--- a/internal/mfa/mfa.go
+++ b/internal/mfa/mfa.go
@@ -1,0 +1,2 @@
+// Package mfa provides multi-factor authentication: TOTP, WebAuthn, backup codes (Phase 2).
+package mfa

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -1,0 +1,2 @@
+// Package oauth provides social login and OIDC provider support (Phase 2).
+package oauth

--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -1,0 +1,2 @@
+// Package rbac provides role-based access control enforcement.
+package rbac

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1,0 +1,2 @@
+// Package session provides session management (Phase 2).
+package session

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,0 +1,2 @@
+// Package testutil provides test containers, fixtures, and helpers.
+package testutil

--- a/internal/user/user.go
+++ b/internal/user/user.go
@@ -1,0 +1,2 @@
+// Package user provides user CRUD operations.
+package user

--- a/pkg/authclient/authclient.go
+++ b/pkg/authclient/authclient.go
@@ -1,0 +1,2 @@
+// Package authclient provides a Go SDK for verifying tokens issued by the auth service.
+package authclient


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-157.

Closes #157

## Changes

Initialize `go.mod` (if not present on this branch), create the full directory tree (`internal/{config,domain,auth,user,client,token,rbac,middleware,storage,logger}/`, `pkg/authclient/`, `migrations/`), and write `cmd/server/main.go` with dual-port HTTP listeners (`:4000` public, `:4001` admin) serving basic health endpoints, plus a `cmd/migrate/main.go` stub. Must compile with `go build ./...`.