### PR TITLE
GH-185: Session domain model and Redis-backed session service

### DIFF
--- a/internal/domain/sentinel_errors.go
+++ b/internal/domain/sentinel_errors.go
@@ -20,6 +20,10 @@ var (
 	ErrClientNotFound  = errors.New("client not found")
 	ErrClientSuspended = errors.New("client suspended")
 
+	// Session errors.
+	ErrSessionNotFound = errors.New("session not found")
+	ErrSessionExpired  = errors.New("session expired")
+
 	// Authorization errors.
 	ErrInsufficientScope = errors.New("insufficient scope")
 	ErrInsufficientRole  = errors.New("insufficient role")

--- a/internal/domain/session.go
+++ b/internal/domain/session.go
@@ -1,0 +1,15 @@
+package domain
+
+import "time"
+
+// Session represents an active user session with device and location metadata.
+type Session struct {
+	ID                string    `json:"session_id"`
+	UserID            string    `json:"user_id"`
+	DeviceFingerprint string    `json:"device_fingerprint"`
+	IP                string    `json:"ip"`
+	UserAgent         string    `json:"user_agent"`
+	RefreshTokenJTI   string    `json:"refresh_token_jti"`
+	CreatedAt         time.Time `json:"created_at"`
+	LastActivityAt    time.Time `json:"last_activity_at"`
+}

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -1,0 +1,252 @@
+// Package session provides session management backed by Redis.
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+const (
+	// sessKeyPrefix is the Redis key prefix for individual session data.
+	sessKeyPrefix = "sess:"
+
+	// userSessKeyPrefix is the Redis key prefix for the set of session IDs per user.
+	userSessKeyPrefix = "user_sess:"
+
+	// defaultSessionTTL is the maximum lifetime of a session (24 hours).
+	defaultSessionTTL = 24 * time.Hour
+)
+
+// SessionService defines the session management operations.
+type SessionService interface {
+	CreateSession(ctx context.Context, session *domain.Session) (*domain.Session, error)
+	GetSession(ctx context.Context, sessionID string) (*domain.Session, error)
+	ListSessions(ctx context.Context, userID string) ([]*domain.Session, error)
+	UpdateActivity(ctx context.Context, sessionID string) error
+	RevokeSession(ctx context.Context, userID, sessionID string) error
+	RevokeAllSessions(ctx context.Context, userID string) error
+}
+
+// Service implements SessionService using Redis as the backing store.
+type Service struct {
+	redis  *redis.Client
+	logger *zap.Logger
+}
+
+// NewService creates a new session Service.
+func NewService(redisClient *redis.Client, logger *zap.Logger) *Service {
+	return &Service{
+		redis:  redisClient,
+		logger: logger,
+	}
+}
+
+// CreateSession stores a new session in Redis with a 24h TTL.
+// It generates a session ID if one is not set.
+func (s *Service) CreateSession(ctx context.Context, session *domain.Session) (*domain.Session, error) {
+	if session.ID == "" {
+		session.ID = uuid.NewString()
+	}
+
+	now := time.Now()
+	session.CreatedAt = now
+	session.LastActivityAt = now
+
+	data, err := json.Marshal(session)
+	if err != nil {
+		return nil, fmt.Errorf("marshal session: %w", err)
+	}
+
+	sessKey := sessKeyPrefix + session.ID
+	userKey := userSessKeyPrefix + session.UserID
+
+	pipe := s.redis.Pipeline()
+	pipe.Set(ctx, sessKey, data, defaultSessionTTL)
+	pipe.SAdd(ctx, userKey, session.ID)
+	pipe.Expire(ctx, userKey, defaultSessionTTL)
+	if _, err := pipe.Exec(ctx); err != nil {
+		return nil, fmt.Errorf("create session: %w", err)
+	}
+
+	s.logger.Info("session created",
+		zap.String("session_id", session.ID),
+		zap.String("user_id", session.UserID),
+	)
+
+	return session, nil
+}
+
+// GetSession retrieves a session by ID from Redis.
+func (s *Service) GetSession(ctx context.Context, sessionID string) (*domain.Session, error) {
+	sessKey := sessKeyPrefix + sessionID
+
+	data, err := s.redis.Get(ctx, sessKey).Bytes()
+	if err == redis.Nil {
+		return nil, domain.ErrSessionNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get session: %w", err)
+	}
+
+	var session domain.Session
+	if err := json.Unmarshal(data, &session); err != nil {
+		return nil, fmt.Errorf("unmarshal session: %w", err)
+	}
+
+	return &session, nil
+}
+
+// ListSessions returns all active sessions for a user.
+func (s *Service) ListSessions(ctx context.Context, userID string) ([]*domain.Session, error) {
+	userKey := userSessKeyPrefix + userID
+
+	sessionIDs, err := s.redis.SMembers(ctx, userKey).Result()
+	if err != nil {
+		return nil, fmt.Errorf("list session IDs: %w", err)
+	}
+
+	if len(sessionIDs) == 0 {
+		return []*domain.Session{}, nil
+	}
+
+	// Build keys for MGET.
+	keys := make([]string, len(sessionIDs))
+	for i, id := range sessionIDs {
+		keys[i] = sessKeyPrefix + id
+	}
+
+	values, err := s.redis.MGet(ctx, keys...).Result()
+	if err != nil {
+		return nil, fmt.Errorf("get sessions: %w", err)
+	}
+
+	// Collect valid sessions and clean up expired references.
+	sessions := make([]*domain.Session, 0, len(values))
+	var expired []string
+	for i, val := range values {
+		if val == nil {
+			// Session key expired but still in the user set.
+			expired = append(expired, sessionIDs[i])
+			continue
+		}
+
+		str, ok := val.(string)
+		if !ok {
+			continue
+		}
+
+		var sess domain.Session
+		if err := json.Unmarshal([]byte(str), &sess); err != nil {
+			s.logger.Warn("failed to unmarshal session", zap.String("session_id", sessionIDs[i]), zap.Error(err))
+			continue
+		}
+		sessions = append(sessions, &sess)
+	}
+
+	// Clean up stale references from the user set.
+	if len(expired) > 0 {
+		members := make([]interface{}, len(expired))
+		for i, id := range expired {
+			members[i] = id
+		}
+		if err := s.redis.SRem(ctx, userKey, members...).Err(); err != nil {
+			s.logger.Warn("failed to clean expired session refs", zap.Error(err))
+		}
+	}
+
+	return sessions, nil
+}
+
+// UpdateActivity refreshes the last activity timestamp and resets the TTL.
+func (s *Service) UpdateActivity(ctx context.Context, sessionID string) error {
+	sessKey := sessKeyPrefix + sessionID
+
+	data, err := s.redis.Get(ctx, sessKey).Bytes()
+	if err == redis.Nil {
+		return domain.ErrSessionNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("get session for update: %w", err)
+	}
+
+	var session domain.Session
+	if err := json.Unmarshal(data, &session); err != nil {
+		return fmt.Errorf("unmarshal session: %w", err)
+	}
+
+	session.LastActivityAt = time.Now()
+
+	updated, err := json.Marshal(&session)
+	if err != nil {
+		return fmt.Errorf("marshal updated session: %w", err)
+	}
+
+	if err := s.redis.Set(ctx, sessKey, updated, defaultSessionTTL).Err(); err != nil {
+		return fmt.Errorf("update session activity: %w", err)
+	}
+
+	return nil
+}
+
+// RevokeSession removes a single session for a user.
+func (s *Service) RevokeSession(ctx context.Context, userID, sessionID string) error {
+	sessKey := sessKeyPrefix + sessionID
+	userKey := userSessKeyPrefix + userID
+
+	pipe := s.redis.Pipeline()
+	pipe.Del(ctx, sessKey)
+	pipe.SRem(ctx, userKey, sessionID)
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("revoke session: %w", err)
+	}
+
+	s.logger.Info("session revoked",
+		zap.String("session_id", sessionID),
+		zap.String("user_id", userID),
+	)
+
+	return nil
+}
+
+// RevokeAllSessions removes all sessions for a user.
+func (s *Service) RevokeAllSessions(ctx context.Context, userID string) error {
+	userKey := userSessKeyPrefix + userID
+
+	sessionIDs, err := s.redis.SMembers(ctx, userKey).Result()
+	if err != nil {
+		return fmt.Errorf("list sessions for revocation: %w", err)
+	}
+
+	if len(sessionIDs) == 0 {
+		return nil
+	}
+
+	// Delete all session keys + the user set in one pipeline.
+	keys := make([]string, 0, len(sessionIDs)+1)
+	for _, id := range sessionIDs {
+		keys = append(keys, sessKeyPrefix+id)
+	}
+	keys = append(keys, userKey)
+
+	if err := s.redis.Del(ctx, keys...).Err(); err != nil {
+		return fmt.Errorf("revoke all sessions: %w", err)
+	}
+
+	s.logger.Info("all sessions revoked",
+		zap.String("user_id", userID),
+		zap.Int("count", len(sessionIDs)),
+	)
+
+	return nil
+}
+
+// Ensure Service implements SessionService at compile time.
+var _ SessionService = (*Service)(nil)

--- a/internal/session/service_test.go
+++ b/internal/session/service_test.go
@@ -1,0 +1,477 @@
+package session_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/session"
+)
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+func newTestRedis(t *testing.T) (*miniredis.Miniredis, *redis.Client) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return mr, client
+}
+
+func testLogger() *zap.Logger {
+	return zap.NewNop()
+}
+
+func newTestService(t *testing.T) (*session.Service, *miniredis.Miniredis) {
+	t.Helper()
+	mr, rc := newTestRedis(t)
+	svc := session.NewService(rc, testLogger())
+	return svc, mr
+}
+
+func newSession(userID string) *domain.Session {
+	return &domain.Session{
+		UserID:            userID,
+		DeviceFingerprint: "fp-abc123",
+		IP:                "192.168.1.1",
+		UserAgent:         "Mozilla/5.0 (test)",
+		RefreshTokenJTI:   "jti-xyz789",
+	}
+}
+
+// ── CreateSession ────────────────────────────────────────────────────────────
+
+func TestCreateSession(t *testing.T) {
+	tests := []struct {
+		name    string
+		session *domain.Session
+	}{
+		{
+			name:    "creates session with generated ID",
+			session: newSession("user-1"),
+		},
+		{
+			name: "creates session with provided ID",
+			session: &domain.Session{
+				ID:                "custom-id",
+				UserID:            "user-2",
+				DeviceFingerprint: "fp-def456",
+				IP:                "10.0.0.1",
+				UserAgent:         "curl/7.68",
+				RefreshTokenJTI:   "jti-abc",
+			},
+		},
+		{
+			name: "creates session with minimal fields",
+			session: &domain.Session{
+				UserID: "user-3",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, _ := newTestService(t)
+			ctx := context.Background()
+
+			result, err := svc.CreateSession(ctx, tt.session)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			assert.NotEmpty(t, result.ID)
+			assert.Equal(t, tt.session.UserID, result.UserID)
+			assert.False(t, result.CreatedAt.IsZero())
+			assert.False(t, result.LastActivityAt.IsZero())
+			assert.Equal(t, result.CreatedAt, result.LastActivityAt)
+
+			if tt.session.ID != "" {
+				assert.Equal(t, tt.session.ID, result.ID)
+			}
+		})
+	}
+}
+
+func TestCreateSession_Retrievable(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+
+	created, err := svc.CreateSession(ctx, newSession("user-1"))
+	require.NoError(t, err)
+
+	got, err := svc.GetSession(ctx, created.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, created.ID, got.ID)
+	assert.Equal(t, created.UserID, got.UserID)
+	assert.Equal(t, created.DeviceFingerprint, got.DeviceFingerprint)
+	assert.Equal(t, created.IP, got.IP)
+	assert.Equal(t, created.UserAgent, got.UserAgent)
+	assert.Equal(t, created.RefreshTokenJTI, got.RefreshTokenJTI)
+}
+
+// ── GetSession ───────────────────────────────────────────────────────────────
+
+func TestGetSession_NotFound(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+
+	_, err := svc.GetSession(ctx, "nonexistent-id")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrSessionNotFound)
+}
+
+func TestGetSession_Expired(t *testing.T) {
+	svc, mr := newTestService(t)
+	ctx := context.Background()
+
+	created, err := svc.CreateSession(ctx, newSession("user-1"))
+	require.NoError(t, err)
+
+	// Fast-forward past the 24h TTL.
+	mr.FastForward(25 * time.Hour)
+
+	_, err = svc.GetSession(ctx, created.ID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrSessionNotFound)
+}
+
+// ── ListSessions ─────────────────────────────────────────────────────────────
+
+func TestListSessions(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupCount    int
+		expectedCount int
+	}{
+		{
+			name:          "no sessions returns empty slice",
+			setupCount:    0,
+			expectedCount: 0,
+		},
+		{
+			name:          "single session",
+			setupCount:    1,
+			expectedCount: 1,
+		},
+		{
+			name:          "multiple sessions",
+			setupCount:    3,
+			expectedCount: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, _ := newTestService(t)
+			ctx := context.Background()
+			userID := "user-list"
+
+			for i := 0; i < tt.setupCount; i++ {
+				sess := newSession(userID)
+				sess.IP = "10.0.0." + string(rune('1'+i))
+				_, err := svc.CreateSession(ctx, sess)
+				require.NoError(t, err)
+			}
+
+			sessions, err := svc.ListSessions(ctx, userID)
+			require.NoError(t, err)
+			assert.Len(t, sessions, tt.expectedCount)
+		})
+	}
+}
+
+func TestListSessions_OnlyReturnsUserSessions(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+
+	// Create sessions for two different users.
+	for i := 0; i < 3; i++ {
+		_, err := svc.CreateSession(ctx, newSession("user-A"))
+		require.NoError(t, err)
+	}
+	for i := 0; i < 2; i++ {
+		_, err := svc.CreateSession(ctx, newSession("user-B"))
+		require.NoError(t, err)
+	}
+
+	sessionsA, err := svc.ListSessions(ctx, "user-A")
+	require.NoError(t, err)
+	assert.Len(t, sessionsA, 3)
+
+	sessionsB, err := svc.ListSessions(ctx, "user-B")
+	require.NoError(t, err)
+	assert.Len(t, sessionsB, 2)
+}
+
+func TestListSessions_CleansExpiredReferences(t *testing.T) {
+	svc, mr := newTestService(t)
+	ctx := context.Background()
+	userID := "user-cleanup"
+
+	// Create a session.
+	created, err := svc.CreateSession(ctx, newSession(userID))
+	require.NoError(t, err)
+
+	// Expire the session key directly but leave the user set entry.
+	mr.FastForward(25 * time.Hour)
+
+	// Create a fresh session (user set still has stale + new entry).
+	fresh := newSession(userID)
+	_, err = svc.CreateSession(ctx, fresh)
+	require.NoError(t, err)
+
+	// ListSessions should return only the fresh session and clean up the stale ref.
+	sessions, err := svc.ListSessions(ctx, userID)
+	require.NoError(t, err)
+	assert.Len(t, sessions, 1)
+	assert.NotEqual(t, created.ID, sessions[0].ID)
+}
+
+// ── UpdateActivity ───────────────────────────────────────────────────────────
+
+func TestUpdateActivity(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+
+	created, err := svc.CreateSession(ctx, newSession("user-1"))
+	require.NoError(t, err)
+
+	// Wait a tiny bit to ensure time difference.
+	time.Sleep(5 * time.Millisecond)
+
+	err = svc.UpdateActivity(ctx, created.ID)
+	require.NoError(t, err)
+
+	updated, err := svc.GetSession(ctx, created.ID)
+	require.NoError(t, err)
+
+	assert.True(t, updated.LastActivityAt.After(created.LastActivityAt),
+		"last_activity_at should be updated")
+	assert.True(t, created.CreatedAt.Equal(updated.CreatedAt),
+		"created_at should not change")
+}
+
+func TestUpdateActivity_NotFound(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+
+	err := svc.UpdateActivity(ctx, "nonexistent-id")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrSessionNotFound)
+}
+
+func TestUpdateActivity_ResetsTTL(t *testing.T) {
+	svc, mr := newTestService(t)
+	ctx := context.Background()
+
+	created, err := svc.CreateSession(ctx, newSession("user-1"))
+	require.NoError(t, err)
+
+	// Advance 23 hours (nearly expired).
+	mr.FastForward(23 * time.Hour)
+
+	// Update activity should reset TTL.
+	err = svc.UpdateActivity(ctx, created.ID)
+	require.NoError(t, err)
+
+	// Advance another 23 hours (would be 46h total, but TTL was reset).
+	mr.FastForward(23 * time.Hour)
+
+	// Session should still be accessible.
+	got, err := svc.GetSession(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, got.ID)
+}
+
+// ── RevokeSession ────────────────────────────────────────────────────────────
+
+func TestRevokeSession(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+	userID := "user-1"
+
+	created, err := svc.CreateSession(ctx, newSession(userID))
+	require.NoError(t, err)
+
+	err = svc.RevokeSession(ctx, userID, created.ID)
+	require.NoError(t, err)
+
+	// Session should no longer be retrievable.
+	_, err = svc.GetSession(ctx, created.ID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrSessionNotFound)
+
+	// Should not appear in user's session list.
+	sessions, err := svc.ListSessions(ctx, userID)
+	require.NoError(t, err)
+	assert.Len(t, sessions, 0)
+}
+
+func TestRevokeSession_DoesNotAffectOtherSessions(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+	userID := "user-1"
+
+	sess1, err := svc.CreateSession(ctx, newSession(userID))
+	require.NoError(t, err)
+
+	sess2, err := svc.CreateSession(ctx, newSession(userID))
+	require.NoError(t, err)
+
+	// Revoke only the first session.
+	err = svc.RevokeSession(ctx, userID, sess1.ID)
+	require.NoError(t, err)
+
+	// Second session should still exist.
+	got, err := svc.GetSession(ctx, sess2.ID)
+	require.NoError(t, err)
+	assert.Equal(t, sess2.ID, got.ID)
+
+	sessions, err := svc.ListSessions(ctx, userID)
+	require.NoError(t, err)
+	assert.Len(t, sessions, 1)
+}
+
+func TestRevokeSession_NonexistentIsIdempotent(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+
+	// Revoking a nonexistent session should not error.
+	err := svc.RevokeSession(ctx, "user-1", "nonexistent-id")
+	require.NoError(t, err)
+}
+
+// ── RevokeAllSessions ────────────────────────────────────────────────────────
+
+func TestRevokeAllSessions(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+	userID := "user-1"
+
+	// Create multiple sessions.
+	for i := 0; i < 5; i++ {
+		_, err := svc.CreateSession(ctx, newSession(userID))
+		require.NoError(t, err)
+	}
+
+	sessions, err := svc.ListSessions(ctx, userID)
+	require.NoError(t, err)
+	assert.Len(t, sessions, 5)
+
+	// Revoke all.
+	err = svc.RevokeAllSessions(ctx, userID)
+	require.NoError(t, err)
+
+	// All should be gone.
+	sessions, err = svc.ListSessions(ctx, userID)
+	require.NoError(t, err)
+	assert.Len(t, sessions, 0)
+}
+
+func TestRevokeAllSessions_DoesNotAffectOtherUsers(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		_, err := svc.CreateSession(ctx, newSession("user-A"))
+		require.NoError(t, err)
+	}
+	_, err := svc.CreateSession(ctx, newSession("user-B"))
+	require.NoError(t, err)
+
+	// Revoke all for user-A.
+	err = svc.RevokeAllSessions(ctx, "user-A")
+	require.NoError(t, err)
+
+	// user-B should be unaffected.
+	sessions, err := svc.ListSessions(ctx, "user-B")
+	require.NoError(t, err)
+	assert.Len(t, sessions, 1)
+}
+
+func TestRevokeAllSessions_NoSessionsIsNoop(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+
+	err := svc.RevokeAllSessions(ctx, "user-no-sessions")
+	require.NoError(t, err)
+}
+
+// ── End-to-end ───────────────────────────────────────────────────────────────
+
+func TestEndToEnd_FullSessionLifecycle(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+	userID := "user-e2e"
+
+	// 1. Create session.
+	created, err := svc.CreateSession(ctx, &domain.Session{
+		UserID:            userID,
+		DeviceFingerprint: "fp-e2e",
+		IP:                "203.0.113.1",
+		UserAgent:         "TestBrowser/1.0",
+		RefreshTokenJTI:   "jti-e2e",
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, created.ID)
+
+	// 2. Get session.
+	got, err := svc.GetSession(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, userID, got.UserID)
+	assert.Equal(t, "fp-e2e", got.DeviceFingerprint)
+	assert.Equal(t, "203.0.113.1", got.IP)
+	assert.Equal(t, "TestBrowser/1.0", got.UserAgent)
+	assert.Equal(t, "jti-e2e", got.RefreshTokenJTI)
+
+	// 3. List sessions.
+	sessions, err := svc.ListSessions(ctx, userID)
+	require.NoError(t, err)
+	assert.Len(t, sessions, 1)
+
+	// 4. Update activity.
+	time.Sleep(5 * time.Millisecond)
+	err = svc.UpdateActivity(ctx, created.ID)
+	require.NoError(t, err)
+
+	updated, err := svc.GetSession(ctx, created.ID)
+	require.NoError(t, err)
+	assert.True(t, updated.LastActivityAt.After(created.LastActivityAt))
+
+	// 5. Create a second session.
+	sess2, err := svc.CreateSession(ctx, &domain.Session{
+		UserID:          userID,
+		IP:              "198.51.100.1",
+		UserAgent:       "MobileApp/2.0",
+		RefreshTokenJTI: "jti-mobile",
+	})
+	require.NoError(t, err)
+
+	sessions, err = svc.ListSessions(ctx, userID)
+	require.NoError(t, err)
+	assert.Len(t, sessions, 2)
+
+	// 6. Revoke first session.
+	err = svc.RevokeSession(ctx, userID, created.ID)
+	require.NoError(t, err)
+
+	sessions, err = svc.ListSessions(ctx, userID)
+	require.NoError(t, err)
+	assert.Len(t, sessions, 1)
+	assert.Equal(t, sess2.ID, sessions[0].ID)
+
+	// 7. Revoke all remaining.
+	err = svc.RevokeAllSessions(ctx, userID)
+	require.NoError(t, err)
+
+	sessions, err = svc.ListSessions(ctx, userID)
+	require.NoError(t, err)
+	assert.Len(t, sessions, 0)
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-185.

Closes #185

## Changes

Define the `Session` struct in `internal/domain/` (user_id, session_id, device_fingerprint, ip, user_agent, created_at, last_activity_at, refresh_token_jti). Implement the full session package in `internal/session/`: Redis-backed store with TTL (24h overall), `CreateSession`, `GetSession`, `ListSessions(ctx, userID)`, `UpdateActivity(ctx, sessionID)`, `RevokeSession(ctx, userID, sessionID)`, `RevokeAllSessions(ctx, userID)`. Follow existing patterns — interface-driven design like `TokenService`, inject `*redis.Client`, use key prefixes (e.g. `sess:`, `user_sess:`). Include comprehensive unit tests with table-driven style and testify.