### PR TITLE
GH-193: Auth service integration, API endpoints, and DI wiring

### DIFF
--- a/.agent/tasks/gh-193.md
+++ b/.agent/tasks/gh-193.md
@@ -1,0 +1,10 @@
+# GH-193
+
+**Created:** 2026-04-05
+
+## Problem
+
+Inject `EmailSender` into `internal/auth/service.go` via constructor. Update `Register()` to generate a verification token and send a verification email. Add `VerifyEmail()` method to confirm the token. Update `ResetPassword()` to send password-reset emails instead of logging tokens. Add `POST /auth/verify-email` handler in `internal/api/auth_handlers.go` and register the route in `internal/api/router.go`. Wire the email sender (console or HTTP based on config) into the DI chain in `cmd/server/main.go`. Add stubs/hooks for MFA enrollment and account-lockout notification emails (MFA package is placeholder, so these are interface-ready calls). Include integration tests with a mock email sender. Packages: `internal/auth/`, `internal/api/`, `cmd/server/`
+
+## Acceptance Criteria
+

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/qf-studio/auth-service/internal/audit"
 	"github.com/qf-studio/auth-service/internal/auth"
 	"github.com/qf-studio/auth-service/internal/config"
+	"github.com/qf-studio/auth-service/internal/email"
 	"github.com/qf-studio/auth-service/internal/health"
 	"github.com/qf-studio/auth-service/internal/hibp"
 	"github.com/qf-studio/auth-service/internal/httpserver"
@@ -85,7 +86,18 @@ func run(log *zap.Logger, cfg *config.Config) error {
 		return fmt.Errorf("token service init failed: %w", err)
 	}
 	hibpClient := hibp.NewClient(http.DefaultClient)
-	authSvc := auth.NewService(redisClient, log, auditSvc, userRepo, refreshTokenRepo, tokenSvc, hasher, hibpClient)
+
+	// ── Email ─────────────────────────────────────────────────────────────
+	var emailSender email.Sender
+	if cfg.Email.Enabled {
+		emailSender = email.NewHTTPSender(cfg.Email.ServiceURL, cfg.Email.APIKey, cfg.Email.SenderAddress, log)
+		log.Info("email sender: HTTP", zap.String("service_url", cfg.Email.ServiceURL))
+	} else {
+		emailSender = email.NewConsoleSender(log)
+		log.Info("email sender: console (development mode)")
+	}
+
+	authSvc := auth.NewService(redisClient, log, auditSvc, userRepo, refreshTokenRepo, tokenSvc, hasher, hibpClient, emailSender)
 
 	// ── Session ──────────────────────────────────────────────────────────
 	sessionStore := session.NewMemoryStore()

--- a/internal/api/auth_handlers.go
+++ b/internal/api/auth_handlers.go
@@ -78,6 +78,18 @@ func (h *AuthHandlers) ConfirmPasswordReset(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "Password has been reset"})
 }
 
+// VerifyEmail handles POST /auth/verify-email.
+func (h *AuthHandlers) VerifyEmail(c *gin.Context) {
+	req := c.MustGet("validated_request").(*domain.VerifyEmailRequest)
+
+	if err := h.auth.VerifyEmail(c.Request.Context(), req.Token); err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Email verified successfully"})
+}
+
 // Me handles GET /auth/me.
 func (h *AuthHandlers) Me(c *gin.Context) {
 	userID := c.GetString("user_id")

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -66,6 +66,8 @@ func NewPublicRouter(svc *Services, mw *MiddlewareStack, healthSvc *health.Servi
 		auth.POST("/token", validateReq(v, &domain.TokenRequest{}), tokenH.Token)
 		auth.POST("/revoke", validateReq(v, &domain.RevokeRequest{}), tokenH.Revoke)
 
+		auth.POST("/verify-email", validateReq(v, &domain.VerifyEmailRequest{}), authH.VerifyEmail)
+
 		pw := auth.Group("/password")
 		pw.POST("/reset", validateReq(v, &domain.PasswordResetRequest{}), authH.ResetPassword)
 		pw.POST("/reset/confirm", validateReq(v, &domain.PasswordResetConfirmRequest{}), authH.ConfirmPasswordReset)
@@ -108,6 +110,8 @@ func validateReq(v *validator.Validate, zero interface{}) gin.HandlerFunc {
 		return domain.ValidateRequest(v, func() interface{} { return &domain.PasswordResetConfirmRequest{} })
 	case *domain.PasswordChangeRequest:
 		return domain.ValidateRequest(v, func() interface{} { return &domain.PasswordChangeRequest{} })
+	case *domain.VerifyEmailRequest:
+		return domain.ValidateRequest(v, func() interface{} { return &domain.VerifyEmailRequest{} })
 	default:
 		panic("unsupported request type for validation middleware")
 	}

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -54,6 +54,10 @@ func (m *mockAuthService) Login(ctx context.Context, email, password string) (*a
 	}, nil
 }
 
+func (m *mockAuthService) VerifyEmail(_ context.Context, _ string) error {
+	return nil
+}
+
 func (m *mockAuthService) ResetPassword(ctx context.Context, email string) error {
 	if m.resetPasswordFn != nil {
 		return m.resetPasswordFn(ctx, email)

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -32,6 +32,7 @@ type JWKSResponse struct {
 type AuthService interface {
 	Register(ctx context.Context, email, password, name string) (*UserInfo, error)
 	Login(ctx context.Context, email, password string) (*AuthResult, error)
+	VerifyEmail(ctx context.Context, token string) error
 	ResetPassword(ctx context.Context, email string) error
 	ConfirmPasswordReset(ctx context.Context, token, newPassword string) error
 	GetMe(ctx context.Context, userID string) (*UserInfo, error)

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/qf-studio/auth-service/internal/api"
 	"github.com/qf-studio/auth-service/internal/audit"
 	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/email"
 	"github.com/qf-studio/auth-service/internal/hibp"
 	"github.com/qf-studio/auth-service/internal/password"
 	"github.com/qf-studio/auth-service/internal/storage"
@@ -27,6 +28,12 @@ const (
 
 	// resetTokenPrefix is the Redis key prefix for password reset tokens.
 	resetTokenPrefix = "pw_reset:"
+
+	// verifyTokenTTL is how long an email verification token remains valid.
+	verifyTokenTTL = 24 * time.Hour
+
+	// verifyTokenPrefix is the Redis key prefix for email verification tokens.
+	verifyTokenPrefix = "email_verify:"
 
 	// resetTokenBytes is the number of random bytes in a reset token (32 bytes = 64 hex chars).
 	resetTokenBytes = 32
@@ -42,14 +49,15 @@ type TokenIssuer interface {
 // Service implements api.AuthService with Redis-backed password reset tokens
 // and PostgreSQL-backed user authentication.
 type Service struct {
-	redis    *redis.Client
-	logger   *zap.Logger
-	audit    audit.EventLogger
-	users    storage.UserRepository
-	tokens   storage.RefreshTokenRepository
-	issuer   TokenIssuer
-	hasher   password.Hasher
+	redis  *redis.Client
+	logger *zap.Logger
+	audit  audit.EventLogger
+	users  storage.UserRepository
+	tokens storage.RefreshTokenRepository
+	issuer TokenIssuer
+	hasher password.Hasher
 	breaches hibp.BreachChecker
+	email  email.Sender
 }
 
 // NewService creates a new auth Service.
@@ -62,6 +70,7 @@ func NewService(
 	issuer TokenIssuer,
 	hasher password.Hasher,
 	breaches hibp.BreachChecker,
+	emailSender email.Sender,
 ) *Service {
 	return &Service{
 		redis:    redisClient,
@@ -72,25 +81,73 @@ func NewService(
 		issuer:   issuer,
 		hasher:   hasher,
 		breaches: breaches,
+		email:    emailSender,
 	}
 }
 
 // Register creates a new user account.
 // Stub: full implementation depends on PostgreSQL user repository (future issue).
-func (s *Service) Register(ctx context.Context, email, _, name string) (*api.UserInfo, error) {
+func (s *Service) Register(ctx context.Context, emailAddr, _, name string) (*api.UserInfo, error) {
 	// TODO(GH-XX): wire PostgreSQL user repository for persistence.
 	info := &api.UserInfo{
 		ID:    "stub-user-id",
-		Email: email,
+		Email: emailAddr,
 		Name:  name,
 	}
 	s.audit.LogEvent(ctx, audit.Event{
 		Type:     audit.EventRegister,
 		ActorID:  info.ID,
 		TargetID: info.ID,
-		Metadata: map[string]string{"email": email},
+		Metadata: map[string]string{"email": emailAddr},
 	})
+
+	// Generate and store email verification token (best-effort; don't fail registration).
+	if s.redis != nil {
+		verifyToken, err := generateResetToken()
+		if err != nil {
+			s.logger.Error("failed to generate verification token", zap.Error(err))
+			return info, nil
+		}
+
+		key := verifyTokenPrefix + verifyToken
+		if err := s.redis.Set(ctx, key, emailAddr, verifyTokenTTL).Err(); err != nil {
+			s.logger.Error("failed to store verification token in redis", zap.Error(err))
+			return info, nil
+		}
+
+		if err := s.email.SendVerificationEmail(ctx, emailAddr, verifyToken); err != nil {
+			s.logger.Error("failed to send verification email",
+				zap.String("email", emailAddr),
+				zap.Error(err),
+			)
+		}
+	}
+
 	return info, nil
+}
+
+// VerifyEmail confirms the email address using the verification token stored in Redis.
+func (s *Service) VerifyEmail(ctx context.Context, token string) error {
+	key := verifyTokenPrefix + token
+
+	emailAddr, err := s.redis.GetDel(ctx, key).Result()
+	if err == redis.Nil {
+		return fmt.Errorf("invalid or expired verification token: %w", api.ErrUnauthorized)
+	}
+	if err != nil {
+		s.logger.Error("failed to retrieve verification token from redis", zap.Error(err))
+		return fmt.Errorf("retrieve verification token: %w", err)
+	}
+
+	// TODO(GH-XX): update user record to set email_verified = true in PostgreSQL.
+	s.logger.Info("email verified", zap.String("email", emailAddr))
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventRegister,
+		Metadata: map[string]string{"email": emailAddr, "action": "email_verified"},
+	})
+
+	return nil
 }
 
 // Login authenticates a user by email and password.
@@ -198,7 +255,13 @@ func (s *Service) ResetPassword(ctx context.Context, email string) error {
 		Metadata: map[string]string{"email": email},
 	})
 
-	// TODO(GH-XX): send email with reset link containing the token.
+	if err := s.email.SendPasswordReset(ctx, email, token); err != nil {
+		s.logger.Error("failed to send password reset email",
+			zap.String("email", email),
+			zap.Error(err),
+		)
+		// Best-effort: don't fail the request if email sending fails.
+	}
 
 	return nil
 }

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/qf-studio/auth-service/internal/api"
 	"github.com/qf-studio/auth-service/internal/audit"
 	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/email"
 	"github.com/qf-studio/auth-service/internal/storage"
 )
 
@@ -108,6 +109,37 @@ func (m *mockBreachChecker) IsBreached(ctx context.Context, password string) (bo
 	return false, nil
 }
 
+type mockEmailSender struct {
+	sendVerificationFn func(ctx context.Context, to, token string) error
+	sendPasswordResetFn func(ctx context.Context, to, token string) error
+	calls              []emailCall
+}
+
+type emailCall struct {
+	method string
+	to     string
+	token  string
+}
+
+func (m *mockEmailSender) SendVerificationEmail(ctx context.Context, to, token string) error {
+	m.calls = append(m.calls, emailCall{method: "verification", to: to, token: token})
+	if m.sendVerificationFn != nil {
+		return m.sendVerificationFn(ctx, to, token)
+	}
+	return nil
+}
+
+func (m *mockEmailSender) SendPasswordReset(ctx context.Context, to, token string) error {
+	m.calls = append(m.calls, emailCall{method: "password_reset", to: to, token: token})
+	if m.sendPasswordResetFn != nil {
+		return m.sendPasswordResetFn(ctx, to, token)
+	}
+	return nil
+}
+
+func (m *mockEmailSender) SendAccountLockout(_ context.Context, _, _ string) error { return nil }
+func (m *mockEmailSender) SendMFAEnrollment(_ context.Context, _ string) error     { return nil }
+
 type mockHasher struct {
 	verifyFn func(password, hash string) (bool, error)
 }
@@ -130,7 +162,7 @@ func (m *mockHasher) Verify(password, hash string) (bool, error) {
 func newUnitService(t *testing.T, users *mockUserRepository, tokens *mockRefreshTokenRepository, issuer *mockTokenIssuer, hasher *mockHasher) *Service {
 	t.Helper()
 	logger, _ := zap.NewDevelopment()
-	return NewService(nil, logger, audit.NopLogger{}, users, tokens, issuer, hasher, &mockBreachChecker{})
+	return NewService(nil, logger, audit.NopLogger{}, users, tokens, issuer, hasher, &mockBreachChecker{}, email.NopSender{})
 }
 
 // newRedisClient creates a Redis client for integration tests (password reset).
@@ -161,12 +193,14 @@ func newRedisClient(t *testing.T) *redis.Client {
 	return client
 }
 
-// newIntegrationService creates a Service with a real Redis client.
-func newIntegrationService(t *testing.T) *Service {
+// newIntegrationService creates a Service with a real Redis client and a mock email sender.
+func newIntegrationService(t *testing.T) (*Service, *mockEmailSender) {
 	t.Helper()
 	client := newRedisClient(t)
 	logger, _ := zap.NewDevelopment()
-	return NewService(client, logger, audit.NopLogger{}, &mockUserRepository{}, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, &mockHasher{}, &mockBreachChecker{})
+	emailMock := &mockEmailSender{}
+	svc := NewService(client, logger, audit.NopLogger{}, &mockUserRepository{}, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, &mockHasher{}, &mockBreachChecker{}, emailMock)
+	return svc, emailMock
 }
 
 // ── Login Tests ──────────────────────────────────────────────────────────────
@@ -480,7 +514,7 @@ func TestLogoutAll_RevokesAllForUser(t *testing.T) {
 // ── Password Reset Tests (integration, require Redis) ────────────────────────
 
 func TestResetPassword_StoresTokenInRedis(t *testing.T) {
-	svc := newIntegrationService(t)
+	svc, _ := newIntegrationService(t)
 	ctx := context.Background()
 
 	err := svc.ResetPassword(ctx, "user@example.com")
@@ -500,7 +534,7 @@ func TestResetPassword_StoresTokenInRedis(t *testing.T) {
 }
 
 func TestConfirmPasswordReset_ValidToken(t *testing.T) {
-	svc := newIntegrationService(t)
+	svc, _ := newIntegrationService(t)
 	ctx := context.Background()
 
 	token := "test-reset-token-abc123"
@@ -517,7 +551,7 @@ func TestConfirmPasswordReset_ValidToken(t *testing.T) {
 }
 
 func TestConfirmPasswordReset_InvalidToken(t *testing.T) {
-	svc := newIntegrationService(t)
+	svc, _ := newIntegrationService(t)
 	ctx := context.Background()
 
 	err := svc.ConfirmPasswordReset(ctx, "nonexistent-token", "new-secure-password-12345")
@@ -526,7 +560,7 @@ func TestConfirmPasswordReset_InvalidToken(t *testing.T) {
 }
 
 func TestConfirmPasswordReset_TokenUsedOnce(t *testing.T) {
-	svc := newIntegrationService(t)
+	svc, _ := newIntegrationService(t)
 	ctx := context.Background()
 
 	token := "one-time-token"
@@ -543,7 +577,7 @@ func TestConfirmPasswordReset_TokenUsedOnce(t *testing.T) {
 }
 
 func TestResetPassword_FullFlow(t *testing.T) {
-	svc := newIntegrationService(t)
+	svc, _ := newIntegrationService(t)
 	ctx := context.Background()
 
 	err := svc.ResetPassword(ctx, "alice@example.com")
@@ -588,4 +622,140 @@ func TestGetMe_ReturnsStub(t *testing.T) {
 	user, err := svc.GetMe(context.Background(), "user-42")
 	require.NoError(t, err)
 	assert.Equal(t, "user-42", user.ID)
+}
+
+// ── Email Integration Tests ─────────────────────────────────────────────────
+
+func TestRegister_SendsVerificationEmail(t *testing.T) {
+	svc, emailMock := newIntegrationService(t)
+	ctx := context.Background()
+
+	user, err := svc.Register(ctx, "newuser@example.com", "password123456789", "New User")
+	require.NoError(t, err)
+	assert.Equal(t, "newuser@example.com", user.Email)
+
+	// Verify email was sent.
+	require.Len(t, emailMock.calls, 1)
+	assert.Equal(t, "verification", emailMock.calls[0].method)
+	assert.Equal(t, "newuser@example.com", emailMock.calls[0].to)
+	assert.NotEmpty(t, emailMock.calls[0].token)
+
+	// Verify token was stored in Redis.
+	keys, err := svc.redis.Keys(ctx, verifyTokenPrefix+"*").Result()
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+
+	storedEmail, err := svc.redis.Get(ctx, keys[0]).Result()
+	require.NoError(t, err)
+	assert.Equal(t, "newuser@example.com", storedEmail)
+}
+
+func TestRegister_EmailFailureDoesNotBlockRegistration(t *testing.T) {
+	svc, emailMock := newIntegrationService(t)
+	emailMock.sendVerificationFn = func(_ context.Context, _, _ string) error {
+		return fmt.Errorf("email service unavailable")
+	}
+	ctx := context.Background()
+
+	user, err := svc.Register(ctx, "user@example.com", "password123456789", "User")
+	require.NoError(t, err)
+	assert.Equal(t, "user@example.com", user.Email)
+}
+
+func TestVerifyEmail_ValidToken(t *testing.T) {
+	svc, _ := newIntegrationService(t)
+	ctx := context.Background()
+
+	// Store a verification token.
+	token := "test-verify-token-abc123"
+	key := verifyTokenPrefix + token
+	err := svc.redis.Set(ctx, key, "user@example.com", verifyTokenTTL).Err()
+	require.NoError(t, err)
+
+	// Verify the email.
+	err = svc.VerifyEmail(ctx, token)
+	require.NoError(t, err)
+
+	// Token should be consumed.
+	exists, err := svc.redis.Exists(ctx, key).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), exists, "token should be deleted after verification")
+}
+
+func TestVerifyEmail_InvalidToken(t *testing.T) {
+	svc, _ := newIntegrationService(t)
+	ctx := context.Background()
+
+	err := svc.VerifyEmail(ctx, "nonexistent-token")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrUnauthorized)
+}
+
+func TestVerifyEmail_TokenUsedOnce(t *testing.T) {
+	svc, _ := newIntegrationService(t)
+	ctx := context.Background()
+
+	token := "one-time-verify-token"
+	key := verifyTokenPrefix + token
+	err := svc.redis.Set(ctx, key, "user@example.com", verifyTokenTTL).Err()
+	require.NoError(t, err)
+
+	err = svc.VerifyEmail(ctx, token)
+	require.NoError(t, err)
+
+	err = svc.VerifyEmail(ctx, token)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrUnauthorized)
+}
+
+func TestVerifyEmail_FullFlow(t *testing.T) {
+	svc, emailMock := newIntegrationService(t)
+	ctx := context.Background()
+
+	// Register sends a verification email.
+	_, err := svc.Register(ctx, "alice@example.com", "password123456789", "Alice")
+	require.NoError(t, err)
+	require.Len(t, emailMock.calls, 1)
+
+	// Extract the token from the email mock.
+	verifyToken := emailMock.calls[0].token
+	require.NotEmpty(t, verifyToken)
+
+	// Verify the email using the token.
+	err = svc.VerifyEmail(ctx, verifyToken)
+	require.NoError(t, err)
+
+	// Token should be consumed — second attempt fails.
+	err = svc.VerifyEmail(ctx, verifyToken)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrUnauthorized)
+}
+
+func TestResetPassword_SendsEmail(t *testing.T) {
+	svc, emailMock := newIntegrationService(t)
+	ctx := context.Background()
+
+	err := svc.ResetPassword(ctx, "user@example.com")
+	require.NoError(t, err)
+
+	require.Len(t, emailMock.calls, 1)
+	assert.Equal(t, "password_reset", emailMock.calls[0].method)
+	assert.Equal(t, "user@example.com", emailMock.calls[0].to)
+	assert.NotEmpty(t, emailMock.calls[0].token)
+}
+
+func TestResetPassword_EmailFailureDoesNotBlockReset(t *testing.T) {
+	svc, emailMock := newIntegrationService(t)
+	emailMock.sendPasswordResetFn = func(_ context.Context, _, _ string) error {
+		return fmt.Errorf("email service unavailable")
+	}
+	ctx := context.Background()
+
+	err := svc.ResetPassword(ctx, "user@example.com")
+	require.NoError(t, err)
+
+	// Token should still be stored in Redis even if email fails.
+	keys, err := svc.redis.Keys(ctx, resetTokenPrefix+"*").Result()
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,15 @@ type Config struct {
 	TLS          TLSConfig
 	CORS         CORSConfig
 	RequestLimit RequestLimitConfig
+	Email        EmailConfig
+}
+
+// EmailConfig holds email sending settings.
+type EmailConfig struct {
+	Enabled       bool   // EMAIL_ENABLED (default false)
+	ServiceURL    string // EMAIL_SERVICE_URL (required when enabled)
+	APIKey        string // EMAIL_API_KEY (required when enabled)
+	SenderAddress string // EMAIL_SENDER_ADDRESS (default "noreply@quantflow.studio")
 }
 
 // AppConfig holds server-level settings.
@@ -194,6 +203,10 @@ func Load() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	emailCfg, err := loadEmail(l)
+	if err != nil {
+		return nil, err
+	}
 
 	if len(l.missing) > 0 {
 		return nil, fmt.Errorf("missing required environment variables: %s", strings.Join(l.missing, ", "))
@@ -213,6 +226,7 @@ func Load() (*Config, error) {
 		TLS:          tls,
 		CORS:         cors,
 		RequestLimit: reqLimit,
+		Email:        emailCfg,
 	}, nil
 }
 
@@ -434,6 +448,24 @@ func loadRequestLimit(l *loader) (RequestLimitConfig, error) {
 	return RequestLimitConfig{
 		MaxBodySize:    int64(maxBodySize), //nolint:gosec // non-negative validated by optInt
 		RequestTimeout: requestTimeout,
+	}, nil
+}
+
+func loadEmail(l *loader) (EmailConfig, error) {
+	enabled, err := l.optBool("EMAIL_ENABLED", false)
+	if err != nil {
+		return EmailConfig{}, err
+	}
+
+	serviceURL := l.optStr("EMAIL_SERVICE_URL", "")
+	apiKey := l.optStr("EMAIL_API_KEY", "")
+	senderAddr := l.optStr("EMAIL_SENDER_ADDRESS", "noreply@quantflow.studio")
+
+	return EmailConfig{
+		Enabled:       enabled,
+		ServiceURL:    serviceURL,
+		APIKey:        apiKey,
+		SenderAddress: senderAddr,
 	}, nil
 }
 

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -4,18 +4,19 @@ import "time"
 
 // User represents a user account in the system.
 type User struct {
-	ID           string
-	Email        string
-	PasswordHash string
-	Name         string
-	Roles        []string
-	Locked       bool
-	LockedAt     *time.Time
-	LockedReason string
-	LastLoginAt  *time.Time
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
-	DeletedAt    *time.Time
+	ID            string
+	Email         string
+	PasswordHash  string
+	Name          string
+	Roles         []string
+	EmailVerified bool
+	Locked        bool
+	LockedAt      *time.Time
+	LockedReason  string
+	LastLoginAt   *time.Time
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	DeletedAt     *time.Time
 }
 
 // IsActive returns true if the user is not locked and not soft-deleted.

--- a/internal/domain/validation.go
+++ b/internal/domain/validation.go
@@ -64,6 +64,11 @@ type PasswordChangeRequest struct {
 	NewPassword string `json:"new_password" validate:"required,nist_password"`
 }
 
+// VerifyEmailRequest is the validated request body for email verification.
+type VerifyEmailRequest struct {
+	Token string `json:"token" validate:"required"`
+}
+
 // --- Validator setup ---
 
 // NewValidator creates a validator.Validate instance with custom NIST password validation registered.

--- a/internal/email/sender.go
+++ b/internal/email/sender.go
@@ -1,0 +1,166 @@
+// Package email provides email sending abstractions for the auth service.
+// It supports a console sender for development (logs emails) and an HTTP
+// sender that calls the email-service REST API in production.
+package email
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// Sender is the interface for sending transactional emails.
+type Sender interface {
+	// SendVerificationEmail sends an email verification link to the user.
+	SendVerificationEmail(ctx context.Context, to, token string) error
+
+	// SendPasswordReset sends a password reset link to the user.
+	SendPasswordReset(ctx context.Context, to, token string) error
+
+	// SendAccountLockout notifies the user that their account has been locked.
+	SendAccountLockout(ctx context.Context, to, reason string) error
+
+	// SendMFAEnrollment notifies the user about MFA enrollment status.
+	SendMFAEnrollment(ctx context.Context, to string) error
+}
+
+// ConsoleSender logs emails to the console instead of sending them.
+// Used in development and testing environments.
+type ConsoleSender struct {
+	logger *zap.Logger
+}
+
+// NewConsoleSender creates a new ConsoleSender.
+func NewConsoleSender(logger *zap.Logger) *ConsoleSender {
+	return &ConsoleSender{logger: logger}
+}
+
+func (s *ConsoleSender) SendVerificationEmail(_ context.Context, to, token string) error {
+	s.logger.Info("email: verification",
+		zap.String("to", to),
+		zap.String("token", token),
+	)
+	return nil
+}
+
+func (s *ConsoleSender) SendPasswordReset(_ context.Context, to, token string) error {
+	s.logger.Info("email: password reset",
+		zap.String("to", to),
+		zap.String("token", token),
+	)
+	return nil
+}
+
+func (s *ConsoleSender) SendAccountLockout(_ context.Context, to, reason string) error {
+	s.logger.Info("email: account lockout",
+		zap.String("to", to),
+		zap.String("reason", reason),
+	)
+	return nil
+}
+
+func (s *ConsoleSender) SendMFAEnrollment(_ context.Context, to string) error {
+	s.logger.Info("email: MFA enrollment",
+		zap.String("to", to),
+	)
+	return nil
+}
+
+// HTTPSender sends emails via the email-service REST API.
+type HTTPSender struct {
+	client     *http.Client
+	baseURL    string
+	apiKey     string
+	fromAddr   string
+	logger     *zap.Logger
+}
+
+// NewHTTPSender creates a new HTTPSender.
+func NewHTTPSender(baseURL, apiKey, fromAddr string, logger *zap.Logger) *HTTPSender {
+	return &HTTPSender{
+		client: &http.Client{Timeout: 10 * time.Second},
+		baseURL:  baseURL,
+		apiKey:   apiKey,
+		fromAddr: fromAddr,
+		logger:   logger,
+	}
+}
+
+type emailRequest struct {
+	From    string `json:"from"`
+	To      string `json:"to"`
+	Subject string `json:"subject"`
+	Body    string `json:"body"`
+}
+
+func (s *HTTPSender) SendVerificationEmail(ctx context.Context, to, token string) error {
+	return s.send(ctx, to, "Verify your email address",
+		fmt.Sprintf("Please verify your email by using this token: %s", token))
+}
+
+func (s *HTTPSender) SendPasswordReset(ctx context.Context, to, token string) error {
+	return s.send(ctx, to, "Reset your password",
+		fmt.Sprintf("Use this token to reset your password: %s", token))
+}
+
+func (s *HTTPSender) SendAccountLockout(ctx context.Context, to, reason string) error {
+	return s.send(ctx, to, "Account locked",
+		fmt.Sprintf("Your account has been locked. Reason: %s", reason))
+}
+
+func (s *HTTPSender) SendMFAEnrollment(ctx context.Context, to string) error {
+	return s.send(ctx, to, "MFA enrollment",
+		"Multi-factor authentication has been configured for your account.")
+}
+
+func (s *HTTPSender) send(ctx context.Context, to, subject, body string) error {
+	payload := emailRequest{
+		From:    s.fromAddr,
+		To:      to,
+		Subject: subject,
+		Body:    body,
+	}
+
+	jsonBody, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal email request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.baseURL+"/send", bytes.NewReader(jsonBody))
+	if err != nil {
+		return fmt.Errorf("create email request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+s.apiKey)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send email: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		s.logger.Error("email service returned error",
+			zap.Int("status", resp.StatusCode),
+			zap.String("body", string(respBody)),
+		)
+		return fmt.Errorf("email service returned status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// NopSender is a no-op email sender used when email is disabled.
+type NopSender struct{}
+
+func (NopSender) SendVerificationEmail(context.Context, string, string) error { return nil }
+func (NopSender) SendPasswordReset(context.Context, string, string) error     { return nil }
+func (NopSender) SendAccountLockout(context.Context, string, string) error    { return nil }
+func (NopSender) SendMFAEnrollment(context.Context, string) error             { return nil }

--- a/internal/email/sender_test.go
+++ b/internal/email/sender_test.go
@@ -1,0 +1,105 @@
+package email
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestConsoleSender_AllMethodsSucceed(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	sender := NewConsoleSender(logger)
+	ctx := context.Background()
+
+	assert.NoError(t, sender.SendVerificationEmail(ctx, "test@example.com", "token123"))
+	assert.NoError(t, sender.SendPasswordReset(ctx, "test@example.com", "token456"))
+	assert.NoError(t, sender.SendAccountLockout(ctx, "test@example.com", "too many attempts"))
+	assert.NoError(t, sender.SendMFAEnrollment(ctx, "test@example.com"))
+}
+
+func TestNopSender_AllMethodsSucceed(t *testing.T) {
+	sender := NopSender{}
+	ctx := context.Background()
+
+	assert.NoError(t, sender.SendVerificationEmail(ctx, "test@example.com", "token123"))
+	assert.NoError(t, sender.SendPasswordReset(ctx, "test@example.com", "token456"))
+	assert.NoError(t, sender.SendAccountLockout(ctx, "test@example.com", "reason"))
+	assert.NoError(t, sender.SendMFAEnrollment(ctx, "test@example.com"))
+}
+
+func TestHTTPSender_SendVerificationEmail(t *testing.T) {
+	var received emailRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/send", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "Bearer test-api-key", r.Header.Get("Authorization"))
+
+		err := json.NewDecoder(r.Body).Decode(&received)
+		require.NoError(t, err)
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	logger, _ := zap.NewDevelopment()
+	sender := NewHTTPSender(server.URL, "test-api-key", "noreply@test.com", logger)
+
+	err := sender.SendVerificationEmail(context.Background(), "user@example.com", "verify-token-123")
+	require.NoError(t, err)
+
+	assert.Equal(t, "noreply@test.com", received.From)
+	assert.Equal(t, "user@example.com", received.To)
+	assert.Equal(t, "Verify your email address", received.Subject)
+	assert.Contains(t, received.Body, "verify-token-123")
+}
+
+func TestHTTPSender_SendPasswordReset(t *testing.T) {
+	var received emailRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewDecoder(r.Body).Decode(&received)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	logger, _ := zap.NewDevelopment()
+	sender := NewHTTPSender(server.URL, "test-api-key", "noreply@test.com", logger)
+
+	err := sender.SendPasswordReset(context.Background(), "user@example.com", "reset-token-456")
+	require.NoError(t, err)
+
+	assert.Equal(t, "user@example.com", received.To)
+	assert.Equal(t, "Reset your password", received.Subject)
+	assert.Contains(t, received.Body, "reset-token-456")
+}
+
+func TestHTTPSender_ErrorResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"service unavailable"}`))
+	}))
+	defer server.Close()
+
+	logger, _ := zap.NewDevelopment()
+	sender := NewHTTPSender(server.URL, "test-api-key", "noreply@test.com", logger)
+
+	err := sender.SendVerificationEmail(context.Background(), "user@example.com", "token")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 500")
+}
+
+func TestHTTPSender_ConnectionError(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	sender := NewHTTPSender("http://localhost:1", "key", "noreply@test.com", logger)
+
+	err := sender.SendVerificationEmail(context.Background(), "user@example.com", "token")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "send email")
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-193.

Closes #193

## Changes

Inject `EmailSender` into `internal/auth/service.go` via constructor. Update `Register()` to generate a verification token and send a verification email. Add `VerifyEmail()` method to confirm the token. Update `ResetPassword()` to send password-reset emails instead of logging tokens. Add `POST /auth/verify-email` handler in `internal/api/auth_handlers.go` and register the route in `internal/api/router.go`. Wire the email sender (console or HTTP based on config) into the DI chain in `cmd/server/main.go`. Add stubs/hooks for MFA enrollment and account-lockout notification emails (MFA package is placeholder, so these are interface-ready calls). Include integration tests with a mock email sender. Packages: `internal/auth/`, `internal/api/`, `cmd/server/`