### PR TITLE
GH-191: Email sender package and configuration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,15 @@ type Config struct {
 	TLS          TLSConfig
 	CORS         CORSConfig
 	RequestLimit RequestLimitConfig
+	Email        EmailConfig
+}
+
+// EmailConfig holds outbound email delivery settings.
+type EmailConfig struct {
+	ServiceURL    string // EMAIL_SERVICE_URL: base URL of the email-service
+	APIKey        string // EMAIL_API_KEY: bearer token for the email-service API
+	SenderAddress string // EMAIL_SENDER_ADDRESS: the From address on outgoing mail
+	Enabled       bool   // EMAIL_ENABLED: false → skip delivery (useful in dev/test)
 }
 
 // AppConfig holds server-level settings.
@@ -194,6 +203,10 @@ func Load() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	email, err := loadEmail(l)
+	if err != nil {
+		return nil, err
+	}
 
 	if len(l.missing) > 0 {
 		return nil, fmt.Errorf("missing required environment variables: %s", strings.Join(l.missing, ", "))
@@ -213,6 +226,7 @@ func Load() (*Config, error) {
 		TLS:          tls,
 		CORS:         cors,
 		RequestLimit: reqLimit,
+		Email:        email,
 	}, nil
 }
 
@@ -434,6 +448,24 @@ func loadRequestLimit(l *loader) (RequestLimitConfig, error) {
 	return RequestLimitConfig{
 		MaxBodySize:    int64(maxBodySize), //nolint:gosec // non-negative validated by optInt
 		RequestTimeout: requestTimeout,
+	}, nil
+}
+
+func loadEmail(l *loader) (EmailConfig, error) {
+	serviceURL := l.optStr("EMAIL_SERVICE_URL", "")
+	apiKey := l.optStr("EMAIL_API_KEY", "")
+	senderAddress := l.optStr("EMAIL_SENDER_ADDRESS", "")
+
+	enabled, err := l.optBool("EMAIL_ENABLED", false)
+	if err != nil {
+		return EmailConfig{}, err
+	}
+
+	return EmailConfig{
+		ServiceURL:    serviceURL,
+		APIKey:        apiKey,
+		SenderAddress: senderAddress,
+		Enabled:       enabled,
 	}, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -81,6 +81,29 @@ func TestLoad_AllDefaults(t *testing.T) {
 
 	// CORS
 	assert.Equal(t, []string{"https://example.com"}, cfg.CORS.AllowedOrigins)
+
+	// Email defaults
+	assert.Equal(t, "", cfg.Email.ServiceURL)
+	assert.Equal(t, "", cfg.Email.APIKey)
+	assert.Equal(t, "", cfg.Email.SenderAddress)
+	assert.False(t, cfg.Email.Enabled)
+}
+
+func TestLoad_EmailConfig(t *testing.T) {
+	env := requiredEnv()
+	env["EMAIL_SERVICE_URL"] = "https://email.internal"
+	env["EMAIL_API_KEY"] = "secret-key"
+	env["EMAIL_SENDER_ADDRESS"] = "noreply@example.com"
+	env["EMAIL_ENABLED"] = "true"
+	setEnv(t, env)
+
+	cfg, err := Load()
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://email.internal", cfg.Email.ServiceURL)
+	assert.Equal(t, "secret-key", cfg.Email.APIKey)
+	assert.Equal(t, "noreply@example.com", cfg.Email.SenderAddress)
+	assert.True(t, cfg.Email.Enabled)
 }
 
 func TestLoad_CustomValues(t *testing.T) {

--- a/internal/email/console.go
+++ b/internal/email/console.go
@@ -1,0 +1,28 @@
+package email
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+// ConsoleSender implements EmailSender by writing the message to the zap logger.
+// Intended for development and test environments where email delivery is not required.
+type ConsoleSender struct {
+	logger *zap.Logger
+}
+
+// NewConsoleSender returns a ConsoleSender backed by the given logger.
+func NewConsoleSender(logger *zap.Logger) *ConsoleSender {
+	return &ConsoleSender{logger: logger}
+}
+
+// Send logs the email message at info level. It never returns an error.
+func (s *ConsoleSender) Send(_ context.Context, msg Message) error {
+	s.logger.Info("email (console)",
+		zap.String("to", msg.To),
+		zap.String("subject", msg.Subject),
+		zap.String("body", msg.Body),
+	)
+	return nil
+}

--- a/internal/email/email.go
+++ b/internal/email/email.go
@@ -1,0 +1,21 @@
+// Package email provides an interface and implementations for sending transactional emails.
+//
+// Two implementations are available:
+//   - ConsoleSender: logs the message via zap (development / testing)
+//   - HTTPSender:    delivers via the email-service REST API (production)
+package email
+
+import "context"
+
+// Message is the payload passed to EmailSender.Send.
+type Message struct {
+	To      string
+	Subject string
+	Body    string
+}
+
+// EmailSender is the single method expected by callers that need to send email.
+// Both ConsoleSender and HTTPSender satisfy this interface.
+type EmailSender interface {
+	Send(ctx context.Context, msg Message) error
+}

--- a/internal/email/email_test.go
+++ b/internal/email/email_test.go
@@ -1,0 +1,141 @@
+package email_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/qf-studio/auth-service/internal/email"
+)
+
+// ── ConsoleSender ─────────────────────────────────────────────────────────────
+
+func TestConsoleSender_Send(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+
+	s := email.NewConsoleSender(logger)
+	msg := email.Message{
+		To:      "alice@example.com",
+		Subject: "Hello",
+		Body:    "World",
+	}
+
+	err := s.Send(context.Background(), msg)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, logs.Len())
+	entry := logs.All()[0]
+	assert.Equal(t, "email (console)", entry.Message)
+
+	fields := map[string]string{}
+	for _, f := range entry.Context {
+		fields[f.Key] = f.String
+	}
+	assert.Equal(t, "alice@example.com", fields["to"])
+	assert.Equal(t, "Hello", fields["subject"])
+	assert.Equal(t, "World", fields["body"])
+}
+
+// ── HTTPSender ────────────────────────────────────────────────────────────────
+
+func TestHTTPSender_Send_success(t *testing.T) {
+	var capturedReq struct {
+		From      string   `json:"from"`
+		To        []string `json:"to"`
+		Subject   string   `json:"subject"`
+		Body      string   `json:"body"`
+		Transport string   `json:"transport"`
+	}
+	var capturedAuth string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/send-email", r.URL.Path)
+
+		capturedAuth = r.Header.Get("Authorization")
+
+		err := json.NewDecoder(r.Body).Decode(&capturedReq)
+		require.NoError(t, err)
+
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"status":"Email queued successfully"}`))
+	}))
+	defer srv.Close()
+
+	s := email.NewHTTPSender(srv.URL, "test-api-key", "noreply@example.com", srv.Client())
+	msg := email.Message{
+		To:      "bob@example.com",
+		Subject: "Welcome",
+		Body:    "Hello Bob",
+	}
+
+	err := s.Send(context.Background(), msg)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer test-api-key", capturedAuth)
+	assert.Equal(t, "noreply@example.com", capturedReq.From)
+	assert.Equal(t, []string{"bob@example.com"}, capturedReq.To)
+	assert.Equal(t, "Welcome", capturedReq.Subject)
+	assert.Equal(t, "Hello Bob", capturedReq.Body)
+	assert.Equal(t, "default", capturedReq.Transport)
+}
+
+func TestHTTPSender_Send_serverError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"internal error"}`))
+	}))
+	defer srv.Close()
+
+	s := email.NewHTTPSender(srv.URL, "key", "from@example.com", srv.Client())
+	err := s.Send(context.Background(), email.Message{To: "x@x.com", Subject: "s", Body: "b"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestHTTPSender_Send_connectionError(t *testing.T) {
+	// Point at a server that is already closed.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.Close()
+
+	s := email.NewHTTPSender(srv.URL, "key", "from@example.com", srv.Client())
+	err := s.Send(context.Background(), email.Message{To: "x@x.com", Subject: "s", Body: "b"})
+
+	require.Error(t, err)
+}
+
+func TestHTTPSender_Send_non2xxTreatedAsError(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+	}{
+		{"400 bad request", http.StatusBadRequest},
+		{"401 unauthorized", http.StatusUnauthorized},
+		{"404 not found", http.StatusNotFound},
+		{"503 service unavailable", http.StatusServiceUnavailable},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+			}))
+			defer srv.Close()
+
+			s := email.NewHTTPSender(srv.URL, "key", "from@example.com", srv.Client())
+			err := s.Send(context.Background(), email.Message{To: "x@x.com", Subject: "s", Body: "b"})
+			require.Error(t, err)
+		})
+	}
+}

--- a/internal/email/http.go
+++ b/internal/email/http.go
@@ -1,0 +1,83 @@
+package email
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// HTTPSender implements EmailSender by calling the email-service REST API.
+// It sends a POST /send-email request with an API key in the Authorization header.
+type HTTPSender struct {
+	client        *http.Client
+	serviceURL    string // base URL, e.g. "https://email.internal"
+	apiKey        string
+	senderAddress string
+}
+
+// NewHTTPSender constructs an HTTPSender.
+//
+//   - serviceURL: base URL of the email service (no trailing slash)
+//   - apiKey: bearer token for the Authorization header
+//   - senderAddress: the From address included in every outgoing message
+//   - client: HTTP client to use; pass nil to get http.DefaultClient
+func NewHTTPSender(serviceURL, apiKey, senderAddress string, client *http.Client) *HTTPSender {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &HTTPSender{
+		client:        client,
+		serviceURL:    serviceURL,
+		apiKey:        apiKey,
+		senderAddress: senderAddress,
+	}
+}
+
+// sendEmailRequest mirrors the email-service /send-email JSON body.
+type sendEmailRequest struct {
+	From      string   `json:"from"`
+	To        []string `json:"to"`
+	Subject   string   `json:"subject"`
+	Body      string   `json:"body"`
+	Transport string   `json:"transport"`
+}
+
+// Send delivers msg via POST {serviceURL}/send-email.
+// A non-2xx status code is treated as an error.
+func (s *HTTPSender) Send(ctx context.Context, msg Message) error {
+	payload := sendEmailRequest{
+		From:      s.senderAddress,
+		To:        []string{msg.To},
+		Subject:   msg.Subject,
+		Body:      msg.Body,
+		Transport: "default",
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("email: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.serviceURL+"/send-email", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("email: create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+s.apiKey)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("email: send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("email: service returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-191.

Closes #191

## Changes

Create the `internal/email/` package with the `EmailSender` interface, `ConsoleSender` (dev/logging), and `HTTPSender` (calls email-service REST API). Add email-related config fields (`EMAIL_SERVICE_URL`, `EMAIL_API_KEY`, `EMAIL_SENDER_ADDRESS`, `EMAIL_ENABLED`) to `internal/config/config.go`. Include unit tests with a mock HTTP server for the HTTP sender. Packages: `internal/email/`, `internal/config/`