### PR TITLE
GH-198: API key service: generation, validation, rotation, and rate limiting

### DIFF
--- a/internal/apikey/service.go
+++ b/internal/apikey/service.go
@@ -1,0 +1,340 @@
+// Package apikey provides business logic for API key lifecycle management
+// including creation, validation, rotation, revocation, and per-key rate limiting.
+package apikey
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/audit"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/password"
+)
+
+const (
+	// apiKeyPrefix is prepended to generated API keys for leak detection.
+	apiKeyPrefix = "qf_ak_"
+	// apiKeyBytes is the number of random bytes (128 bits = 16 bytes).
+	apiKeyBytes = 16
+	// gracePeriodDuration is the grace period for previous keys after rotation.
+	gracePeriodDuration = 24 * time.Hour
+	// rateLimitKeyPrefix is the Redis key prefix for per-key rate limiting.
+	rateLimitKeyPrefix = "rl:ak:"
+	// rateLimitWindow is the sliding window duration for rate limiting.
+	rateLimitWindow = 1 * time.Minute
+)
+
+// Audit event types for API key operations.
+const (
+	EventAPIKeyCreate = "apikey_create"
+	EventAPIKeyRotate = "apikey_rotate"
+	EventAPIKeyRevoke = "apikey_revoke"
+)
+
+// Repository defines the storage interface for API keys.
+type Repository interface {
+	Create(ctx context.Context, key *domain.APIKey) (*domain.APIKey, error)
+	FindByID(ctx context.Context, id uuid.UUID) (*domain.APIKey, error)
+	FindByKeyHash(ctx context.Context, keyHash string) (*domain.APIKey, error)
+	UpdateLastUsed(ctx context.Context, id uuid.UUID, t time.Time) error
+	RotateKey(ctx context.Context, id uuid.UUID, newKeyHash string, gracePeriodEnds time.Time) error
+	Revoke(ctx context.Context, id uuid.UUID) error
+}
+
+// RateLimitInfo contains rate limit state returned after validation.
+type RateLimitInfo struct {
+	Limit     int   // max requests per window
+	Remaining int   // requests left in current window
+	ResetAt   int64 // unix timestamp when the window resets
+}
+
+// CreateResult is returned by CreateAPIKey with the plaintext key shown once.
+type CreateResult struct {
+	APIKey      *domain.APIKey
+	PlaintextKey string
+}
+
+// RotateResult is returned by RotateKey with the new plaintext key.
+type RotateResult struct {
+	APIKey          *domain.APIKey
+	PlaintextKey    string
+	GracePeriodEnds time.Time
+}
+
+// Service implements API key business logic.
+type Service struct {
+	repo   Repository
+	hasher password.Hasher
+	rdb    *redis.Client
+	logger *zap.Logger
+	audit  audit.EventLogger
+}
+
+// NewService creates a new API key service.
+func NewService(repo Repository, hasher password.Hasher, rdb *redis.Client, logger *zap.Logger, auditor audit.EventLogger) *Service {
+	return &Service{
+		repo:   repo,
+		hasher: hasher,
+		rdb:    rdb,
+		logger: logger,
+		audit:  auditor,
+	}
+}
+
+// CreateAPIKey generates a new API key with the qf_ak_ prefix, hashes it with
+// Argon2id, and stores only the hash. The plaintext key is returned once.
+func (s *Service) CreateAPIKey(ctx context.Context, clientID uuid.UUID, name string, scopes []string, rateLimit int, expiresAt *time.Time) (*CreateResult, error) {
+	plaintext, err := generateAPIKey()
+	if err != nil {
+		s.logger.Error("generate api key failed", zap.Error(err))
+		return nil, fmt.Errorf("create api key: %w", err)
+	}
+
+	hash, err := s.hasher.Hash(plaintext)
+	if err != nil {
+		s.logger.Error("hash api key failed", zap.Error(err))
+		return nil, fmt.Errorf("create api key: %w", err)
+	}
+
+	now := time.Now().UTC()
+	if scopes == nil {
+		scopes = []string{}
+	}
+
+	key := &domain.APIKey{
+		ID:        uuid.New(),
+		ClientID:  clientID,
+		Name:      name,
+		KeyHash:   hash,
+		Scopes:    scopes,
+		RateLimit: rateLimit,
+		Status:    domain.APIKeyStatusActive,
+		ExpiresAt: expiresAt,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	created, err := s.repo.Create(ctx, key)
+	if err != nil {
+		s.logger.Error("store api key failed", zap.Error(err))
+		return nil, fmt.Errorf("create api key: %w", err)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     EventAPIKeyCreate,
+		TargetID: created.ID.String(),
+		Metadata: map[string]string{
+			"client_id": clientID.String(),
+			"name":      name,
+		},
+	})
+
+	return &CreateResult{
+		APIKey:       created,
+		PlaintextKey: plaintext,
+	}, nil
+}
+
+// ValidateAPIKey hashes the provided key, looks it up by hash (checking both
+// current and previous key hashes during grace period), verifies expiry/status,
+// updates last_used_at, and checks per-key rate limits.
+func (s *Service) ValidateAPIKey(ctx context.Context, plaintextKey string) (*domain.APIKey, *RateLimitInfo, error) {
+	hash, err := s.hasher.Hash(plaintextKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("validate api key: %w", err)
+	}
+
+	key, err := s.repo.FindByKeyHash(ctx, hash)
+	if err != nil {
+		if isNotFound(err) {
+			return nil, nil, domain.ErrAPIKeyNotFound
+		}
+		s.logger.Error("find api key by hash failed", zap.Error(err))
+		return nil, nil, fmt.Errorf("validate api key: %w", err)
+	}
+
+	if key.Status == domain.APIKeyStatusRevoked {
+		return nil, nil, domain.ErrAPIKeyRevoked
+	}
+
+	if key.IsExpired() {
+		return nil, nil, domain.ErrAPIKeyExpired
+	}
+
+	// Check per-key rate limit.
+	rlInfo, err := s.checkRateLimit(ctx, key.ID.String(), key.RateLimit)
+	if err != nil {
+		s.logger.Error("rate limit check failed", zap.String("key_id", key.ID.String()), zap.Error(err))
+		return nil, nil, fmt.Errorf("validate api key: %w", err)
+	}
+
+	if rlInfo.Remaining < 0 {
+		return nil, rlInfo, domain.ErrAPIKeyRateLimited
+	}
+
+	// Update last_used_at asynchronously (best-effort).
+	now := time.Now().UTC()
+	if updateErr := s.repo.UpdateLastUsed(ctx, key.ID, now); updateErr != nil {
+		s.logger.Warn("update last_used_at failed", zap.String("key_id", key.ID.String()), zap.Error(updateErr))
+	}
+
+	return key, rlInfo, nil
+}
+
+// RotateKey creates a new key, moves the current hash to previous_key_hash
+// with a 24-hour grace period.
+func (s *Service) RotateKey(ctx context.Context, keyID uuid.UUID) (*RotateResult, error) {
+	existing, err := s.repo.FindByID(ctx, keyID)
+	if err != nil {
+		if isNotFound(err) {
+			return nil, fmt.Errorf("key %s: %w", keyID, domain.ErrAPIKeyNotFound)
+		}
+		s.logger.Error("find api key for rotation failed", zap.String("key_id", keyID.String()), zap.Error(err))
+		return nil, fmt.Errorf("rotate key: %w", err)
+	}
+
+	if existing.Status == domain.APIKeyStatusRevoked {
+		return nil, fmt.Errorf("key %s: %w", keyID, domain.ErrAPIKeyRevoked)
+	}
+
+	plaintext, err := generateAPIKey()
+	if err != nil {
+		s.logger.Error("generate api key for rotation failed", zap.Error(err))
+		return nil, fmt.Errorf("rotate key: %w", err)
+	}
+
+	hash, err := s.hasher.Hash(plaintext)
+	if err != nil {
+		s.logger.Error("hash api key for rotation failed", zap.Error(err))
+		return nil, fmt.Errorf("rotate key: %w", err)
+	}
+
+	graceEnd := time.Now().UTC().Add(gracePeriodDuration)
+
+	if err := s.repo.RotateKey(ctx, keyID, hash, graceEnd); err != nil {
+		if isNotFound(err) {
+			return nil, fmt.Errorf("key %s: %w", keyID, domain.ErrAPIKeyNotFound)
+		}
+		s.logger.Error("rotate key failed", zap.String("key_id", keyID.String()), zap.Error(err))
+		return nil, fmt.Errorf("rotate key: %w", err)
+	}
+
+	// Re-read the key to get updated state.
+	updated, err := s.repo.FindByID(ctx, keyID)
+	if err != nil {
+		s.logger.Error("re-read key after rotation failed", zap.String("key_id", keyID.String()), zap.Error(err))
+		return nil, fmt.Errorf("rotate key: %w", err)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     EventAPIKeyRotate,
+		TargetID: keyID.String(),
+		Metadata: map[string]string{
+			"client_id": existing.ClientID.String(),
+		},
+	})
+
+	return &RotateResult{
+		APIKey:          updated,
+		PlaintextKey:    plaintext,
+		GracePeriodEnds: graceEnd,
+	}, nil
+}
+
+// RevokeKey soft-deletes an API key by setting its status to revoked.
+func (s *Service) RevokeKey(ctx context.Context, keyID uuid.UUID) error {
+	existing, err := s.repo.FindByID(ctx, keyID)
+	if err != nil {
+		if isNotFound(err) {
+			return fmt.Errorf("key %s: %w", keyID, domain.ErrAPIKeyNotFound)
+		}
+		s.logger.Error("find api key for revocation failed", zap.String("key_id", keyID.String()), zap.Error(err))
+		return fmt.Errorf("revoke key: %w", err)
+	}
+
+	if existing.Status == domain.APIKeyStatusRevoked {
+		return fmt.Errorf("key %s already revoked: %w", keyID, domain.ErrAPIKeyRevoked)
+	}
+
+	if err := s.repo.Revoke(ctx, keyID); err != nil {
+		if isNotFound(err) {
+			return fmt.Errorf("key %s: %w", keyID, domain.ErrAPIKeyNotFound)
+		}
+		s.logger.Error("revoke key failed", zap.String("key_id", keyID.String()), zap.Error(err))
+		return fmt.Errorf("revoke key: %w", err)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     EventAPIKeyRevoke,
+		TargetID: keyID.String(),
+		Metadata: map[string]string{
+			"client_id": existing.ClientID.String(),
+		},
+	})
+
+	return nil
+}
+
+// checkRateLimit uses a Redis sliding window to enforce per-key rate limits.
+// Returns rate limit info including remaining requests and window reset time.
+func (s *Service) checkRateLimit(ctx context.Context, keyID string, limit int) (*RateLimitInfo, error) {
+	if limit <= 0 {
+		// No rate limit configured for this key.
+		return &RateLimitInfo{Limit: 0, Remaining: 0, ResetAt: 0}, nil
+	}
+
+	redisKey := rateLimitKeyPrefix + keyID
+	now := time.Now().UTC()
+	windowStart := now.Add(-rateLimitWindow)
+	resetAt := now.Add(rateLimitWindow).Unix()
+
+	pipe := s.rdb.Pipeline()
+
+	// Remove entries outside the current window.
+	pipe.ZRemRangeByScore(ctx, redisKey, "0", fmt.Sprintf("%d", windowStart.UnixNano()))
+
+	// Count current entries in the window.
+	countCmd := pipe.ZCard(ctx, redisKey)
+
+	// Add the current request with the current timestamp as score.
+	member := fmt.Sprintf("%d:%s", now.UnixNano(), uuid.New().String()[:8])
+	pipe.ZAdd(ctx, redisKey, redis.Z{Score: float64(now.UnixNano()), Member: member})
+
+	// Set TTL on the key to auto-expire after the window.
+	pipe.Expire(ctx, redisKey, rateLimitWindow+time.Second)
+
+	if _, err := pipe.Exec(ctx); err != nil {
+		return nil, fmt.Errorf("rate limit check: %w", err)
+	}
+
+	count := int(countCmd.Val())
+	remaining := limit - count - 1 // -1 because we just added one
+
+	return &RateLimitInfo{
+		Limit:     limit,
+		Remaining: remaining,
+		ResetAt:   resetAt,
+	}, nil
+}
+
+// generateAPIKey creates a cryptographically random API key with the qf_ak_ prefix.
+func generateAPIKey() (string, error) {
+	b := make([]byte, apiKeyBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate random bytes: %w", err)
+	}
+	return apiKeyPrefix + hex.EncodeToString(b), nil
+}
+
+// isNotFound checks for common "not found" sentinel errors.
+func isNotFound(err error) bool {
+	return errors.Is(err, domain.ErrAPIKeyNotFound)
+}

--- a/internal/apikey/service_test.go
+++ b/internal/apikey/service_test.go
@@ -1,0 +1,665 @@
+package apikey
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/audit"
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// --- Mock Repository ---
+
+type mockRepo struct {
+	createFn       func(ctx context.Context, key *domain.APIKey) (*domain.APIKey, error)
+	findByIDFn     func(ctx context.Context, id uuid.UUID) (*domain.APIKey, error)
+	findByKeyHashFn func(ctx context.Context, keyHash string) (*domain.APIKey, error)
+	updateLastUsedFn func(ctx context.Context, id uuid.UUID, t time.Time) error
+	rotateKeyFn    func(ctx context.Context, id uuid.UUID, newKeyHash string, gracePeriodEnds time.Time) error
+	revokeFn       func(ctx context.Context, id uuid.UUID) error
+}
+
+func (m *mockRepo) Create(ctx context.Context, key *domain.APIKey) (*domain.APIKey, error) {
+	if m.createFn != nil {
+		return m.createFn(ctx, key)
+	}
+	return key, nil
+}
+
+func (m *mockRepo) FindByID(ctx context.Context, id uuid.UUID) (*domain.APIKey, error) {
+	if m.findByIDFn != nil {
+		return m.findByIDFn(ctx, id)
+	}
+	return testAPIKey(id), nil
+}
+
+func (m *mockRepo) FindByKeyHash(ctx context.Context, keyHash string) (*domain.APIKey, error) {
+	if m.findByKeyHashFn != nil {
+		return m.findByKeyHashFn(ctx, keyHash)
+	}
+	return testAPIKey(uuid.New()), nil
+}
+
+func (m *mockRepo) UpdateLastUsed(ctx context.Context, id uuid.UUID, t time.Time) error {
+	if m.updateLastUsedFn != nil {
+		return m.updateLastUsedFn(ctx, id, t)
+	}
+	return nil
+}
+
+func (m *mockRepo) RotateKey(ctx context.Context, id uuid.UUID, newKeyHash string, gracePeriodEnds time.Time) error {
+	if m.rotateKeyFn != nil {
+		return m.rotateKeyFn(ctx, id, newKeyHash, gracePeriodEnds)
+	}
+	return nil
+}
+
+func (m *mockRepo) Revoke(ctx context.Context, id uuid.UUID) error {
+	if m.revokeFn != nil {
+		return m.revokeFn(ctx, id)
+	}
+	return nil
+}
+
+// --- Mock Hasher ---
+
+type mockHasher struct {
+	hashFn   func(password string) (string, error)
+	verifyFn func(password, hash string) (bool, error)
+}
+
+func (m *mockHasher) Hash(password string) (string, error) {
+	if m.hashFn != nil {
+		return m.hashFn(password)
+	}
+	return "$argon2id$mock$" + password, nil
+}
+
+func (m *mockHasher) Verify(password, hash string) (bool, error) {
+	if m.verifyFn != nil {
+		return m.verifyFn(password, hash)
+	}
+	return hash == "$argon2id$mock$"+password, nil
+}
+
+// --- Helpers ---
+
+func testAPIKey(id uuid.UUID) *domain.APIKey {
+	now := time.Now().UTC()
+	return &domain.APIKey{
+		ID:        id,
+		ClientID:  uuid.New(),
+		Name:      "test-key",
+		KeyHash:   "$argon2id$mock$hash",
+		Scopes:    []string{"read:data"},
+		RateLimit: 100,
+		Status:    domain.APIKeyStatusActive,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+func newTestService(repo *mockRepo) *Service {
+	return NewService(repo, &mockHasher{}, nil, zap.NewNop(), audit.NopLogger{})
+}
+
+func newTestServiceWithRedis(repo *mockRepo, rdb *redis.Client) *Service {
+	return NewService(repo, &mockHasher{}, rdb, zap.NewNop(), audit.NopLogger{})
+}
+
+// --- generateAPIKey ---
+
+func TestGenerateAPIKey(t *testing.T) {
+	key, err := generateAPIKey()
+	require.NoError(t, err)
+	assert.True(t, len(key) > len(apiKeyPrefix), "key must be longer than prefix")
+	assert.Contains(t, key, apiKeyPrefix)
+	// 16 bytes hex = 32 chars + prefix
+	assert.Len(t, key, len(apiKeyPrefix)+32)
+}
+
+func TestGenerateAPIKey_Uniqueness(t *testing.T) {
+	keys := make(map[string]struct{})
+	for i := 0; i < 100; i++ {
+		key, err := generateAPIKey()
+		require.NoError(t, err)
+		_, exists := keys[key]
+		assert.False(t, exists, "duplicate key generated")
+		keys[key] = struct{}{}
+	}
+}
+
+// --- CreateAPIKey ---
+
+func TestService_CreateAPIKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		repo      *mockRepo
+		hasher    *mockHasher
+		clientID  uuid.UUID
+		keyName   string
+		scopes    []string
+		rateLimit int
+		expiresAt *time.Time
+		wantErr   bool
+		check     func(t *testing.T, result *CreateResult)
+	}{
+		{
+			name:      "success",
+			repo:      &mockRepo{},
+			clientID:  uuid.New(),
+			keyName:   "my-key",
+			scopes:    []string{"read:data"},
+			rateLimit: 100,
+			check: func(t *testing.T, result *CreateResult) {
+				assert.Contains(t, result.PlaintextKey, apiKeyPrefix)
+				assert.Equal(t, "my-key", result.APIKey.Name)
+				assert.Equal(t, domain.APIKeyStatusActive, result.APIKey.Status)
+				assert.Equal(t, 100, result.APIKey.RateLimit)
+			},
+		},
+		{
+			name:     "nil scopes become empty slice",
+			repo:     &mockRepo{},
+			clientID: uuid.New(),
+			keyName:  "nil-scopes",
+			scopes:   nil,
+			check: func(t *testing.T, result *CreateResult) {
+				assert.NotNil(t, result.APIKey.Scopes)
+				assert.Empty(t, result.APIKey.Scopes)
+			},
+		},
+		{
+			name:     "with expiration",
+			repo:     &mockRepo{},
+			clientID: uuid.New(),
+			keyName:  "expiring-key",
+			expiresAt: func() *time.Time {
+				t := time.Now().Add(24 * time.Hour)
+				return &t
+			}(),
+			check: func(t *testing.T, result *CreateResult) {
+				assert.NotNil(t, result.APIKey.ExpiresAt)
+			},
+		},
+		{
+			name: "hash error",
+			repo: &mockRepo{},
+			hasher: &mockHasher{
+				hashFn: func(_ string) (string, error) {
+					return "", fmt.Errorf("hash failed")
+				},
+			},
+			clientID: uuid.New(),
+			keyName:  "fail-hash",
+			wantErr:  true,
+		},
+		{
+			name: "repo create error",
+			repo: &mockRepo{
+				createFn: func(_ context.Context, _ *domain.APIKey) (*domain.APIKey, error) {
+					return nil, fmt.Errorf("db error")
+				},
+			},
+			clientID: uuid.New(),
+			keyName:  "fail-create",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hasher := tt.hasher
+			if hasher == nil {
+				hasher = &mockHasher{}
+			}
+			svc := NewService(tt.repo, hasher, nil, zap.NewNop(), audit.NopLogger{})
+
+			result, err := svc.CreateAPIKey(context.Background(), tt.clientID, tt.keyName, tt.scopes, tt.rateLimit, tt.expiresAt)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tt.check != nil {
+				tt.check(t, result)
+			}
+		})
+	}
+}
+
+// --- ValidateAPIKey ---
+
+func TestService_ValidateAPIKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		repo    *mockRepo
+		hasher  *mockHasher
+		key     string
+		wantErr error
+	}{
+		{
+			name: "success - active key",
+			repo: &mockRepo{
+				findByKeyHashFn: func(_ context.Context, _ string) (*domain.APIKey, error) {
+					k := testAPIKey(uuid.New())
+					k.RateLimit = 0 // no rate limit to skip Redis
+					return k, nil
+				},
+			},
+			key: "qf_ak_test",
+		},
+		{
+			name: "not found",
+			repo: &mockRepo{
+				findByKeyHashFn: func(_ context.Context, _ string) (*domain.APIKey, error) {
+					return nil, domain.ErrAPIKeyNotFound
+				},
+			},
+			key:     "qf_ak_nonexistent",
+			wantErr: domain.ErrAPIKeyNotFound,
+		},
+		{
+			name: "revoked key",
+			repo: &mockRepo{
+				findByKeyHashFn: func(_ context.Context, _ string) (*domain.APIKey, error) {
+					k := testAPIKey(uuid.New())
+					k.Status = domain.APIKeyStatusRevoked
+					return k, nil
+				},
+			},
+			key:     "qf_ak_revoked",
+			wantErr: domain.ErrAPIKeyRevoked,
+		},
+		{
+			name: "expired key",
+			repo: &mockRepo{
+				findByKeyHashFn: func(_ context.Context, _ string) (*domain.APIKey, error) {
+					k := testAPIKey(uuid.New())
+					past := time.Now().Add(-1 * time.Hour)
+					k.ExpiresAt = &past
+					return k, nil
+				},
+			},
+			key:     "qf_ak_expired",
+			wantErr: domain.ErrAPIKeyExpired,
+		},
+		{
+			name: "hash error",
+			hasher: &mockHasher{
+				hashFn: func(_ string) (string, error) {
+					return "", fmt.Errorf("hash error")
+				},
+			},
+			repo:    &mockRepo{},
+			key:     "qf_ak_hash_fail",
+			wantErr: errors.New("validate api key"),
+		},
+		{
+			name: "repo error (non-not-found)",
+			repo: &mockRepo{
+				findByKeyHashFn: func(_ context.Context, _ string) (*domain.APIKey, error) {
+					return nil, fmt.Errorf("db connection failed")
+				},
+			},
+			key:     "qf_ak_db_fail",
+			wantErr: errors.New("validate api key"),
+		},
+		{
+			name: "update last_used_at failure is non-fatal",
+			repo: &mockRepo{
+				findByKeyHashFn: func(_ context.Context, _ string) (*domain.APIKey, error) {
+					k := testAPIKey(uuid.New())
+					k.RateLimit = 0
+					return k, nil
+				},
+				updateLastUsedFn: func(_ context.Context, _ uuid.UUID, _ time.Time) error {
+					return fmt.Errorf("redis timeout")
+				},
+			},
+			key: "qf_ak_last_used_fail",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hasher := tt.hasher
+			if hasher == nil {
+				hasher = &mockHasher{}
+			}
+			svc := NewService(tt.repo, hasher, nil, zap.NewNop(), audit.NopLogger{})
+
+			key, _, err := svc.ValidateAPIKey(context.Background(), tt.key)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				if errors.Is(tt.wantErr, domain.ErrAPIKeyNotFound) ||
+					errors.Is(tt.wantErr, domain.ErrAPIKeyRevoked) ||
+					errors.Is(tt.wantErr, domain.ErrAPIKeyExpired) {
+					assert.ErrorIs(t, err, tt.wantErr)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.NotNil(t, key)
+			assert.Equal(t, domain.APIKeyStatusActive, key.Status)
+		})
+	}
+}
+
+// --- RotateKey ---
+
+func TestService_RotateKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		repo    *mockRepo
+		hasher  *mockHasher
+		keyID   uuid.UUID
+		wantErr error
+		check   func(t *testing.T, result *RotateResult)
+	}{
+		{
+			name:  "success",
+			repo:  &mockRepo{},
+			keyID: uuid.New(),
+			check: func(t *testing.T, result *RotateResult) {
+				assert.Contains(t, result.PlaintextKey, apiKeyPrefix)
+				assert.NotNil(t, result.APIKey)
+				assert.True(t, result.GracePeriodEnds.After(time.Now()))
+				// Grace period should be ~24h from now.
+				assert.WithinDuration(t, time.Now().Add(gracePeriodDuration), result.GracePeriodEnds, 5*time.Second)
+			},
+		},
+		{
+			name: "not found",
+			repo: &mockRepo{
+				findByIDFn: func(_ context.Context, _ uuid.UUID) (*domain.APIKey, error) {
+					return nil, domain.ErrAPIKeyNotFound
+				},
+			},
+			keyID:   uuid.New(),
+			wantErr: domain.ErrAPIKeyNotFound,
+		},
+		{
+			name: "revoked key cannot be rotated",
+			repo: &mockRepo{
+				findByIDFn: func(_ context.Context, id uuid.UUID) (*domain.APIKey, error) {
+					k := testAPIKey(id)
+					k.Status = domain.APIKeyStatusRevoked
+					return k, nil
+				},
+			},
+			keyID:   uuid.New(),
+			wantErr: domain.ErrAPIKeyRevoked,
+		},
+		{
+			name: "hash error during rotation",
+			hasher: &mockHasher{
+				hashFn: func(_ string) (string, error) {
+					return "", fmt.Errorf("hash failed")
+				},
+			},
+			repo:    &mockRepo{},
+			keyID:   uuid.New(),
+			wantErr: errors.New("rotate key"),
+		},
+		{
+			name: "repo rotate error",
+			repo: &mockRepo{
+				rotateKeyFn: func(_ context.Context, _ uuid.UUID, _ string, _ time.Time) error {
+					return fmt.Errorf("db error")
+				},
+			},
+			keyID:   uuid.New(),
+			wantErr: errors.New("rotate key"),
+		},
+		{
+			name: "repo rotate not found",
+			repo: &mockRepo{
+				rotateKeyFn: func(_ context.Context, _ uuid.UUID, _ string, _ time.Time) error {
+					return domain.ErrAPIKeyNotFound
+				},
+			},
+			keyID:   uuid.New(),
+			wantErr: domain.ErrAPIKeyNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hasher := tt.hasher
+			if hasher == nil {
+				hasher = &mockHasher{}
+			}
+			svc := NewService(tt.repo, hasher, nil, zap.NewNop(), audit.NopLogger{})
+
+			result, err := svc.RotateKey(context.Background(), tt.keyID)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				if errors.Is(tt.wantErr, domain.ErrAPIKeyNotFound) ||
+					errors.Is(tt.wantErr, domain.ErrAPIKeyRevoked) {
+					assert.ErrorIs(t, err, tt.wantErr)
+				}
+				return
+			}
+			require.NoError(t, err)
+			if tt.check != nil {
+				tt.check(t, result)
+			}
+		})
+	}
+}
+
+// --- RevokeKey ---
+
+func TestService_RevokeKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		repo    *mockRepo
+		keyID   uuid.UUID
+		wantErr error
+	}{
+		{
+			name:  "success",
+			repo:  &mockRepo{},
+			keyID: uuid.New(),
+		},
+		{
+			name: "not found",
+			repo: &mockRepo{
+				findByIDFn: func(_ context.Context, _ uuid.UUID) (*domain.APIKey, error) {
+					return nil, domain.ErrAPIKeyNotFound
+				},
+			},
+			keyID:   uuid.New(),
+			wantErr: domain.ErrAPIKeyNotFound,
+		},
+		{
+			name: "already revoked",
+			repo: &mockRepo{
+				findByIDFn: func(_ context.Context, id uuid.UUID) (*domain.APIKey, error) {
+					k := testAPIKey(id)
+					k.Status = domain.APIKeyStatusRevoked
+					return k, nil
+				},
+			},
+			keyID:   uuid.New(),
+			wantErr: domain.ErrAPIKeyRevoked,
+		},
+		{
+			name: "repo revoke error",
+			repo: &mockRepo{
+				revokeFn: func(_ context.Context, _ uuid.UUID) error {
+					return fmt.Errorf("db error")
+				},
+			},
+			keyID:   uuid.New(),
+			wantErr: errors.New("revoke key"),
+		},
+		{
+			name: "repo revoke not found",
+			repo: &mockRepo{
+				revokeFn: func(_ context.Context, _ uuid.UUID) error {
+					return domain.ErrAPIKeyNotFound
+				},
+			},
+			keyID:   uuid.New(),
+			wantErr: domain.ErrAPIKeyNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newTestService(tt.repo)
+
+			err := svc.RevokeKey(context.Background(), tt.keyID)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				if errors.Is(tt.wantErr, domain.ErrAPIKeyNotFound) ||
+					errors.Is(tt.wantErr, domain.ErrAPIKeyRevoked) {
+					assert.ErrorIs(t, err, tt.wantErr)
+				}
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+// --- checkRateLimit ---
+
+func TestService_CheckRateLimit_NoLimit(t *testing.T) {
+	svc := newTestService(&mockRepo{})
+
+	info, err := svc.checkRateLimit(context.Background(), "test-key", 0)
+	require.NoError(t, err)
+	assert.Equal(t, 0, info.Limit)
+}
+
+func TestService_CheckRateLimit_NegativeLimit(t *testing.T) {
+	svc := newTestService(&mockRepo{})
+
+	info, err := svc.checkRateLimit(context.Background(), "test-key", -1)
+	require.NoError(t, err)
+	assert.Equal(t, 0, info.Limit)
+}
+
+// --- Domain type tests ---
+
+func TestAPIKey_IsExpired(t *testing.T) {
+	tests := []struct {
+		name      string
+		expiresAt *time.Time
+		want      bool
+	}{
+		{
+			name:      "nil expiration - not expired",
+			expiresAt: nil,
+			want:      false,
+		},
+		{
+			name: "future expiration - not expired",
+			expiresAt: func() *time.Time {
+				t := time.Now().Add(1 * time.Hour)
+				return &t
+			}(),
+			want: false,
+		},
+		{
+			name: "past expiration - expired",
+			expiresAt: func() *time.Time {
+				t := time.Now().Add(-1 * time.Hour)
+				return &t
+			}(),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := &domain.APIKey{ExpiresAt: tt.expiresAt}
+			assert.Equal(t, tt.want, key.IsExpired())
+		})
+	}
+}
+
+func TestAPIKey_IsActive(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    string
+		expiresAt *time.Time
+		want      bool
+	}{
+		{
+			name:   "active status, no expiry",
+			status: domain.APIKeyStatusActive,
+			want:   true,
+		},
+		{
+			name:   "revoked status",
+			status: domain.APIKeyStatusRevoked,
+			want:   false,
+		},
+		{
+			name:   "active but expired",
+			status: domain.APIKeyStatusActive,
+			expiresAt: func() *time.Time {
+				t := time.Now().Add(-1 * time.Hour)
+				return &t
+			}(),
+			want: false,
+		},
+		{
+			name:   "active with future expiry",
+			status: domain.APIKeyStatusActive,
+			expiresAt: func() *time.Time {
+				t := time.Now().Add(1 * time.Hour)
+				return &t
+			}(),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := &domain.APIKey{Status: tt.status, ExpiresAt: tt.expiresAt}
+			assert.Equal(t, tt.want, key.IsActive())
+		})
+	}
+}
+
+// --- NewService ---
+
+func TestNewService(t *testing.T) {
+	repo := &mockRepo{}
+	hasher := &mockHasher{}
+	rdb := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+	logger := zap.NewNop()
+	auditor := audit.NopLogger{}
+
+	svc := NewService(repo, hasher, rdb, logger, auditor)
+	assert.NotNil(t, svc)
+	assert.Equal(t, repo, svc.repo)
+	assert.Equal(t, hasher, svc.hasher)
+	assert.Equal(t, rdb, svc.rdb)
+	assert.Equal(t, logger, svc.logger)
+
+	_ = rdb.Close()
+}
+
+// --- isNotFound ---
+
+func TestIsNotFound(t *testing.T) {
+	assert.True(t, isNotFound(domain.ErrAPIKeyNotFound))
+	assert.True(t, isNotFound(fmt.Errorf("wrapped: %w", domain.ErrAPIKeyNotFound)))
+	assert.False(t, isNotFound(fmt.Errorf("some other error")))
+	assert.False(t, isNotFound(domain.ErrAPIKeyRevoked))
+}

--- a/internal/domain/apikey.go
+++ b/internal/domain/apikey.go
@@ -1,0 +1,40 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// APIKey status constants.
+const (
+	APIKeyStatusActive  = "active"
+	APIKeyStatusRevoked = "revoked"
+)
+
+// APIKey represents a long-lived API key bound to a client.
+type APIKey struct {
+	ID                    uuid.UUID  `json:"id"                        db:"id"`
+	ClientID              uuid.UUID  `json:"client_id"                 db:"client_id"`
+	Name                  string     `json:"name"                      db:"name"`
+	KeyHash               string     `json:"-"                         db:"key_hash"`
+	PreviousKeyHash       string     `json:"-"                         db:"previous_key_hash"`
+	PreviousKeyExpiresAt  *time.Time `json:"-"                         db:"previous_key_expires_at"`
+	Scopes                []string   `json:"scopes"                    db:"scopes"`
+	RateLimit             int        `json:"rate_limit"                db:"rate_limit"` // requests per minute
+	Status                string     `json:"status"                    db:"status"`
+	ExpiresAt             *time.Time `json:"expires_at,omitempty"      db:"expires_at"`
+	LastUsedAt            *time.Time `json:"last_used_at,omitempty"    db:"last_used_at"`
+	CreatedAt             time.Time  `json:"created_at"                db:"created_at"`
+	UpdatedAt             time.Time  `json:"updated_at"                db:"updated_at"`
+}
+
+// IsExpired returns true if the API key has passed its expiration time.
+func (k *APIKey) IsExpired() bool {
+	return k.ExpiresAt != nil && time.Now().UTC().After(*k.ExpiresAt)
+}
+
+// IsActive returns true if the key status is active and it is not expired.
+func (k *APIKey) IsActive() bool {
+	return k.Status == APIKeyStatusActive && !k.IsExpired()
+}

--- a/internal/domain/sentinel_errors.go
+++ b/internal/domain/sentinel_errors.go
@@ -20,6 +20,12 @@ var (
 	ErrClientNotFound  = errors.New("client not found")
 	ErrClientSuspended = errors.New("client suspended")
 
+	// API key errors.
+	ErrAPIKeyNotFound    = errors.New("api key not found")
+	ErrAPIKeyRevoked     = errors.New("api key revoked")
+	ErrAPIKeyExpired     = errors.New("api key expired")
+	ErrAPIKeyRateLimited = errors.New("api key rate limit exceeded")
+
 	// Session errors.
 	ErrSessionInactive = errors.New("session inactive due to inactivity")
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-198.

Closes #198

## Changes

Create `internal/apikey/service.go` with the core business logic. `CreateAPIKey` generates 128-bit random keys with `qf_ak_` prefix (following `generateClientSecret()` pattern in `internal/admin/client_service.go`), hashes with Argon2id before storage. `ValidateAPIKey` hashes the input, looks up by hash, checks expiry/status, updates `last_used_at`. `RotateKey` creates a new key, moves current hash to `previous_key_hash` with 24h grace period (matching the client secret rotation pattern in `internal/storage/client_repository.go`). `RevokeKey` soft-deletes. Implement per-key rate limiting via Redis (key pattern `rl:ak:{keyID}`) using a sliding window or token bucket, returning rate limit info. Include comprehensive table-driven tests.