### PR TITLE
GH-186: Inactivity check middleware

### DIFF
--- a/internal/domain/sentinel_errors.go
+++ b/internal/domain/sentinel_errors.go
@@ -20,6 +20,9 @@ var (
 	ErrClientNotFound  = errors.New("client not found")
 	ErrClientSuspended = errors.New("client suspended")
 
+	// Session errors.
+	ErrSessionInactive = errors.New("session inactive due to inactivity")
+
 	// Authorization errors.
 	ErrInsufficientScope = errors.New("insufficient scope")
 	ErrInsufficientRole  = errors.New("insufficient role")

--- a/internal/middleware/session_activity.go
+++ b/internal/middleware/session_activity.go
@@ -1,0 +1,69 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// DefaultInactivityThreshold is the maximum allowed duration since last
+// session activity before the session is considered inactive.
+const DefaultInactivityThreshold = 1 * time.Hour
+
+// SessionChecker defines the session operations required by SessionActivity
+// middleware. The session service implements this interface.
+type SessionChecker interface {
+	// LastActivityAt returns the last activity timestamp for the given user's
+	// session. Returns an error if the session does not exist.
+	LastActivityAt(ctx context.Context, userID string) (time.Time, error)
+
+	// UpdateActivity updates the last activity timestamp for the given user's
+	// session to the current time.
+	UpdateActivity(ctx context.Context, userID string) error
+}
+
+// SessionActivity returns a Gin middleware that enforces session inactivity
+// timeouts. It must be placed after AuthMiddleware so that claims and user_id
+// are available in context.
+//
+// On each request it:
+//  1. Retrieves the user ID from context (set by AuthMiddleware)
+//  2. Checks last_activity_at via SessionChecker
+//  3. If the elapsed time exceeds the inactivity threshold, returns 401
+//     requiring reauthentication
+//  4. Otherwise updates last_activity_at via SessionChecker
+func SessionActivity(checker SessionChecker, threshold time.Duration) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID := c.GetString(userIDContextKey)
+		if userID == "" {
+			domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized,
+				"authentication required")
+			return
+		}
+
+		lastActivity, err := checker.LastActivityAt(c.Request.Context(), userID)
+		if err != nil {
+			domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized,
+				"session not found")
+			return
+		}
+
+		if time.Since(lastActivity) > threshold {
+			domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized,
+				"session expired due to inactivity, please reauthenticate")
+			return
+		}
+
+		if err := checker.UpdateActivity(c.Request.Context(), userID); err != nil {
+			domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized,
+				"failed to update session activity")
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/internal/middleware/session_activity_test.go
+++ b/internal/middleware/session_activity_test.go
@@ -1,0 +1,177 @@
+package middleware_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/middleware"
+)
+
+// mockSessionChecker implements middleware.SessionChecker for testing.
+type mockSessionChecker struct {
+	lastActivity    time.Time
+	lastActivityErr error
+	updateErr       error
+	updatedUserID   string
+}
+
+func (m *mockSessionChecker) LastActivityAt(_ context.Context, _ string) (time.Time, error) {
+	return m.lastActivity, m.lastActivityErr
+}
+
+func (m *mockSessionChecker) UpdateActivity(_ context.Context, userID string) error {
+	m.updatedUserID = userID
+	return m.updateErr
+}
+
+// newSessionActivityTestRouter creates a router with AuthMiddleware + SessionActivity.
+func newSessionActivityTestRouter(v middleware.TokenValidator, sc middleware.SessionChecker, threshold time.Duration) *gin.Engine {
+	r := gin.New()
+	r.Use(middleware.AuthMiddleware(v))
+	r.Use(middleware.SessionActivity(sc, threshold))
+	r.GET("/protected", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+	return r
+}
+
+func TestSessionActivity(t *testing.T) {
+	validClaims := &domain.TokenClaims{
+		Subject:    "user-123",
+		Roles:      []string{"user"},
+		ClientType: domain.ClientTypeUser,
+		TokenID:    "tok-abc",
+	}
+	threshold := 1 * time.Hour
+
+	tests := []struct {
+		name             string
+		authHeader       string
+		validator        *mockValidator
+		checker          *mockSessionChecker
+		wantStatus       int
+		wantBodyContains string
+		wantUpdated      bool
+	}{
+		{
+			name:       "active session passes and activity updated",
+			authHeader: "Bearer qf_at_validtoken",
+			validator:  &mockValidator{claims: validClaims},
+			checker: &mockSessionChecker{
+				lastActivity: time.Now().Add(-30 * time.Minute), // 30 min ago, within threshold
+			},
+			wantStatus:       http.StatusOK,
+			wantBodyContains: "ok",
+			wantUpdated:      true,
+		},
+		{
+			name:       "inactive session rejected with 401",
+			authHeader: "Bearer qf_at_validtoken",
+			validator:  &mockValidator{claims: validClaims},
+			checker: &mockSessionChecker{
+				lastActivity: time.Now().Add(-2 * time.Hour), // 2 hours ago, exceeds threshold
+			},
+			wantStatus:       http.StatusUnauthorized,
+			wantBodyContains: "reauthenticate",
+			wantUpdated:      false,
+		},
+		{
+			name:       "session exactly at threshold boundary is rejected",
+			authHeader: "Bearer qf_at_validtoken",
+			validator:  &mockValidator{claims: validClaims},
+			checker: &mockSessionChecker{
+				lastActivity: time.Now().Add(-1*time.Hour - 1*time.Second), // just past threshold
+			},
+			wantStatus:       http.StatusUnauthorized,
+			wantBodyContains: "reauthenticate",
+			wantUpdated:      false,
+		},
+		{
+			name:       "session not found returns 401",
+			authHeader: "Bearer qf_at_validtoken",
+			validator:  &mockValidator{claims: validClaims},
+			checker: &mockSessionChecker{
+				lastActivityErr: errors.New("session not found"),
+			},
+			wantStatus:       http.StatusUnauthorized,
+			wantBodyContains: "session not found",
+			wantUpdated:      false,
+		},
+		{
+			name:       "update activity failure returns 401",
+			authHeader: "Bearer qf_at_validtoken",
+			validator:  &mockValidator{claims: validClaims},
+			checker: &mockSessionChecker{
+				lastActivity: time.Now().Add(-5 * time.Minute),
+				updateErr:    errors.New("redis unavailable"),
+			},
+			wantStatus:       http.StatusUnauthorized,
+			wantBodyContains: "failed to update session activity",
+			wantUpdated:      true, // UpdateActivity is called but returns error
+		},
+		{
+			name:       "no auth token returns 401 from auth middleware before session check",
+			authHeader: "",
+			validator:  &mockValidator{claims: validClaims},
+			checker: &mockSessionChecker{
+				lastActivity: time.Now(),
+			},
+			wantStatus:  http.StatusUnauthorized,
+			wantUpdated: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			router := newSessionActivityTestRouter(tc.validator, tc.checker, threshold)
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/protected", http.NoBody)
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+			if tc.wantBodyContains != "" {
+				assert.Contains(t, w.Body.String(), tc.wantBodyContains)
+			}
+			if tc.wantUpdated {
+				assert.Equal(t, "user-123", tc.checker.updatedUserID,
+					"UpdateActivity should have been called with the user ID")
+			} else if tc.checker.updatedUserID != "" && !tc.wantUpdated {
+				t.Errorf("UpdateActivity should not have been called, but was called with %q",
+					tc.checker.updatedUserID)
+			}
+		})
+	}
+}
+
+func TestSessionActivity_WithoutAuthMiddleware(t *testing.T) {
+	// Test that SessionActivity returns 401 when no user_id is in context
+	// (i.e., when AuthMiddleware has not run).
+	checker := &mockSessionChecker{
+		lastActivity: time.Now(),
+	}
+
+	r := gin.New()
+	r.Use(middleware.SessionActivity(checker, 1*time.Hour))
+	r.GET("/protected", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/protected", http.NoBody)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Contains(t, w.Body.String(), "authentication required")
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-186.

Closes #186

## Changes

Add session-activity middleware in `internal/middleware/` that intercepts authenticated requests, checks `last_activity_at` against the 1h inactivity threshold, returns 401 with reauth requirement if exceeded, and updates `last_activity_at` on the session via the session service on valid requests. Define a `SessionChecker` interface in the middleware package (following the existing `TokenValidator` pattern in `auth.go`). Include unit tests covering: active session passes, inactive session rejected, activity timestamp updated.