### PR TITLE
GH-181: Admin audit query API endpoint

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -112,16 +112,19 @@ func run(log *zap.Logger, cfg *config.Config) error {
 	// ── Repositories (admin) ─────────────────────────────────────────────
 	adminUserRepo := storage.NewPostgresAdminUserRepository(pgPool)
 	clientRepo := storage.NewPostgresClientRepository(pgPool)
+	auditRepo := storage.NewPostgresAuditRepository(pgPool)
 
 	// ── Admin services ────────────────────────────────────────────────────
 	adminUserSvc := admin.NewUserService(adminUserRepo, hasher, log)
 	adminClientSvc := admin.NewClientService(clientRepo, hasher, log)
 	adminTokenSvc := admin.NewTokenService(tokenSvc, refreshTokenRepo, "auth-service", log)
+	adminAuditSvc := admin.NewAuditService(auditRepo, log)
 
 	adminServices := &api.AdminServices{
 		Users:   adminUserSvc,
 		Clients: adminClientSvc,
 		Tokens:  adminTokenSvc,
+		Audit:   adminAuditSvc,
 	}
 
 	adminDeps := &api.AdminDeps{

--- a/internal/admin/audit_service.go
+++ b/internal/admin/audit_service.go
@@ -1,0 +1,43 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+// AuditService implements api.AdminAuditService.
+type AuditService struct {
+	repo   storage.AuditRepository
+	logger *zap.Logger
+}
+
+// NewAuditService creates a new admin audit service.
+func NewAuditService(repo storage.AuditRepository, logger *zap.Logger) *AuditService {
+	return &AuditService{
+		repo:   repo,
+		logger: logger,
+	}
+}
+
+// ListEvents returns a paginated list of audit events matching the given filters.
+func (s *AuditService) ListEvents(ctx context.Context, page, perPage int, filter api.AuditFilter) (*api.AdminAuditList, error) {
+	offset := (page - 1) * perPage
+
+	events, total, err := s.repo.List(ctx, perPage, offset, filter)
+	if err != nil {
+		s.logger.Error("list audit events failed", zap.Error(err))
+		return nil, fmt.Errorf("list audit events: %w", api.ErrInternalError)
+	}
+
+	return &api.AdminAuditList{
+		Events:  events,
+		Total:   total,
+		Page:    page,
+		PerPage: perPage,
+	}, nil
+}

--- a/internal/api/admin_audit_handlers.go
+++ b/internal/api/admin_audit_handlers.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// AdminAuditHandlers provides HTTP handlers for the admin audit log API.
+type AdminAuditHandlers struct {
+	audit AdminAuditService
+}
+
+// NewAdminAuditHandlers creates a new AdminAuditHandlers.
+func NewAdminAuditHandlers(audit AdminAuditService) *AdminAuditHandlers {
+	return &AdminAuditHandlers{audit: audit}
+}
+
+// List handles GET /admin/audit with pagination and filters.
+// Query parameters:
+//   - page, per_page: pagination (defaults: 1, 20)
+//   - user_id: filter by user ID
+//   - client_id: filter by client ID
+//   - event_type: filter by event type
+//   - start_date: filter events on or after this RFC 3339 timestamp
+//   - end_date: filter events on or before this RFC 3339 timestamp
+func (h *AdminAuditHandlers) List(c *gin.Context) {
+	page, perPage := parsePagination(c)
+
+	filter := AuditFilter{
+		UserID:    c.Query("user_id"),
+		ClientID:  c.Query("client_id"),
+		EventType: c.Query("event_type"),
+	}
+
+	if raw := c.Query("start_date"); raw != "" {
+		t, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid start_date: expected RFC 3339 format")
+			return
+		}
+		filter.StartDate = &t
+	}
+
+	if raw := c.Query("end_date"); raw != "" {
+		t, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid end_date: expected RFC 3339 format")
+			return
+		}
+		filter.EndDate = &t
+	}
+
+	result, err := h.audit.ListEvents(c.Request.Context(), page, perPage, filter)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}

--- a/internal/api/admin_audit_handlers_test.go
+++ b/internal/api/admin_audit_handlers_test.go
@@ -1,0 +1,361 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/health"
+)
+
+// --- Mock AdminAuditService ---
+
+type mockAdminAuditService struct {
+	listEventsFn func(ctx context.Context, page, perPage int, filter api.AuditFilter) (*api.AdminAuditList, error)
+}
+
+func (m *mockAdminAuditService) ListEvents(ctx context.Context, page, perPage int, filter api.AuditFilter) (*api.AdminAuditList, error) {
+	if m.listEventsFn != nil {
+		return m.listEventsFn(ctx, page, perPage, filter)
+	}
+	return &api.AdminAuditList{
+		Events:  []api.AdminAuditEvent{},
+		Total:   0,
+		Page:    page,
+		PerPage: perPage,
+	}, nil
+}
+
+// --- Helper ---
+
+func setupAuditRouter(auditSvc api.AdminAuditService) *gin.Engine {
+	svc := &api.AdminServices{Audit: auditSvc}
+	return api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+}
+
+// --- List audit events: defaults ---
+
+func TestAdminListAudit_Success(t *testing.T) {
+	now := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+	svc := &mockAdminAuditService{
+		listEventsFn: func(_ context.Context, page, perPage int, filter api.AuditFilter) (*api.AdminAuditList, error) {
+			assert.Equal(t, 1, page)
+			assert.Equal(t, 20, perPage)
+			assert.Empty(t, filter.UserID)
+			assert.Empty(t, filter.ClientID)
+			assert.Empty(t, filter.EventType)
+			assert.Nil(t, filter.StartDate)
+			assert.Nil(t, filter.EndDate)
+			return &api.AdminAuditList{
+				Events: []api.AdminAuditEvent{
+					{ID: "ev-1", UserID: "u1", EventType: "login_success", CreatedAt: now},
+					{ID: "ev-2", UserID: "u2", EventType: "login_failure", CreatedAt: now.Add(-time.Hour)},
+				},
+				Total:   2,
+				Page:    page,
+				PerPage: perPage,
+			}, nil
+		},
+	}
+	r := setupAuditRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/audit", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminAuditList
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 2, resp.Total)
+	assert.Len(t, resp.Events, 2)
+	assert.Equal(t, 1, resp.Page)
+	assert.Equal(t, 20, resp.PerPage)
+	assert.Equal(t, "ev-1", resp.Events[0].ID)
+	assert.Equal(t, "login_success", resp.Events[0].EventType)
+}
+
+// --- Empty results ---
+
+func TestAdminListAudit_EmptyResults(t *testing.T) {
+	svc := &mockAdminAuditService{}
+	r := setupAuditRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/audit", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminAuditList
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 0, resp.Total)
+	assert.Empty(t, resp.Events)
+}
+
+// --- Pagination ---
+
+func TestAdminListAudit_Pagination(t *testing.T) {
+	svc := &mockAdminAuditService{
+		listEventsFn: func(_ context.Context, page, perPage int, _ api.AuditFilter) (*api.AdminAuditList, error) {
+			assert.Equal(t, 3, page)
+			assert.Equal(t, 5, perPage)
+			return &api.AdminAuditList{Events: []api.AdminAuditEvent{}, Total: 50, Page: page, PerPage: perPage}, nil
+		},
+	}
+	r := setupAuditRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/audit?page=3&per_page=5", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminAuditList
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 3, resp.Page)
+	assert.Equal(t, 5, resp.PerPage)
+	assert.Equal(t, 50, resp.Total)
+}
+
+func TestAdminListAudit_PaginationClampNegativePage(t *testing.T) {
+	svc := &mockAdminAuditService{
+		listEventsFn: func(_ context.Context, page, perPage int, _ api.AuditFilter) (*api.AdminAuditList, error) {
+			assert.Equal(t, 1, page)
+			return &api.AdminAuditList{Events: []api.AdminAuditEvent{}, Total: 0, Page: page, PerPage: perPage}, nil
+		},
+	}
+	r := setupAuditRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/audit?page=-5", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestAdminListAudit_PaginationClampPerPageMax(t *testing.T) {
+	svc := &mockAdminAuditService{
+		listEventsFn: func(_ context.Context, _, perPage int, _ api.AuditFilter) (*api.AdminAuditList, error) {
+			assert.Equal(t, 100, perPage)
+			return &api.AdminAuditList{Events: []api.AdminAuditEvent{}, Total: 0, Page: 1, PerPage: perPage}, nil
+		},
+	}
+	r := setupAuditRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/audit?per_page=500", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// --- Filter: user_id ---
+
+func TestAdminListAudit_FilterByUserID(t *testing.T) {
+	svc := &mockAdminAuditService{
+		listEventsFn: func(_ context.Context, _, _ int, filter api.AuditFilter) (*api.AdminAuditList, error) {
+			assert.Equal(t, "user-42", filter.UserID)
+			return &api.AdminAuditList{
+				Events: []api.AdminAuditEvent{
+					{ID: "ev-1", UserID: "user-42", EventType: "login_success", CreatedAt: time.Now()},
+				},
+				Total: 1, Page: 1, PerPage: 20,
+			}, nil
+		},
+	}
+	r := setupAuditRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/audit?user_id=user-42", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminAuditList
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.Total)
+	assert.Equal(t, "user-42", resp.Events[0].UserID)
+}
+
+// --- Filter: event_type ---
+
+func TestAdminListAudit_FilterByEventType(t *testing.T) {
+	svc := &mockAdminAuditService{
+		listEventsFn: func(_ context.Context, _, _ int, filter api.AuditFilter) (*api.AdminAuditList, error) {
+			assert.Equal(t, "login_failure", filter.EventType)
+			return &api.AdminAuditList{Events: []api.AdminAuditEvent{}, Total: 0, Page: 1, PerPage: 20}, nil
+		},
+	}
+	r := setupAuditRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/audit?event_type=login_failure", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// --- Filter: client_id ---
+
+func TestAdminListAudit_FilterByClientID(t *testing.T) {
+	svc := &mockAdminAuditService{
+		listEventsFn: func(_ context.Context, _, _ int, filter api.AuditFilter) (*api.AdminAuditList, error) {
+			assert.Equal(t, "client-abc", filter.ClientID)
+			return &api.AdminAuditList{Events: []api.AdminAuditEvent{}, Total: 0, Page: 1, PerPage: 20}, nil
+		},
+	}
+	r := setupAuditRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/audit?client_id=client-abc", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// --- Filter: date range ---
+
+func TestAdminListAudit_FilterByDateRange(t *testing.T) {
+	startStr := "2026-01-01T00:00:00Z"
+	endStr := "2026-01-31T23:59:59Z"
+	expectedStart, _ := time.Parse(time.RFC3339, startStr)
+	expectedEnd, _ := time.Parse(time.RFC3339, endStr)
+
+	svc := &mockAdminAuditService{
+		listEventsFn: func(_ context.Context, _, _ int, filter api.AuditFilter) (*api.AdminAuditList, error) {
+			require.NotNil(t, filter.StartDate)
+			require.NotNil(t, filter.EndDate)
+			assert.True(t, expectedStart.Equal(*filter.StartDate))
+			assert.True(t, expectedEnd.Equal(*filter.EndDate))
+			return &api.AdminAuditList{Events: []api.AdminAuditEvent{}, Total: 0, Page: 1, PerPage: 20}, nil
+		},
+	}
+	r := setupAuditRouter(svc)
+	w := doRequest(r, http.MethodGet, fmt.Sprintf("/admin/audit?start_date=%s&end_date=%s", startStr, endStr), nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestAdminListAudit_InvalidStartDate(t *testing.T) {
+	r := setupAuditRouter(&mockAdminAuditService{})
+	w := doRequest(r, http.MethodGet, "/admin/audit?start_date=not-a-date", nil)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminListAudit_InvalidEndDate(t *testing.T) {
+	r := setupAuditRouter(&mockAdminAuditService{})
+	w := doRequest(r, http.MethodGet, "/admin/audit?end_date=2026-13-99", nil)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// --- Combined filters ---
+
+func TestAdminListAudit_CombinedFilters(t *testing.T) {
+	startStr := "2026-03-01T00:00:00Z"
+	expectedStart, _ := time.Parse(time.RFC3339, startStr)
+
+	svc := &mockAdminAuditService{
+		listEventsFn: func(_ context.Context, page, perPage int, filter api.AuditFilter) (*api.AdminAuditList, error) {
+			assert.Equal(t, 2, page)
+			assert.Equal(t, 10, perPage)
+			assert.Equal(t, "user-7", filter.UserID)
+			assert.Equal(t, "client-x", filter.ClientID)
+			assert.Equal(t, "password_change", filter.EventType)
+			require.NotNil(t, filter.StartDate)
+			assert.True(t, expectedStart.Equal(*filter.StartDate))
+			assert.Nil(t, filter.EndDate)
+			return &api.AdminAuditList{Events: []api.AdminAuditEvent{}, Total: 0, Page: page, PerPage: perPage}, nil
+		},
+	}
+	r := setupAuditRouter(svc)
+	w := doRequest(r, http.MethodGet, fmt.Sprintf(
+		"/admin/audit?page=2&per_page=10&user_id=user-7&client_id=client-x&event_type=password_change&start_date=%s",
+		startStr,
+	), nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// --- Service error ---
+
+func TestAdminListAudit_ServiceError(t *testing.T) {
+	svc := &mockAdminAuditService{
+		listEventsFn: func(_ context.Context, _, _ int, _ api.AuditFilter) (*api.AdminAuditList, error) {
+			return nil, fmt.Errorf("db down: %w", api.ErrInternalError)
+		},
+	}
+	r := setupAuditRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/audit", nil)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- Response structure ---
+
+func TestAdminListAudit_ResponseContainsAllFields(t *testing.T) {
+	now := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	svc := &mockAdminAuditService{
+		listEventsFn: func(_ context.Context, _, _ int, _ api.AuditFilter) (*api.AdminAuditList, error) {
+			return &api.AdminAuditList{
+				Events: []api.AdminAuditEvent{
+					{
+						ID:        "ev-full",
+						UserID:    "u1",
+						ClientID:  "c1",
+						EventType: "token_refresh",
+						IPAddress: "10.0.0.1",
+						UserAgent: "Go-http-client/1.1",
+						Metadata:  map[string]string{"scope": "read"},
+						CreatedAt: now,
+					},
+				},
+				Total: 1, Page: 1, PerPage: 20,
+			}, nil
+		},
+	}
+	r := setupAuditRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/audit", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminAuditList
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Events, 1)
+
+	ev := resp.Events[0]
+	assert.Equal(t, "ev-full", ev.ID)
+	assert.Equal(t, "u1", ev.UserID)
+	assert.Equal(t, "c1", ev.ClientID)
+	assert.Equal(t, "token_refresh", ev.EventType)
+	assert.Equal(t, "10.0.0.1", ev.IPAddress)
+	assert.Equal(t, "Go-http-client/1.1", ev.UserAgent)
+	assert.Equal(t, "read", ev.Metadata["scope"])
+	assert.True(t, now.Equal(ev.CreatedAt))
+}
+
+// --- Only start_date filter ---
+
+func TestAdminListAudit_FilterByStartDateOnly(t *testing.T) {
+	startStr := "2026-02-15T08:00:00Z"
+	expectedStart, _ := time.Parse(time.RFC3339, startStr)
+
+	svc := &mockAdminAuditService{
+		listEventsFn: func(_ context.Context, _, _ int, filter api.AuditFilter) (*api.AdminAuditList, error) {
+			require.NotNil(t, filter.StartDate)
+			assert.True(t, expectedStart.Equal(*filter.StartDate))
+			assert.Nil(t, filter.EndDate)
+			return &api.AdminAuditList{Events: []api.AdminAuditEvent{}, Total: 0, Page: 1, PerPage: 20}, nil
+		},
+	}
+	r := setupAuditRouter(svc)
+	w := doRequest(r, http.MethodGet, fmt.Sprintf("/admin/audit?start_date=%s", startStr), nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// --- Only end_date filter ---
+
+func TestAdminListAudit_FilterByEndDateOnly(t *testing.T) {
+	endStr := "2026-06-30T23:59:59Z"
+	expectedEnd, _ := time.Parse(time.RFC3339, endStr)
+
+	svc := &mockAdminAuditService{
+		listEventsFn: func(_ context.Context, _, _ int, filter api.AuditFilter) (*api.AdminAuditList, error) {
+			assert.Nil(t, filter.StartDate)
+			require.NotNil(t, filter.EndDate)
+			assert.True(t, expectedEnd.Equal(*filter.EndDate))
+			return &api.AdminAuditList{Events: []api.AdminAuditEvent{}, Total: 0, Page: 1, PerPage: 20}, nil
+		},
+	}
+	r := setupAuditRouter(svc)
+	w := doRequest(r, http.MethodGet, fmt.Sprintf("/admin/audit?end_date=%s", endStr), nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/internal/api/admin_router.go
+++ b/internal/api/admin_router.go
@@ -81,6 +81,12 @@ func NewAdminRouter(svc *AdminServices, deps *AdminDeps) *gin.Engine {
 		admin.POST("/tokens/introspect", tokenH.Introspect)
 	}
 
+	// Audit log.
+	if svc.Audit != nil {
+		auditH := NewAdminAuditHandlers(svc.Audit)
+		admin.GET("/audit", auditH.List)
+	}
+
 	return r
 }
 

--- a/internal/api/admin_services.go
+++ b/internal/api/admin_services.go
@@ -112,6 +112,37 @@ type IntrospectRequest struct {
 	Token string `json:"token" validate:"required"`
 }
 
+// --- Admin audit types ---
+
+// AdminAuditEvent represents a single audit log entry in admin API responses.
+type AdminAuditEvent struct {
+	ID        string    `json:"id"`
+	UserID    string    `json:"user_id,omitempty"`
+	ClientID  string    `json:"client_id,omitempty"`
+	EventType string    `json:"event_type"`
+	IPAddress string    `json:"ip_address,omitempty"`
+	UserAgent string    `json:"user_agent,omitempty"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// AdminAuditList is the paginated response for listing audit events.
+type AdminAuditList struct {
+	Events  []AdminAuditEvent `json:"events"`
+	Total   int               `json:"total"`
+	Page    int               `json:"page"`
+	PerPage int               `json:"per_page"`
+}
+
+// AuditFilter holds filter parameters for querying audit events.
+type AuditFilter struct {
+	UserID    string
+	ClientID  string
+	EventType string
+	StartDate *time.Time
+	EndDate   *time.Time
+}
+
 // --- Admin service interfaces ---
 
 // AdminUserService defines admin operations for user management.
@@ -140,9 +171,15 @@ type AdminTokenService interface {
 	Introspect(ctx context.Context, token string) (*IntrospectionResponse, error)
 }
 
+// AdminAuditService defines admin operations for querying audit logs.
+type AdminAuditService interface {
+	ListEvents(ctx context.Context, page, perPage int, filter AuditFilter) (*AdminAuditList, error)
+}
+
 // AdminServices aggregates all admin service interfaces required by admin API handlers.
 type AdminServices struct {
 	Users   AdminUserService
 	Clients AdminClientService
 	Tokens  AdminTokenService
+	Audit   AdminAuditService
 }

--- a/internal/storage/audit_repository.go
+++ b/internal/storage/audit_repository.go
@@ -1,0 +1,120 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/qf-studio/auth-service/internal/api"
+)
+
+// AuditRepository defines persistence operations for querying audit events.
+type AuditRepository interface {
+	// List returns a paginated list of audit events matching the given filters.
+	List(ctx context.Context, limit, offset int, filter api.AuditFilter) ([]api.AdminAuditEvent, int, error)
+}
+
+// PostgresAuditRepository implements AuditRepository using PostgreSQL.
+type PostgresAuditRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresAuditRepository creates a new PostgreSQL-backed audit repository.
+func NewPostgresAuditRepository(pool *pgxpool.Pool) *PostgresAuditRepository {
+	return &PostgresAuditRepository{pool: pool}
+}
+
+// List queries the audit_events table with optional filters and pagination.
+func (r *PostgresAuditRepository) List(ctx context.Context, limit, offset int, filter api.AuditFilter) ([]api.AdminAuditEvent, int, error) {
+	var conditions []string
+	var args []interface{}
+	argIdx := 1
+
+	if filter.UserID != "" {
+		conditions = append(conditions, fmt.Sprintf("user_id = $%d", argIdx))
+		args = append(args, filter.UserID)
+		argIdx++
+	}
+	if filter.ClientID != "" {
+		conditions = append(conditions, fmt.Sprintf("client_id = $%d", argIdx))
+		args = append(args, filter.ClientID)
+		argIdx++
+	}
+	if filter.EventType != "" {
+		conditions = append(conditions, fmt.Sprintf("event_type = $%d", argIdx))
+		args = append(args, filter.EventType)
+		argIdx++
+	}
+	if filter.StartDate != nil {
+		conditions = append(conditions, fmt.Sprintf("created_at >= $%d", argIdx))
+		args = append(args, filter.StartDate)
+		argIdx++
+	}
+	if filter.EndDate != nil {
+		conditions = append(conditions, fmt.Sprintf("created_at <= $%d", argIdx))
+		args = append(args, filter.EndDate)
+		argIdx++
+	}
+
+	where := ""
+	if len(conditions) > 0 {
+		where = "WHERE " + strings.Join(conditions, " AND ")
+	}
+
+	// Count total matching rows.
+	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM audit_events %s", where)
+	var total int
+	if err := r.pool.QueryRow(ctx, countQuery, args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count audit events: %w", err)
+	}
+
+	// Fetch the page.
+	dataQuery := fmt.Sprintf(
+		"SELECT id, user_id, client_id, event_type, ip_address, user_agent, metadata, created_at FROM audit_events %s ORDER BY created_at DESC LIMIT $%d OFFSET $%d",
+		where, argIdx, argIdx+1,
+	)
+	args = append(args, limit, offset)
+
+	rows, err := r.pool.Query(ctx, dataQuery, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("query audit events: %w", err)
+	}
+	defer rows.Close()
+
+	events := make([]api.AdminAuditEvent, 0)
+	for rows.Next() {
+		var e api.AdminAuditEvent
+		var userID, clientID, ipAddress, userAgent *string
+		var metadata map[string]string
+		var createdAt time.Time
+
+		if err := rows.Scan(&e.ID, &userID, &clientID, &e.EventType, &ipAddress, &userAgent, &metadata, &createdAt); err != nil {
+			return nil, 0, fmt.Errorf("scan audit event: %w", err)
+		}
+
+		if userID != nil {
+			e.UserID = *userID
+		}
+		if clientID != nil {
+			e.ClientID = *clientID
+		}
+		if ipAddress != nil {
+			e.IPAddress = *ipAddress
+		}
+		if userAgent != nil {
+			e.UserAgent = *userAgent
+		}
+		e.Metadata = metadata
+		e.CreatedAt = createdAt
+		events = append(events, e)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate audit events: %w", err)
+	}
+
+	return events, total, nil
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-181.

Closes #181

## Changes

Add `AdminAuditService` interface to `internal/api/admin_services.go`, implement `GET /admin/audit` handler in new `internal/api/admin_audit_handlers.go` with pagination and filters (user_id, event_type, date range, client_id), register the route in `internal/api/admin_router.go`, add the audit service to `AdminServices` struct, and complete the wiring in `cmd/server/main.go`. Include handler tests covering filter combinations, pagination edge cases, and empty results.