### PR TITLE
GH-180: Service-layer integration and DI wiring

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/qf-studio/auth-service/internal/admin"
 	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/audit"
 	"github.com/qf-studio/auth-service/internal/auth"
 	"github.com/qf-studio/auth-service/internal/hibp"
 	"github.com/qf-studio/auth-service/internal/config"
@@ -73,14 +74,17 @@ func run(log *zap.Logger, cfg *config.Config) error {
 	userRepo := storage.NewPostgresUserRepository(pgPool)
 	refreshTokenRepo := storage.NewPostgresRefreshTokenRepository(pgPool)
 
+	// ── Audit ─────────────────────────────────────────────────────────────
+	auditSvc := audit.NewService(log, 1024)
+
 	// ── Services ─────────────────────────────────────────────────────────
 	hasher := password.New([]byte(cfg.Argon2.Pepper))
-	tokenSvc, err := token.NewService(cfg.JWT, redisClient, log)
+	tokenSvc, err := token.NewService(cfg.JWT, redisClient, log, auditSvc)
 	if err != nil {
 		return fmt.Errorf("token service init failed: %w", err)
 	}
 	hibpClient := hibp.NewClient(http.DefaultClient)
-	authSvc := auth.NewService(redisClient, log, userRepo, refreshTokenRepo, tokenSvc, hasher, hibpClient)
+	authSvc := auth.NewService(redisClient, log, auditSvc, userRepo, refreshTokenRepo, tokenSvc, hasher, hibpClient)
 
 	services := &api.Services{
 		Auth:  authSvc,
@@ -114,9 +118,9 @@ func run(log *zap.Logger, cfg *config.Config) error {
 	clientRepo := storage.NewPostgresClientRepository(pgPool)
 
 	// ── Admin services ────────────────────────────────────────────────────
-	adminUserSvc := admin.NewUserService(adminUserRepo, hasher, log)
-	adminClientSvc := admin.NewClientService(clientRepo, hasher, log)
-	adminTokenSvc := admin.NewTokenService(tokenSvc, refreshTokenRepo, "auth-service", log)
+	adminUserSvc := admin.NewUserService(adminUserRepo, hasher, log, auditSvc)
+	adminClientSvc := admin.NewClientService(clientRepo, hasher, log, auditSvc)
+	adminTokenSvc := admin.NewTokenService(tokenSvc, refreshTokenRepo, "auth-service", log, auditSvc)
 
 	adminServices := &api.AdminServices{
 		Users:   adminUserSvc,
@@ -148,6 +152,7 @@ func run(log *zap.Logger, cfg *config.Config) error {
 	// Decision: Redis is listed before any future DB closer so that
 	// token-revocation lookups during drain can still reach the cache.
 	closers := []httpserver.Closer{
+		auditSvc,
 		&redisCloser{client: redisClient},
 	}
 

--- a/internal/admin/client_service.go
+++ b/internal/admin/client_service.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/audit"
 	"github.com/qf-studio/auth-service/internal/domain"
 	"github.com/qf-studio/auth-service/internal/password"
 	"github.com/qf-studio/auth-service/internal/storage"
@@ -31,14 +32,16 @@ type ClientService struct {
 	repo   storage.ClientRepository
 	hasher password.Hasher
 	logger *zap.Logger
+	audit  audit.EventLogger
 }
 
 // NewClientService creates a new admin client service.
-func NewClientService(repo storage.ClientRepository, hasher password.Hasher, logger *zap.Logger) *ClientService {
+func NewClientService(repo storage.ClientRepository, hasher password.Hasher, logger *zap.Logger, auditor audit.EventLogger) *ClientService {
 	return &ClientService{
 		repo:   repo,
 		hasher: hasher,
 		logger: logger,
+		audit:  auditor,
 	}
 }
 
@@ -128,6 +131,12 @@ func (s *ClientService) CreateClient(ctx context.Context, req *api.CreateClientR
 		return nil, fmt.Errorf("create client: %w", api.ErrInternalError)
 	}
 
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminClientCreate,
+		TargetID: created.ID.String(),
+		Metadata: map[string]string{"name": created.Name, "type": string(created.ClientType)},
+	})
+
 	return &api.AdminClientWithSecret{
 		AdminClient:  domainClientToAdmin(created),
 		ClientSecret: secret,
@@ -169,6 +178,11 @@ func (s *ClientService) UpdateClient(ctx context.Context, clientID string, req *
 		return nil, fmt.Errorf("update client: %w", api.ErrInternalError)
 	}
 
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminClientUpdate,
+		TargetID: clientID,
+	})
+
 	admin := domainClientToAdmin(updated)
 	return &admin, nil
 }
@@ -191,6 +205,10 @@ func (s *ClientService) DeleteClient(ctx context.Context, clientID string) error
 		s.logger.Error("delete client failed", zap.String("client_id", clientID), zap.Error(err))
 		return fmt.Errorf("delete client: %w", api.ErrInternalError)
 	}
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminClientDelete,
+		TargetID: clientID,
+	})
 	return nil
 }
 
@@ -229,6 +247,11 @@ func (s *ClientService) RotateSecret(ctx context.Context, clientID string) (*api
 		s.logger.Error("re-read client after rotation failed", zap.String("client_id", clientID), zap.Error(err))
 		return nil, fmt.Errorf("rotate secret: %w", api.ErrInternalError)
 	}
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminClientRotate,
+		TargetID: clientID,
+	})
+
 	return &api.AdminClientWithSecret{
 		AdminClient:     domainClientToAdmin(client),
 		ClientSecret:    secret,

--- a/internal/admin/client_service_test.go
+++ b/internal/admin/client_service_test.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/audit"
 	"github.com/qf-studio/auth-service/internal/domain"
 	"github.com/qf-studio/auth-service/internal/storage"
 )
@@ -108,7 +109,7 @@ func testClient() *domain.Client {
 }
 
 func newTestClientService(repo *mockClientRepo) *ClientService {
-	return NewClientService(repo, &mockHasher{}, zap.NewNop())
+	return NewClientService(repo, &mockHasher{}, zap.NewNop(), audit.NopLogger{})
 }
 
 // --- ListClients ---

--- a/internal/admin/token_service.go
+++ b/internal/admin/token_service.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/audit"
 	"github.com/qf-studio/auth-service/internal/domain"
 )
 
@@ -28,16 +29,18 @@ type TokenService struct {
 	refreshTokens RefreshTokenLookup
 	issuer        string
 	logger        *zap.Logger
+	audit         audit.EventLogger
 }
 
 // NewTokenService creates a new admin token service.
 // refreshTokens may be nil; when nil, refresh token introspection returns active=false.
-func NewTokenService(validator TokenValidator, refreshTokens RefreshTokenLookup, issuer string, logger *zap.Logger) *TokenService {
+func NewTokenService(validator TokenValidator, refreshTokens RefreshTokenLookup, issuer string, logger *zap.Logger, auditor audit.EventLogger) *TokenService {
 	return &TokenService{
 		validator:     validator,
 		refreshTokens: refreshTokens,
 		issuer:        issuer,
 		logger:        logger,
+		audit:         auditor,
 	}
 }
 
@@ -48,10 +51,26 @@ func NewTokenService(validator TokenValidator, refreshTokens RefreshTokenLookup,
 //
 // Returns active=false for invalid, expired, or revoked tokens (never an error for those cases).
 func (s *TokenService) Introspect(ctx context.Context, token string) (*api.IntrospectionResponse, error) {
+	var resp *api.IntrospectionResponse
+	var err error
+
 	if strings.HasPrefix(token, "qf_rt_") {
-		return s.introspectRefreshToken(ctx, token)
+		resp, err = s.introspectRefreshToken(ctx, token)
+	} else {
+		resp, err = s.introspectAccessToken(ctx, token)
 	}
-	return s.introspectAccessToken(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type: audit.EventTokenIntrospect,
+		Metadata: map[string]string{
+			"active": fmt.Sprintf("%t", resp.Active),
+		},
+	})
+
+	return resp, nil
 }
 
 // introspectAccessToken validates a JWT access token (qf_at_ prefix accepted).

--- a/internal/admin/token_service_test.go
+++ b/internal/admin/token_service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/qf-studio/auth-service/internal/audit"
 	"github.com/qf-studio/auth-service/internal/domain"
 	"github.com/qf-studio/auth-service/internal/storage"
 )
@@ -67,7 +68,7 @@ func (m *mockRefreshTokenLookup) FindBySignature(ctx context.Context, signature 
 // --- Helpers ---
 
 func newTestTokenService(validator *mockTokenValidator, lookup RefreshTokenLookup) *TokenService {
-	return NewTokenService(validator, lookup, "auth-service", zap.NewNop())
+	return NewTokenService(validator, lookup, "auth-service", zap.NewNop(), audit.NopLogger{})
 }
 
 // --- Introspect: Access Token (Active) ---

--- a/internal/admin/user_service.go
+++ b/internal/admin/user_service.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/audit"
 	"github.com/qf-studio/auth-service/internal/domain"
 	"github.com/qf-studio/auth-service/internal/password"
 	"github.com/qf-studio/auth-service/internal/storage"
@@ -22,14 +23,16 @@ type UserService struct {
 	repo   storage.AdminUserRepository
 	hasher password.Hasher
 	logger *zap.Logger
+	audit  audit.EventLogger
 }
 
 // NewUserService creates a new admin user service.
-func NewUserService(repo storage.AdminUserRepository, hasher password.Hasher, logger *zap.Logger) *UserService {
+func NewUserService(repo storage.AdminUserRepository, hasher password.Hasher, logger *zap.Logger, auditor audit.EventLogger) *UserService {
 	return &UserService{
 		repo:   repo,
 		hasher: hasher,
 		logger: logger,
+		audit:  auditor,
 	}
 }
 
@@ -105,6 +108,12 @@ func (s *UserService) CreateUser(ctx context.Context, req *api.CreateUserRequest
 		return nil, fmt.Errorf("create user: %w", api.ErrInternalError)
 	}
 
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminUserCreate,
+		TargetID: created.ID,
+		Metadata: map[string]string{"email": created.Email},
+	})
+
 	admin := domainUserToAdmin(created)
 	return &admin, nil
 }
@@ -142,6 +151,11 @@ func (s *UserService) UpdateUser(ctx context.Context, userID string, req *api.Up
 		return nil, fmt.Errorf("update user: %w", api.ErrInternalError)
 	}
 
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminUserUpdate,
+		TargetID: userID,
+	})
+
 	admin := domainUserToAdmin(updated)
 	return &admin, nil
 }
@@ -159,6 +173,10 @@ func (s *UserService) DeleteUser(ctx context.Context, userID string) error {
 		s.logger.Error("delete user failed", zap.String("user_id", userID), zap.Error(err))
 		return fmt.Errorf("delete user: %w", api.ErrInternalError)
 	}
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminUserDelete,
+		TargetID: userID,
+	})
 	return nil
 }
 
@@ -172,6 +190,12 @@ func (s *UserService) LockUser(ctx context.Context, userID string, reason string
 		s.logger.Error("lock user failed", zap.String("user_id", userID), zap.Error(err))
 		return nil, fmt.Errorf("lock user: %w", api.ErrInternalError)
 	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminUserLock,
+		TargetID: userID,
+		Metadata: map[string]string{"reason": reason},
+	})
 
 	admin := domainUserToAdmin(u)
 	return &admin, nil
@@ -187,6 +211,11 @@ func (s *UserService) UnlockUser(ctx context.Context, userID string) (*api.Admin
 		s.logger.Error("unlock user failed", zap.String("user_id", userID), zap.Error(err))
 		return nil, fmt.Errorf("unlock user: %w", api.ErrInternalError)
 	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminUserUnlock,
+		TargetID: userID,
+	})
 
 	admin := domainUserToAdmin(u)
 	return &admin, nil

--- a/internal/admin/user_service_test.go
+++ b/internal/admin/user_service_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/audit"
 	"github.com/qf-studio/auth-service/internal/domain"
 	"github.com/qf-studio/auth-service/internal/storage"
 )
@@ -123,7 +124,7 @@ func testUser() *domain.User {
 }
 
 func newTestUserService(repo *mockAdminUserRepo) *UserService {
-	return NewUserService(repo, &mockHasher{}, zap.NewNop())
+	return NewUserService(repo, &mockHasher{}, zap.NewNop(), audit.NopLogger{})
 }
 
 // --- ListUsers ---
@@ -238,7 +239,7 @@ func TestUserService_CreateUser_HashError(t *testing.T) {
 		hashFn: func(_ string) (string, error) {
 			return "", fmt.Errorf("hash failed")
 		},
-	}, zap.NewNop())
+	}, zap.NewNop(), audit.NopLogger{})
 
 	_, err := svc.CreateUser(context.Background(), &api.CreateUserRequest{
 		Email:    "new@example.com",

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -1,2 +1,127 @@
-// Package audit provides structured audit logging (Phase 2).
+// Package audit provides structured audit event logging for security-relevant
+// operations. Events are dispatched asynchronously via a buffered channel and
+// persisted by a pluggable repository.
 package audit
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// Event types for all auditable operations.
+const (
+	EventLoginSuccess       = "login_success"
+	EventLoginFailure       = "login_failure"
+	EventRegister           = "register"
+	EventLogout             = "logout"
+	EventLogoutAll          = "logout_all"
+	EventPasswordChange     = "password_change"
+	EventPasswordReset      = "password_reset"
+	EventPasswordResetConfm = "password_reset_confirm"
+	EventTokenRefresh       = "token_refresh"
+	EventTokenRevoke        = "token_revoke"
+	EventAdminUserCreate    = "admin_user_create"
+	EventAdminUserUpdate    = "admin_user_update"
+	EventAdminUserDelete    = "admin_user_delete"
+	EventAdminUserLock      = "admin_user_lock"
+	EventAdminUserUnlock    = "admin_user_unlock"
+	EventAdminClientCreate  = "admin_client_create"
+	EventAdminClientUpdate  = "admin_client_update"
+	EventAdminClientDelete  = "admin_client_delete"
+	EventAdminClientRotate  = "admin_client_rotate_secret"
+	EventTokenIntrospect    = "token_introspect"
+)
+
+// Event represents a single audit log entry.
+type Event struct {
+	Type      string
+	ActorID   string // user or client performing the action
+	TargetID  string // resource being acted upon
+	IP        string
+	Metadata  map[string]string
+	Timestamp time.Time
+}
+
+// EventLogger is the interface consumed by services to emit audit events.
+type EventLogger interface {
+	LogEvent(ctx context.Context, event Event)
+}
+
+// Service implements EventLogger with an async buffered channel. Events are
+// drained on Close so nothing is lost during graceful shutdown.
+type Service struct {
+	logger *zap.Logger
+	ch     chan Event
+	done   chan struct{}
+}
+
+// NewService creates an audit Service with the given buffer size.
+// Events exceeding the buffer are logged and dropped (non-blocking).
+func NewService(logger *zap.Logger, bufferSize int) *Service {
+	if bufferSize <= 0 {
+		bufferSize = 1024
+	}
+	s := &Service{
+		logger: logger,
+		ch:     make(chan Event, bufferSize),
+		done:   make(chan struct{}),
+	}
+	go s.drain()
+	return s
+}
+
+// LogEvent enqueues an audit event. It is non-blocking; if the buffer is full
+// the event is logged at warn level and dropped.
+func (s *Service) LogEvent(_ context.Context, event Event) {
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now().UTC()
+	}
+	select {
+	case s.ch <- event:
+	default:
+		s.logger.Warn("audit buffer full, event dropped",
+			zap.String("event_type", event.Type),
+			zap.String("actor_id", event.ActorID),
+		)
+	}
+}
+
+// Close signals the drain goroutine to flush remaining events and waits for
+// completion. Implements httpserver.Closer semantics.
+func (s *Service) Close() error {
+	close(s.ch)
+	<-s.done
+	return nil
+}
+
+// Name returns the closer label for shutdown logging.
+func (s *Service) Name() string { return "audit" }
+
+// drain reads events from the channel and logs them via zap structured fields.
+// In a future iteration this will persist to the audit_log table via a repository.
+func (s *Service) drain() {
+	defer close(s.done)
+	for ev := range s.ch {
+		fields := []zap.Field{
+			zap.String("audit_event", ev.Type),
+			zap.String("actor_id", ev.ActorID),
+			zap.String("target_id", ev.TargetID),
+			zap.Time("event_time", ev.Timestamp),
+		}
+		if ev.IP != "" {
+			fields = append(fields, zap.String("ip", ev.IP))
+		}
+		for k, v := range ev.Metadata {
+			fields = append(fields, zap.String("meta_"+k, v))
+		}
+		s.logger.Info("audit", fields...)
+	}
+}
+
+// NopLogger is a no-op implementation of EventLogger for use in tests.
+type NopLogger struct{}
+
+// LogEvent does nothing.
+func (NopLogger) LogEvent(_ context.Context, _ Event) {}

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -1,0 +1,106 @@
+package audit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestService_LogEvent_DrainOnClose(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+
+	svc := NewService(logger, 64)
+
+	svc.LogEvent(context.Background(), Event{
+		Type:     EventLoginSuccess,
+		ActorID:  "user-1",
+		TargetID: "user-1",
+	})
+	svc.LogEvent(context.Background(), Event{
+		Type:     EventLogout,
+		ActorID:  "user-2",
+		TargetID: "user-2",
+	})
+
+	err := svc.Close()
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, logs.Len(), "expected 2 audit log entries after drain")
+
+	entry := logs.All()[0]
+	assert.Equal(t, "audit", entry.Message)
+
+	fields := make(map[string]string)
+	for _, f := range entry.ContextMap() {
+		if s, ok := f.(string); ok {
+			fields[entry.ContextMap()["audit_event"].(string)] = s
+		}
+	}
+	assert.Equal(t, EventLoginSuccess, entry.ContextMap()["audit_event"])
+	assert.Equal(t, "user-1", entry.ContextMap()["actor_id"])
+}
+
+func TestService_LogEvent_SetsTimestamp(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+
+	svc := NewService(logger, 64)
+
+	before := time.Now().UTC()
+	svc.LogEvent(context.Background(), Event{
+		Type:    EventRegister,
+		ActorID: "user-3",
+	})
+	err := svc.Close()
+	require.NoError(t, err)
+
+	require.Equal(t, 1, logs.Len())
+	eventTime := logs.All()[0].ContextMap()["event_time"].(time.Time)
+	assert.False(t, eventTime.Before(before), "event timestamp should be >= before")
+}
+
+func TestService_LogEvent_BufferFull_Drops(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	// Buffer size 1, fill the channel by blocking the drain goroutine.
+	svc := &Service{
+		logger: logger,
+		ch:     make(chan Event, 1),
+		done:   make(chan struct{}),
+	}
+
+	// Fill the buffer without draining.
+	svc.ch <- Event{Type: EventLoginSuccess}
+
+	// This one should be dropped and produce a warning.
+	svc.LogEvent(context.Background(), Event{Type: EventLogout})
+
+	assert.Equal(t, 1, logs.Len(), "expected 1 warn log for dropped event")
+	assert.Equal(t, "audit buffer full, event dropped", logs.All()[0].Message)
+
+	// Drain to avoid goroutine leak.
+	<-svc.ch
+	close(svc.ch)
+	close(svc.done)
+}
+
+func TestService_Name(t *testing.T) {
+	svc := NewService(zap.NewNop(), 1)
+	assert.Equal(t, "audit", svc.Name())
+	_ = svc.Close()
+}
+
+func TestNopLogger_DoesNotPanic(t *testing.T) {
+	nop := NopLogger{}
+	nop.LogEvent(context.Background(), Event{
+		Type:    EventLoginSuccess,
+		ActorID: "test",
+	})
+}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/audit"
 	"github.com/qf-studio/auth-service/internal/domain"
 	"github.com/qf-studio/auth-service/internal/hibp"
 	"github.com/qf-studio/auth-service/internal/password"
@@ -41,19 +42,21 @@ type TokenIssuer interface {
 // Service implements api.AuthService with Redis-backed password reset tokens
 // and PostgreSQL-backed user authentication.
 type Service struct {
-	redis     *redis.Client
-	logger    *zap.Logger
-	users     storage.UserRepository
-	tokens    storage.RefreshTokenRepository
-	issuer    TokenIssuer
-	hasher    password.Hasher
-	breaches  hibp.BreachChecker
+	redis    *redis.Client
+	logger   *zap.Logger
+	audit    audit.EventLogger
+	users    storage.UserRepository
+	tokens   storage.RefreshTokenRepository
+	issuer   TokenIssuer
+	hasher   password.Hasher
+	breaches hibp.BreachChecker
 }
 
 // NewService creates a new auth Service.
 func NewService(
 	redisClient *redis.Client,
 	logger *zap.Logger,
+	auditor audit.EventLogger,
 	users storage.UserRepository,
 	tokens storage.RefreshTokenRepository,
 	issuer TokenIssuer,
@@ -63,6 +66,7 @@ func NewService(
 	return &Service{
 		redis:    redisClient,
 		logger:   logger,
+		audit:    auditor,
 		users:    users,
 		tokens:   tokens,
 		issuer:   issuer,
@@ -73,13 +77,20 @@ func NewService(
 
 // Register creates a new user account.
 // Stub: full implementation depends on PostgreSQL user repository (future issue).
-func (s *Service) Register(_ context.Context, email, _, name string) (*api.UserInfo, error) {
+func (s *Service) Register(ctx context.Context, email, _, name string) (*api.UserInfo, error) {
 	// TODO(GH-XX): wire PostgreSQL user repository for persistence.
-	return &api.UserInfo{
+	info := &api.UserInfo{
 		ID:    "stub-user-id",
 		Email: email,
 		Name:  name,
-	}, nil
+	}
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventRegister,
+		ActorID:  info.ID,
+		TargetID: info.ID,
+		Metadata: map[string]string{"email": email},
+	})
+	return info, nil
 }
 
 // Login authenticates a user by email and password.
@@ -88,6 +99,10 @@ func (s *Service) Login(ctx context.Context, email, pwd string) (*api.AuthResult
 	user, err := s.users.FindByEmail(ctx, email)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
+			s.audit.LogEvent(ctx, audit.Event{
+				Type:     audit.EventLoginFailure,
+				Metadata: map[string]string{"reason": "user_not_found"},
+			})
 			return nil, fmt.Errorf("invalid credentials: %w", api.ErrUnauthorized)
 		}
 		s.logger.Error("failed to find user by email", zap.Error(err))
@@ -96,9 +111,21 @@ func (s *Service) Login(ctx context.Context, email, pwd string) (*api.AuthResult
 
 	// Check account status before verifying password.
 	if user.DeletedAt != nil {
+		s.audit.LogEvent(ctx, audit.Event{
+			Type:     audit.EventLoginFailure,
+			ActorID:  user.ID,
+			TargetID: user.ID,
+			Metadata: map[string]string{"reason": "account_suspended"},
+		})
 		return nil, fmt.Errorf("account suspended: %w", api.ErrUnauthorized)
 	}
 	if user.Locked {
+		s.audit.LogEvent(ctx, audit.Event{
+			Type:     audit.EventLoginFailure,
+			ActorID:  user.ID,
+			TargetID: user.ID,
+			Metadata: map[string]string{"reason": "account_locked"},
+		})
 		return nil, fmt.Errorf("account locked: %w", api.ErrUnauthorized)
 	}
 
@@ -108,6 +135,12 @@ func (s *Service) Login(ctx context.Context, email, pwd string) (*api.AuthResult
 		return nil, fmt.Errorf("verify password: %w", err)
 	}
 	if !match {
+		s.audit.LogEvent(ctx, audit.Event{
+			Type:     audit.EventLoginFailure,
+			ActorID:  user.ID,
+			TargetID: user.ID,
+			Metadata: map[string]string{"reason": "invalid_password"},
+		})
 		return nil, fmt.Errorf("invalid credentials: %w", api.ErrUnauthorized)
 	}
 
@@ -127,6 +160,12 @@ func (s *Service) Login(ctx context.Context, email, pwd string) (*api.AuthResult
 	if err := s.users.UpdateLastLogin(ctx, user.ID, time.Now().UTC()); err != nil {
 		s.logger.Error("failed to update last_login_at", zap.String("user_id", user.ID), zap.Error(err))
 	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventLoginSuccess,
+		ActorID:  user.ID,
+		TargetID: user.ID,
+	})
 
 	return result, nil
 }
@@ -151,6 +190,11 @@ func (s *Service) ResetPassword(ctx context.Context, email string) error {
 		zap.String("email", email),
 		zap.Duration("ttl", resetTokenTTL),
 	)
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventPasswordReset,
+		Metadata: map[string]string{"email": email},
+	})
 
 	// TODO(GH-XX): send email with reset link containing the token.
 
@@ -178,6 +222,11 @@ func (s *Service) ConfirmPasswordReset(ctx context.Context, token, newPassword s
 
 	s.logger.Info("password reset confirmed", zap.String("email", email))
 
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventPasswordResetConfm,
+		Metadata: map[string]string{"email": email},
+	})
+
 	return nil
 }
 
@@ -194,8 +243,13 @@ func (s *Service) GetMe(_ context.Context, userID string) (*api.UserInfo, error)
 
 // ChangePassword changes the authenticated user's password.
 // Stub: full implementation depends on PostgreSQL user repository.
-func (s *Service) ChangePassword(_ context.Context, _, _, _ string) error {
+func (s *Service) ChangePassword(ctx context.Context, userID, _, _ string) error {
 	// TODO(GH-XX): wire PostgreSQL user repository + Argon2 verification.
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventPasswordChange,
+		ActorID:  userID,
+		TargetID: userID,
+	})
 	return fmt.Errorf("change password not yet implemented: %w", api.ErrInternalError)
 }
 
@@ -211,6 +265,12 @@ func (s *Service) Logout(ctx context.Context, userID, token string) error {
 		return fmt.Errorf("revoke access token: %w", err)
 	}
 
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventLogout,
+		ActorID:  userID,
+		TargetID: userID,
+	})
+
 	s.logger.Info("session terminated", zap.String("user_id", userID))
 	return nil
 }
@@ -224,6 +284,12 @@ func (s *Service) LogoutAll(ctx context.Context, userID string) error {
 		)
 		return fmt.Errorf("revoke all sessions: %w", err)
 	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventLogoutAll,
+		ActorID:  userID,
+		TargetID: userID,
+	})
 
 	s.logger.Info("all sessions terminated", zap.String("user_id", userID))
 	return nil

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/audit"
 	"github.com/qf-studio/auth-service/internal/domain"
 	"github.com/qf-studio/auth-service/internal/storage"
 )
@@ -129,7 +130,7 @@ func (m *mockHasher) Verify(password, hash string) (bool, error) {
 func newUnitService(t *testing.T, users *mockUserRepository, tokens *mockRefreshTokenRepository, issuer *mockTokenIssuer, hasher *mockHasher) *Service {
 	t.Helper()
 	logger, _ := zap.NewDevelopment()
-	return NewService(nil, logger, users, tokens, issuer, hasher, &mockBreachChecker{})
+	return NewService(nil, logger, audit.NopLogger{}, users, tokens, issuer, hasher, &mockBreachChecker{})
 }
 
 // newRedisClient creates a Redis client for integration tests (password reset).
@@ -165,7 +166,7 @@ func newIntegrationService(t *testing.T) *Service {
 	t.Helper()
 	client := newRedisClient(t)
 	logger, _ := zap.NewDevelopment()
-	return NewService(client, logger, &mockUserRepository{}, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, &mockHasher{}, &mockBreachChecker{})
+	return NewService(client, logger, audit.NopLogger{}, &mockUserRepository{}, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, &mockHasher{}, &mockBreachChecker{})
 }
 
 // ── Login Tests ──────────────────────────────────────────────────────────────

--- a/internal/token/service.go
+++ b/internal/token/service.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/audit"
 	"github.com/qf-studio/auth-service/internal/config"
 	"github.com/qf-studio/auth-service/internal/domain"
 )
@@ -54,6 +55,7 @@ const (
 // Service implements api.TokenService and middleware.TokenValidator.
 type Service struct {
 	logger        *zap.Logger
+	audit         audit.EventLogger
 	redis         *redis.Client
 	cfg           config.JWTConfig
 	privateKey    crypto.Signer
@@ -63,7 +65,7 @@ type Service struct {
 
 // NewService creates a new token Service, loading the private key from the
 // path specified in cfg.PrivateKeyPath.
-func NewService(cfg config.JWTConfig, redisClient *redis.Client, logger *zap.Logger) (*Service, error) {
+func NewService(cfg config.JWTConfig, redisClient *redis.Client, logger *zap.Logger, auditor audit.EventLogger) (*Service, error) {
 	keyData, err := os.ReadFile(cfg.PrivateKeyPath)
 	if err != nil {
 		return nil, fmt.Errorf("read private key: %w", err)
@@ -76,6 +78,7 @@ func NewService(cfg config.JWTConfig, redisClient *redis.Client, logger *zap.Log
 
 	return &Service{
 		logger:        logger,
+		audit:         auditor,
 		redis:         redisClient,
 		cfg:           cfg,
 		privateKey:    signer,
@@ -86,7 +89,7 @@ func NewService(cfg config.JWTConfig, redisClient *redis.Client, logger *zap.Log
 
 // NewServiceFromKey creates a token Service from an already-parsed private key.
 // Useful for testing without filesystem access.
-func NewServiceFromKey(cfg config.JWTConfig, privateKey crypto.Signer, redisClient *redis.Client, logger *zap.Logger) (*Service, error) {
+func NewServiceFromKey(cfg config.JWTConfig, privateKey crypto.Signer, redisClient *redis.Client, logger *zap.Logger, auditor audit.EventLogger) (*Service, error) {
 	pub := privateKey.Public()
 	method, err := signingMethodForKey(privateKey, cfg.Algorithm)
 	if err != nil {
@@ -95,6 +98,7 @@ func NewServiceFromKey(cfg config.JWTConfig, privateKey crypto.Signer, redisClie
 
 	return &Service{
 		logger:        logger,
+		audit:         auditor,
 		redis:         redisClient,
 		cfg:           cfg,
 		privateKey:    privateKey,
@@ -135,7 +139,18 @@ func (s *Service) Refresh(ctx context.Context, rawRefreshToken string) (*api.Aut
 
 	// Issue new pair — refresh tokens carry no roles/scopes, so we issue with empty.
 	// The caller (auth service) should enrich with user's current roles/scopes.
-	return s.IssueTokenPair(ctx, subject, nil, nil, domain.ClientTypeUser)
+	result, err := s.IssueTokenPair(ctx, subject, nil, nil, domain.ClientTypeUser)
+	if err != nil {
+		return nil, err
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventTokenRefresh,
+		ActorID:  subject,
+		TargetID: subject,
+	})
+
+	return result, nil
 }
 
 // ClientCredentials issues an access token for service-to-service authentication.
@@ -181,6 +196,11 @@ func (s *Service) Revoke(ctx context.Context, rawToken string) error {
 		)
 		return fmt.Errorf("revoke token: %w", err)
 	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventTokenRevoke,
+		Metadata: map[string]string{"jti": jti},
+	})
 
 	s.logger.Info("token revoked", zap.String("jti", jti), zap.Duration("ttl", ttl))
 	return nil

--- a/internal/token/service_test.go
+++ b/internal/token/service_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/qf-studio/auth-service/internal/audit"
 	"github.com/qf-studio/auth-service/internal/config"
 	"github.com/qf-studio/auth-service/internal/domain"
 	"github.com/qf-studio/auth-service/internal/token"
@@ -82,7 +83,7 @@ func newES256Service(t *testing.T) (*token.Service, *miniredis.Miniredis) {
 	key := generateES256Key(t)
 	mr, rc := newTestRedis(t)
 	cfg := defaultCfg()
-	svc, err := token.NewServiceFromKey(cfg, key, rc, testLogger())
+	svc, err := token.NewServiceFromKey(cfg, key, rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 	return svc, mr
 }
@@ -93,7 +94,7 @@ func newEdDSAService(t *testing.T) (*token.Service, *miniredis.Miniredis) {
 	mr, rc := newTestRedis(t)
 	cfg := defaultCfg()
 	cfg.Algorithm = "EdDSA"
-	svc, err := token.NewServiceFromKey(cfg, key, rc, testLogger())
+	svc, err := token.NewServiceFromKey(cfg, key, rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 	return svc, mr
 }
@@ -109,7 +110,7 @@ func TestNewService_ES256FromFile(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.PrivateKeyPath = keyPath
 
-	svc, err := token.NewService(cfg, rc, testLogger())
+	svc, err := token.NewService(cfg, rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 	require.NotNil(t, svc)
 }
@@ -124,7 +125,7 @@ func TestNewService_EdDSAFromFile(t *testing.T) {
 	cfg.Algorithm = "EdDSA"
 	cfg.PrivateKeyPath = keyPath
 
-	svc, err := token.NewService(cfg, rc, testLogger())
+	svc, err := token.NewService(cfg, rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 	require.NotNil(t, svc)
 }
@@ -134,7 +135,7 @@ func TestNewService_InvalidKeyPath(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.PrivateKeyPath = "/nonexistent/key.pem"
 
-	_, err := token.NewService(cfg, rc, testLogger())
+	_, err := token.NewService(cfg, rc, testLogger(), audit.NopLogger{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "read private key")
 }
@@ -149,7 +150,7 @@ func TestNewService_AlgorithmMismatch(t *testing.T) {
 	cfg.PrivateKeyPath = keyPath
 	cfg.Algorithm = "EdDSA" // ECDSA key with EdDSA algorithm
 
-	_, err := token.NewService(cfg, rc, testLogger())
+	_, err := token.NewService(cfg, rc, testLogger(), audit.NopLogger{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "parse private key")
 }
@@ -257,7 +258,7 @@ func TestValidateToken_ExpiredToken(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.AccessTokenTTL = 1 * time.Millisecond // Very short TTL
 
-	svc, err := token.NewServiceFromKey(cfg, key, rc, testLogger())
+	svc, err := token.NewServiceFromKey(cfg, key, rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -349,7 +350,7 @@ func TestRevoke_ExpiredTokenNoBlocklist(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.AccessTokenTTL = 1 * time.Millisecond
 
-	svc, err := token.NewServiceFromKey(cfg, key, rc, testLogger())
+	svc, err := token.NewServiceFromKey(cfg, key, rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -409,7 +410,7 @@ func TestRefresh_ExpiredRefreshToken(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.RefreshTokenTTL = 1 * time.Second
 
-	svc, err := token.NewServiceFromKey(cfg, key, rc, testLogger())
+	svc, err := token.NewServiceFromKey(cfg, key, rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -433,7 +434,7 @@ func TestRefresh_SecretRotation(t *testing.T) {
 	oldCfg := defaultCfg()
 	oldCfg.SystemSecrets = []string{"old-secret"}
 
-	oldSvc, err := token.NewServiceFromKey(oldCfg, key, rc, testLogger())
+	oldSvc, err := token.NewServiceFromKey(oldCfg, key, rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -444,7 +445,7 @@ func TestRefresh_SecretRotation(t *testing.T) {
 	newCfg := defaultCfg()
 	newCfg.SystemSecrets = []string{"new-secret", "old-secret"}
 
-	newSvc, err := token.NewServiceFromKey(newCfg, key, rc, testLogger())
+	newSvc, err := token.NewServiceFromKey(newCfg, key, rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 
 	// Old refresh token should still validate with the new service.
@@ -511,7 +512,7 @@ func TestNewServiceFromKey_AlgorithmMismatch(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.Algorithm = "EdDSA"
 
-	_, err := token.NewServiceFromKey(cfg, key, rc, testLogger())
+	_, err := token.NewServiceFromKey(cfg, key, rc, testLogger(), audit.NopLogger{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ECDSA")
 }
@@ -537,7 +538,7 @@ func TestNewService_ECKeyFile(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.PrivateKeyPath = path
 
-	svc, err := token.NewService(cfg, rc, testLogger())
+	svc, err := token.NewService(cfg, rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 	require.NotNil(t, svc)
 }
@@ -594,7 +595,7 @@ func TestIssueTokenPair_NoSystemSecretsError(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.SystemSecrets = nil
 
-	svc, err := token.NewServiceFromKey(cfg, key, rc, testLogger())
+	svc, err := token.NewServiceFromKey(cfg, key, rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-180.

Closes #180

## Changes

Inject the audit service into `internal/auth/service.go`, `internal/token/service.go`, `internal/admin/user_service.go`, `internal/admin/client_service.go`, and `internal/admin/token_service.go`. Add `LogEvent` calls at the service layer (not handler) for all auth events: login success/failure, register, logout, logout_all, password change/reset, token refresh/revoke, admin user CRUD/lock/unlock, admin client CRUD/rotate-secret, and token introspection. Never log passwords, tokens, or secrets. Wire audit service construction in `cmd/server/main.go` (create service, inject into all dependents, register closer for graceful shutdown). Update existing service tests to accommodate the new audit dependency (mock or no-op audit logger).