### PR TITLE
GH-199: API key authentication middleware

### DIFF
--- a/internal/middleware/apikey.go
+++ b/internal/middleware/apikey.go
@@ -1,0 +1,157 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/time/rate"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+const apiKeyHeader = "X-API-Key"
+
+// APIKeyInfo holds the validated API key metadata returned by the validator.
+type APIKeyInfo struct {
+	ClientID   string
+	ClientType domain.ClientType
+	Scopes     []string
+	RateLimit  int // requests per second; 0 means no per-key limit
+}
+
+// APIKeyValidator defines the operations required by APIKeyMiddleware.
+type APIKeyValidator interface {
+	// ValidateAPIKey checks the raw API key (with qf_ak_ prefix) and returns
+	// its associated metadata. Returns an error if the key is invalid, expired,
+	// or revoked.
+	ValidateAPIKey(ctx context.Context, rawKey string) (*APIKeyInfo, error)
+}
+
+// apiKeyVisitor tracks per-key rate limit state.
+type apiKeyVisitor struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+// APIKeyRateLimiter manages per-key token bucket rate limiters.
+type APIKeyRateLimiter struct {
+	mu       sync.Mutex
+	visitors map[string]*apiKeyVisitor
+}
+
+// NewAPIKeyRateLimiter creates a per-key rate limiter.
+func NewAPIKeyRateLimiter() *APIKeyRateLimiter {
+	rl := &APIKeyRateLimiter{
+		visitors: make(map[string]*apiKeyVisitor),
+	}
+	go rl.cleanup()
+	return rl
+}
+
+// getVisitor returns the rate limiter for the given key, creating one if the
+// limit has changed or the key is seen for the first time.
+func (rl *APIKeyRateLimiter) getVisitor(clientID string, rps int) *apiKeyVisitor {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	v, exists := rl.visitors[clientID]
+	if !exists || int(v.limiter.Limit()) != rps {
+		v = &apiKeyVisitor{
+			limiter: rate.NewLimiter(rate.Limit(rps), rps),
+		}
+		rl.visitors[clientID] = v
+	}
+	v.lastSeen = time.Now()
+	return v
+}
+
+// cleanup removes visitors that haven't been seen for 3+ minutes.
+func (rl *APIKeyRateLimiter) cleanup() {
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+	for range ticker.C {
+		rl.mu.Lock()
+		for id, v := range rl.visitors {
+			if time.Since(v.lastSeen) > 3*time.Minute {
+				delete(rl.visitors, id)
+			}
+		}
+		rl.mu.Unlock()
+	}
+}
+
+// APIKeyMiddleware returns a Gin middleware that authenticates requests via
+// the X-API-Key header. Behaviour:
+//
+//  1. If no X-API-Key header is present, calls c.Next() (fall-through to
+//     Bearer token auth).
+//  2. Validates the key via the APIKeyValidator.
+//  3. Enforces per-key rate limits when the key has a non-zero RateLimit.
+//  4. Stores *domain.TokenClaims under "claims" and ClientID under "user_id",
+//     matching the context keys set by AuthMiddleware.
+//
+// Rate limit headers (X-RateLimit-Limit, X-RateLimit-Remaining,
+// X-RateLimit-Reset) are set following the pattern in ratelimit.go.
+func APIKeyMiddleware(validator APIKeyValidator, rateLimiter *APIKeyRateLimiter) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rawKey := c.GetHeader(apiKeyHeader)
+		if rawKey == "" {
+			c.Next()
+			return
+		}
+
+		info, err := validator.ValidateAPIKey(c.Request.Context(), rawKey)
+		if err != nil {
+			domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized,
+				"invalid or expired API key")
+			return
+		}
+
+		// Enforce per-key rate limit if configured.
+		if info.RateLimit > 0 {
+			v := rateLimiter.getVisitor(info.ClientID, info.RateLimit)
+			reservation := v.limiter.Reserve()
+			if !reservation.OK() {
+				domain.RespondWithError(c, http.StatusTooManyRequests, domain.CodeRateLimitExceded,
+					"API key rate limit exceeded")
+				return
+			}
+
+			delay := reservation.Delay()
+			if delay > 0 {
+				reservation.Cancel()
+				retryAfter := int(delay.Seconds()) + 1
+				c.Header("Retry-After", strconv.Itoa(retryAfter))
+				c.Header("X-RateLimit-Limit", strconv.Itoa(info.RateLimit))
+				c.Header("X-RateLimit-Remaining", "0")
+				c.Header("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(delay).Unix(), 10))
+				domain.RespondWithError(c, http.StatusTooManyRequests, domain.CodeRateLimitExceded,
+					"API key rate limit exceeded")
+				return
+			}
+
+			remaining := int(v.limiter.Tokens())
+			if remaining < 0 {
+				remaining = 0
+			}
+			c.Header("X-RateLimit-Limit", strconv.Itoa(info.RateLimit))
+			c.Header("X-RateLimit-Remaining", strconv.Itoa(remaining))
+			c.Header("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(time.Second).Unix(), 10))
+		}
+
+		// Populate the same context keys used by AuthMiddleware so downstream
+		// handlers (RBAC, etc.) work identically.
+		claims := &domain.TokenClaims{
+			Subject:    info.ClientID,
+			Scopes:     info.Scopes,
+			ClientType: info.ClientType,
+		}
+		c.Set(claimsContextKey, claims)
+		c.Set(userIDContextKey, info.ClientID)
+		c.Next()
+	}
+}

--- a/internal/middleware/apikey_test.go
+++ b/internal/middleware/apikey_test.go
@@ -1,0 +1,244 @@
+package middleware_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/middleware"
+)
+
+// mockAPIKeyValidator implements middleware.APIKeyValidator for testing.
+type mockAPIKeyValidator struct {
+	info *middleware.APIKeyInfo
+	err  error
+}
+
+func (m *mockAPIKeyValidator) ValidateAPIKey(_ context.Context, _ string) (*middleware.APIKeyInfo, error) {
+	return m.info, m.err
+}
+
+func newAPIKeyTestRouter(v middleware.APIKeyValidator, rl *middleware.APIKeyRateLimiter) *gin.Engine {
+	r := gin.New()
+	r.Use(middleware.APIKeyMiddleware(v, rl))
+	r.GET("/resource", func(c *gin.Context) {
+		userID := c.GetString("user_id")
+		c.String(http.StatusOK, userID)
+	})
+	return r
+}
+
+func TestAPIKeyMiddleware_NoHeader_FallsThrough(t *testing.T) {
+	v := &mockAPIKeyValidator{info: &middleware.APIKeyInfo{ClientID: "c1"}}
+	rl := middleware.NewAPIKeyRateLimiter()
+
+	router := newAPIKeyTestRouter(v, rl)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/resource", http.NoBody)
+	router.ServeHTTP(w, req)
+
+	// No X-API-Key → middleware falls through, handler runs with empty user_id.
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Body.String())
+}
+
+func TestAPIKeyMiddleware_ValidKey_SetsClaims(t *testing.T) {
+	info := &middleware.APIKeyInfo{
+		ClientID:   "client-abc",
+		ClientType: domain.ClientTypeService,
+		Scopes:     []string{"read:data", "write:data"},
+		RateLimit:  0,
+	}
+	v := &mockAPIKeyValidator{info: info}
+	rl := middleware.NewAPIKeyRateLimiter()
+
+	var capturedClaims *domain.TokenClaims
+	r := gin.New()
+	r.Use(middleware.APIKeyMiddleware(v, rl))
+	r.GET("/check", func(c *gin.Context) {
+		got, err := middleware.GetClaims(c)
+		require.NoError(t, err)
+		capturedClaims = got
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/check", http.NoBody)
+	req.Header.Set("X-API-Key", "qf_ak_testkey123")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, capturedClaims)
+	assert.Equal(t, "client-abc", capturedClaims.Subject)
+	assert.Equal(t, []string{"read:data", "write:data"}, capturedClaims.Scopes)
+	assert.Equal(t, domain.ClientTypeService, capturedClaims.ClientType)
+}
+
+func TestAPIKeyMiddleware_ValidKey_SetsUserID(t *testing.T) {
+	info := &middleware.APIKeyInfo{
+		ClientID:   "client-xyz",
+		ClientType: domain.ClientTypeAgent,
+		Scopes:     []string{"read:metrics"},
+	}
+	v := &mockAPIKeyValidator{info: info}
+	rl := middleware.NewAPIKeyRateLimiter()
+
+	router := newAPIKeyTestRouter(v, rl)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/resource", http.NoBody)
+	req.Header.Set("X-API-Key", "qf_ak_validkey")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "client-xyz", w.Body.String())
+}
+
+func TestAPIKeyMiddleware_InvalidKey_Returns401(t *testing.T) {
+	v := &mockAPIKeyValidator{err: errors.New("key revoked")}
+	rl := middleware.NewAPIKeyRateLimiter()
+
+	router := newAPIKeyTestRouter(v, rl)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/resource", http.NoBody)
+	req.Header.Set("X-API-Key", "qf_ak_badkey")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Contains(t, w.Body.String(), "invalid or expired API key")
+}
+
+func TestAPIKeyMiddleware_RateLimitHeaders_Set(t *testing.T) {
+	info := &middleware.APIKeyInfo{
+		ClientID:   "client-rl",
+		ClientType: domain.ClientTypeService,
+		Scopes:     []string{"read:data"},
+		RateLimit:  100,
+	}
+	v := &mockAPIKeyValidator{info: info}
+	rl := middleware.NewAPIKeyRateLimiter()
+
+	router := newAPIKeyTestRouter(v, rl)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/resource", http.NoBody)
+	req.Header.Set("X-API-Key", "qf_ak_rlkey")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "100", w.Header().Get("X-RateLimit-Limit"))
+	assert.NotEmpty(t, w.Header().Get("X-RateLimit-Remaining"))
+	assert.NotEmpty(t, w.Header().Get("X-RateLimit-Reset"))
+}
+
+func TestAPIKeyMiddleware_NoRateLimit_NoHeaders(t *testing.T) {
+	info := &middleware.APIKeyInfo{
+		ClientID:   "client-nrl",
+		ClientType: domain.ClientTypeService,
+		Scopes:     []string{"read:data"},
+		RateLimit:  0,
+	}
+	v := &mockAPIKeyValidator{info: info}
+	rl := middleware.NewAPIKeyRateLimiter()
+
+	router := newAPIKeyTestRouter(v, rl)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/resource", http.NoBody)
+	req.Header.Set("X-API-Key", "qf_ak_nrlkey")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get("X-RateLimit-Limit"))
+}
+
+func TestAPIKeyMiddleware_RateLimitExceeded_Returns429(t *testing.T) {
+	info := &middleware.APIKeyInfo{
+		ClientID:   "client-burst",
+		ClientType: domain.ClientTypeService,
+		Scopes:     []string{"read:data"},
+		RateLimit:  1, // 1 req/sec, burst 1
+	}
+	v := &mockAPIKeyValidator{info: info}
+	rl := middleware.NewAPIKeyRateLimiter()
+
+	router := newAPIKeyTestRouter(v, rl)
+
+	// First request should succeed.
+	w1 := httptest.NewRecorder()
+	req1 := httptest.NewRequest(http.MethodGet, "/resource", http.NoBody)
+	req1.Header.Set("X-API-Key", "qf_ak_burstkey")
+	router.ServeHTTP(w1, req1)
+	assert.Equal(t, http.StatusOK, w1.Code)
+
+	// Rapid second request should be rate-limited.
+	w2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodGet, "/resource", http.NoBody)
+	req2.Header.Set("X-API-Key", "qf_ak_burstkey")
+	router.ServeHTTP(w2, req2)
+	assert.Equal(t, http.StatusTooManyRequests, w2.Code)
+	assert.Contains(t, w2.Body.String(), "rate limit exceeded")
+	assert.NotEmpty(t, w2.Header().Get("Retry-After"))
+	assert.Equal(t, "1", w2.Header().Get("X-RateLimit-Limit"))
+	assert.Equal(t, "0", w2.Header().Get("X-RateLimit-Remaining"))
+}
+
+func TestAPIKeyMiddleware_TableDriven(t *testing.T) {
+	validInfo := &middleware.APIKeyInfo{
+		ClientID:   "client-td",
+		ClientType: domain.ClientTypeService,
+		Scopes:     []string{"read:data"},
+	}
+
+	tests := []struct {
+		name             string
+		apiKey           string
+		validator        *mockAPIKeyValidator
+		wantStatus       int
+		wantBodyContains string
+	}{
+		{
+			name:       "no API key header falls through",
+			apiKey:     "",
+			validator:  &mockAPIKeyValidator{info: validInfo},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:             "valid key authenticates",
+			apiKey:           "qf_ak_valid",
+			validator:        &mockAPIKeyValidator{info: validInfo},
+			wantStatus:       http.StatusOK,
+			wantBodyContains: "client-td",
+		},
+		{
+			name:             "validation error returns 401",
+			apiKey:           "qf_ak_bad",
+			validator:        &mockAPIKeyValidator{err: errors.New("invalid key")},
+			wantStatus:       http.StatusUnauthorized,
+			wantBodyContains: "invalid or expired API key",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rl := middleware.NewAPIKeyRateLimiter()
+			router := newAPIKeyTestRouter(tc.validator, rl)
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/resource", http.NoBody)
+			if tc.apiKey != "" {
+				req.Header.Set("X-API-Key", tc.apiKey)
+			}
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+			if tc.wantBodyContains != "" {
+				assert.Contains(t, w.Body.String(), tc.wantBodyContains)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-199.

Closes #199

## Changes

Create `internal/middleware/apikey.go` with `APIKeyMiddleware` that checks for `X-API-Key` header, validates the key via the apikey service, enforces per-key rate limits, and sets claims (client_id, scopes) into the Gin context using the same context keys as the existing `AuthMiddleware` in `internal/middleware/auth.go`. If no `X-API-Key` header is present, the middleware falls through (calls `c.Next()`) so the existing Bearer token auth middleware can handle it. Add rate limit headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`) following the pattern in `internal/middleware/ratelimit.go`. Include unit tests.