### PR TITLE
GH-200: Admin API endpoints and DI wiring

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -106,6 +106,17 @@ func run(log *zap.Logger, cfg *config.Config) error {
 	// ── Metrics ───────────────────────────────────────────────────────────
 	metricsCollector := metrics.New()
 
+	// ── Repositories (admin) ─────────────────────────────────────────────
+	adminUserRepo := storage.NewPostgresAdminUserRepository(pgPool)
+	clientRepo := storage.NewPostgresClientRepository(pgPool)
+	apiKeyRepo := storage.NewPostgresAPIKeyRepository(pgPool)
+
+	// ── Admin services ────────────────────────────────────────────────────
+	adminUserSvc := admin.NewUserService(adminUserRepo, hasher, log, auditSvc)
+	adminClientSvc := admin.NewClientService(clientRepo, hasher, log, auditSvc)
+	adminTokenSvc := admin.NewTokenService(tokenSvc, refreshTokenRepo, "auth-service", log, auditSvc)
+	adminAPIKeySvc := admin.NewAPIKeyService(apiKeyRepo, hasher, log, auditSvc)
+
 	// ── Middleware ─────────────────────────────────────────────────────────
 	rateLimiter := middleware.NewRateLimiter(cfg.Rate)
 
@@ -115,23 +126,16 @@ func run(log *zap.Logger, cfg *config.Config) error {
 		SecurityHeaders: middleware.SecurityHeaders(),
 		RateLimit:       rateLimiter.Handler(),
 		RequestSize:     middleware.RequestSize(cfg.RequestLimit),
+		APIKey:          middleware.APIKeyMiddleware(adminAPIKeySvc),
 		Auth:            middleware.AuthMiddleware(tokenSvc),
 		Metrics:         metricsCollector.Middleware(),
 	}
-
-	// ── Repositories (admin) ─────────────────────────────────────────────
-	adminUserRepo := storage.NewPostgresAdminUserRepository(pgPool)
-	clientRepo := storage.NewPostgresClientRepository(pgPool)
-
-	// ── Admin services ────────────────────────────────────────────────────
-	adminUserSvc := admin.NewUserService(adminUserRepo, hasher, log, auditSvc)
-	adminClientSvc := admin.NewClientService(clientRepo, hasher, log, auditSvc)
-	adminTokenSvc := admin.NewTokenService(tokenSvc, refreshTokenRepo, "auth-service", log, auditSvc)
 
 	adminServices := &api.AdminServices{
 		Users:   adminUserSvc,
 		Clients: adminClientSvc,
 		Tokens:  adminTokenSvc,
+		APIKeys: adminAPIKeySvc,
 	}
 
 	adminDeps := &api.AdminDeps{

--- a/internal/admin/apikey_service.go
+++ b/internal/admin/apikey_service.go
@@ -1,0 +1,338 @@
+package admin
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/audit"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/middleware"
+	"github.com/qf-studio/auth-service/internal/password"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+const (
+	// apiKeyPrefix is prepended to generated API keys for leak detection.
+	apiKeyPrefix = "qf_ak_"
+	// apiKeyBytes is the number of random bytes for API key generation (128-bit).
+	apiKeyBytes = 16
+	// apiKeyGracePeriod is the grace period after key rotation.
+	apiKeyGracePeriod = 24 * time.Hour
+	// defaultRateLimit is the default per-key rate limit (requests/minute).
+	defaultRateLimit = 1000
+)
+
+// APIKeyService implements api.AdminAPIKeyService.
+type APIKeyService struct {
+	repo   storage.APIKeyRepository
+	hasher password.Hasher
+	logger *zap.Logger
+	audit  audit.EventLogger
+}
+
+// NewAPIKeyService creates a new admin API key service.
+func NewAPIKeyService(repo storage.APIKeyRepository, hasher password.Hasher, logger *zap.Logger, auditor audit.EventLogger) *APIKeyService {
+	return &APIKeyService{
+		repo:   repo,
+		hasher: hasher,
+		logger: logger,
+		audit:  auditor,
+	}
+}
+
+// ListAPIKeys returns a paginated list of API keys, optionally filtered by client_id.
+func (s *APIKeyService) ListAPIKeys(ctx context.Context, page, perPage int, clientID string) (*api.AdminAPIKeyList, error) {
+	offset := (page - 1) * perPage
+
+	keys, total, err := s.repo.List(ctx, perPage, offset, clientID)
+	if err != nil {
+		s.logger.Error("list api keys failed", zap.Error(err))
+		return nil, fmt.Errorf("list api keys: %w", api.ErrInternalError)
+	}
+
+	result := &api.AdminAPIKeyList{
+		APIKeys: make([]api.AdminAPIKey, 0, len(keys)),
+		Total:   total,
+		Page:    page,
+		PerPage: perPage,
+	}
+
+	for _, k := range keys {
+		result.APIKeys = append(result.APIKeys, domainAPIKeyToAdmin(k))
+	}
+
+	return result, nil
+}
+
+// GetAPIKey retrieves a single API key by ID.
+func (s *APIKeyService) GetAPIKey(ctx context.Context, keyID string) (*api.AdminAPIKey, error) {
+	id, err := uuid.Parse(keyID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid api key ID: %w", api.ErrNotFound)
+	}
+
+	k, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("api key %s: %w", keyID, api.ErrNotFound)
+		}
+		s.logger.Error("get api key failed", zap.String("key_id", keyID), zap.Error(err))
+		return nil, fmt.Errorf("get api key: %w", api.ErrInternalError)
+	}
+
+	admin := domainAPIKeyToAdmin(k)
+	return &admin, nil
+}
+
+// CreateAPIKey creates a new API key with a generated raw key.
+func (s *APIKeyService) CreateAPIKey(ctx context.Context, req *api.CreateAPIKeyRequest) (*api.AdminAPIKeyWithSecret, error) {
+	clientID, err := uuid.Parse(req.ClientID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid client ID: %w", api.ErrNotFound)
+	}
+
+	rawKey, err := generateAPIKey()
+	if err != nil {
+		s.logger.Error("generate api key failed", zap.Error(err))
+		return nil, fmt.Errorf("create api key: %w", api.ErrInternalError)
+	}
+
+	hash, err := s.hasher.Hash(rawKey)
+	if err != nil {
+		s.logger.Error("hash api key failed", zap.Error(err))
+		return nil, fmt.Errorf("create api key: %w", api.ErrInternalError)
+	}
+
+	now := time.Now().UTC()
+	scopes := req.Scopes
+	if scopes == nil {
+		scopes = []string{}
+	}
+
+	rateLimit := defaultRateLimit
+	if req.RateLimit != nil {
+		rateLimit = *req.RateLimit
+	}
+
+	// Store the first 8 characters of the key for identification.
+	keyPrefix := rawKey[:len(apiKeyPrefix)+8]
+
+	var expiresAt *time.Time
+	if req.ExpiresAt != nil {
+		t, err := time.Parse(time.RFC3339, *req.ExpiresAt)
+		if err != nil {
+			return nil, fmt.Errorf("invalid expires_at format (use RFC3339): %w", api.ErrConflict)
+		}
+		expiresAt = &t
+	}
+
+	key := &domain.APIKey{
+		ID:        uuid.New(),
+		ClientID:  clientID,
+		Name:      req.Name,
+		KeyHash:   hash,
+		KeyPrefix: keyPrefix,
+		Scopes:    scopes,
+		RateLimit: rateLimit,
+		Status:    domain.APIKeyStatusActive,
+		ExpiresAt: expiresAt,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	created, err := s.repo.Create(ctx, key)
+	if err != nil {
+		s.logger.Error("create api key failed", zap.Error(err))
+		return nil, fmt.Errorf("create api key: %w", api.ErrInternalError)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminAPIKeyCreate,
+		TargetID: created.ID.String(),
+		Metadata: map[string]string{"name": created.Name, "client_id": created.ClientID.String()},
+	})
+
+	return &api.AdminAPIKeyWithSecret{
+		AdminAPIKey: domainAPIKeyToAdmin(created),
+		Key:         rawKey,
+	}, nil
+}
+
+// UpdateAPIKey modifies API key fields (name, scopes, rate_limit).
+func (s *APIKeyService) UpdateAPIKey(ctx context.Context, keyID string, req *api.UpdateAPIKeyRequest) (*api.AdminAPIKey, error) {
+	id, err := uuid.Parse(keyID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid api key ID: %w", api.ErrNotFound)
+	}
+
+	existing, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("api key %s: %w", keyID, api.ErrNotFound)
+		}
+		s.logger.Error("find api key for update failed", zap.String("key_id", keyID), zap.Error(err))
+		return nil, fmt.Errorf("update api key: %w", api.ErrInternalError)
+	}
+
+	if req.Name != nil {
+		existing.Name = *req.Name
+	}
+	if req.Scopes != nil {
+		existing.Scopes = req.Scopes
+	}
+	if req.RateLimit != nil {
+		existing.RateLimit = *req.RateLimit
+	}
+
+	updated, err := s.repo.Update(ctx, existing)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("api key %s: %w", keyID, api.ErrNotFound)
+		}
+		s.logger.Error("update api key failed", zap.String("key_id", keyID), zap.Error(err))
+		return nil, fmt.Errorf("update api key: %w", api.ErrInternalError)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminAPIKeyUpdate,
+		TargetID: keyID,
+	})
+
+	admin := domainAPIKeyToAdmin(updated)
+	return &admin, nil
+}
+
+// RevokeAPIKey marks an API key as revoked.
+func (s *APIKeyService) RevokeAPIKey(ctx context.Context, keyID string) error {
+	id, err := uuid.Parse(keyID)
+	if err != nil {
+		return fmt.Errorf("invalid api key ID: %w", api.ErrNotFound)
+	}
+
+	err = s.repo.Revoke(ctx, id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return fmt.Errorf("api key %s: %w", keyID, api.ErrNotFound)
+		}
+		if errors.Is(err, storage.ErrAlreadyDeleted) {
+			return fmt.Errorf("api key %s already revoked: %w", keyID, api.ErrConflict)
+		}
+		s.logger.Error("revoke api key failed", zap.String("key_id", keyID), zap.Error(err))
+		return fmt.Errorf("revoke api key: %w", api.ErrInternalError)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminAPIKeyRevoke,
+		TargetID: keyID,
+	})
+	return nil
+}
+
+// RotateAPIKey generates a new key for the API key with a grace period.
+func (s *APIKeyService) RotateAPIKey(ctx context.Context, keyID string) (*api.AdminAPIKeyWithSecret, error) {
+	id, err := uuid.Parse(keyID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid api key ID: %w", api.ErrNotFound)
+	}
+
+	rawKey, err := generateAPIKey()
+	if err != nil {
+		s.logger.Error("generate api key failed", zap.Error(err))
+		return nil, fmt.Errorf("rotate api key: %w", api.ErrInternalError)
+	}
+
+	hash, err := s.hasher.Hash(rawKey)
+	if err != nil {
+		s.logger.Error("hash api key failed", zap.Error(err))
+		return nil, fmt.Errorf("rotate api key: %w", api.ErrInternalError)
+	}
+
+	graceEnd := time.Now().UTC().Add(apiKeyGracePeriod)
+
+	if err := s.repo.RotateKey(ctx, id, hash, graceEnd); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("api key %s: %w", keyID, api.ErrNotFound)
+		}
+		s.logger.Error("rotate api key failed", zap.String("key_id", keyID), zap.Error(err))
+		return nil, fmt.Errorf("rotate api key: %w", api.ErrInternalError)
+	}
+
+	key, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		s.logger.Error("re-read api key after rotation failed", zap.String("key_id", keyID), zap.Error(err))
+		return nil, fmt.Errorf("rotate api key: %w", api.ErrInternalError)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminAPIKeyRotate,
+		TargetID: keyID,
+	})
+
+	return &api.AdminAPIKeyWithSecret{
+		AdminAPIKey:     domainAPIKeyToAdmin(key),
+		Key:             rawKey,
+		GracePeriodEnds: &graceEnd,
+	}, nil
+}
+
+// ValidateAPIKey validates a raw API key and returns its metadata.
+// This method satisfies middleware.APIKeyValidator.
+func (s *APIKeyService) ValidateAPIKey(ctx context.Context, rawKey string) (*middleware.APIKeyInfo, error) {
+	hash, err := s.hasher.Hash(rawKey)
+	if err != nil {
+		s.logger.Error("hash api key for validation failed", zap.Error(err))
+		return nil, fmt.Errorf("validate api key: %w", err)
+	}
+
+	key, err := s.repo.FindByKeyHash(ctx, hash)
+	if err != nil {
+		return nil, fmt.Errorf("validate api key: %w", err)
+	}
+
+	if !key.IsActive() {
+		return nil, fmt.Errorf("api key is not active")
+	}
+
+	// Best-effort update of last_used_at.
+	_ = s.repo.UpdateLastUsed(ctx, key.ID)
+
+	return &middleware.APIKeyInfo{
+		ClientID:  key.ClientID.String(),
+		Scopes:    key.Scopes,
+		RateLimit: key.RateLimit,
+	}, nil
+}
+
+// generateAPIKey generates a cryptographically random API key with the qf_ak_ prefix.
+func generateAPIKey() (string, error) {
+	b := make([]byte, apiKeyBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate random bytes: %w", err)
+	}
+	return apiKeyPrefix + hex.EncodeToString(b), nil
+}
+
+// domainAPIKeyToAdmin converts a domain.APIKey to an api.AdminAPIKey response DTO.
+func domainAPIKeyToAdmin(k *domain.APIKey) api.AdminAPIKey {
+	return api.AdminAPIKey{
+		ID:         k.ID.String(),
+		ClientID:   k.ClientID.String(),
+		Name:       k.Name,
+		KeyPrefix:  k.KeyPrefix,
+		Scopes:     k.Scopes,
+		RateLimit:  k.RateLimit,
+		Status:     k.Status,
+		ExpiresAt:  k.ExpiresAt,
+		LastUsedAt: k.LastUsedAt,
+		CreatedAt:  k.CreatedAt,
+		UpdatedAt:  k.UpdatedAt,
+	}
+}

--- a/internal/api/admin_apikey_handlers.go
+++ b/internal/api/admin_apikey_handlers.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// AdminAPIKeyHandlers groups HTTP handlers for admin API key management endpoints.
+type AdminAPIKeyHandlers struct {
+	apiKeys AdminAPIKeyService
+}
+
+// NewAdminAPIKeyHandlers creates a new AdminAPIKeyHandlers with the given AdminAPIKeyService.
+func NewAdminAPIKeyHandlers(apiKeys AdminAPIKeyService) *AdminAPIKeyHandlers {
+	return &AdminAPIKeyHandlers{apiKeys: apiKeys}
+}
+
+// List handles GET /admin/apikeys.
+// Query params: page (default 1), per_page (default 20), client_id (filter by client).
+func (h *AdminAPIKeyHandlers) List(c *gin.Context) {
+	page, perPage := parsePagination(c)
+	clientID := c.DefaultQuery("client_id", "")
+
+	result, err := h.apiKeys.ListAPIKeys(c.Request.Context(), page, perPage, clientID)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// Get handles GET /admin/apikeys/:id.
+func (h *AdminAPIKeyHandlers) Get(c *gin.Context) {
+	keyID := c.Param("id")
+
+	key, err := h.apiKeys.GetAPIKey(c.Request.Context(), keyID)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, key)
+}
+
+// Create handles POST /admin/apikeys.
+// Returns the API key with the generated raw key (only time key is visible).
+func (h *AdminAPIKeyHandlers) Create(c *gin.Context) {
+	var req CreateAPIKeyRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid request body")
+		return
+	}
+
+	if err := adminValidator.Struct(req); err != nil {
+		handleValidationError(c, err)
+		return
+	}
+
+	key, err := h.apiKeys.CreateAPIKey(c.Request.Context(), &req)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, key)
+}
+
+// Update handles PATCH /admin/apikeys/:id.
+func (h *AdminAPIKeyHandlers) Update(c *gin.Context) {
+	keyID := c.Param("id")
+
+	var req UpdateAPIKeyRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid request body")
+		return
+	}
+
+	if err := adminValidator.Struct(req); err != nil {
+		handleValidationError(c, err)
+		return
+	}
+
+	key, err := h.apiKeys.UpdateAPIKey(c.Request.Context(), keyID, &req)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, key)
+}
+
+// Delete handles DELETE /admin/apikeys/:id (revoke).
+func (h *AdminAPIKeyHandlers) Delete(c *gin.Context) {
+	keyID := c.Param("id")
+
+	if err := h.apiKeys.RevokeAPIKey(c.Request.Context(), keyID); err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "api key revoked"})
+}
+
+// Rotate handles POST /admin/apikeys/:id/rotate.
+// Returns the new key with a 24-hour grace period for the old key.
+func (h *AdminAPIKeyHandlers) Rotate(c *gin.Context) {
+	keyID := c.Param("id")
+
+	key, err := h.apiKeys.RotateAPIKey(c.Request.Context(), keyID)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, key)
+}

--- a/internal/api/admin_apikey_handlers_test.go
+++ b/internal/api/admin_apikey_handlers_test.go
@@ -1,0 +1,427 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/health"
+)
+
+// --- Mock AdminAPIKeyService ---
+
+type mockAdminAPIKeyService struct {
+	listAPIKeysFn  func(ctx context.Context, page, perPage int, clientID string) (*api.AdminAPIKeyList, error)
+	getAPIKeyFn    func(ctx context.Context, keyID string) (*api.AdminAPIKey, error)
+	createAPIKeyFn func(ctx context.Context, req *api.CreateAPIKeyRequest) (*api.AdminAPIKeyWithSecret, error)
+	updateAPIKeyFn func(ctx context.Context, keyID string, req *api.UpdateAPIKeyRequest) (*api.AdminAPIKey, error)
+	revokeAPIKeyFn func(ctx context.Context, keyID string) error
+	rotateAPIKeyFn func(ctx context.Context, keyID string) (*api.AdminAPIKeyWithSecret, error)
+}
+
+func (m *mockAdminAPIKeyService) ListAPIKeys(ctx context.Context, page, perPage int, clientID string) (*api.AdminAPIKeyList, error) {
+	if m.listAPIKeysFn != nil {
+		return m.listAPIKeysFn(ctx, page, perPage, clientID)
+	}
+	return &api.AdminAPIKeyList{
+		APIKeys: []api.AdminAPIKey{{
+			ID:        "ak1",
+			ClientID:  "c1",
+			Name:      "test-key",
+			KeyPrefix: "qf_ak_abcd1234",
+			Scopes:    []string{"read:users"},
+			RateLimit: 1000,
+			Status:    "active",
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}},
+		Total:   1,
+		Page:    page,
+		PerPage: perPage,
+	}, nil
+}
+
+func (m *mockAdminAPIKeyService) GetAPIKey(ctx context.Context, keyID string) (*api.AdminAPIKey, error) {
+	if m.getAPIKeyFn != nil {
+		return m.getAPIKeyFn(ctx, keyID)
+	}
+	return &api.AdminAPIKey{
+		ID:        keyID,
+		ClientID:  "c1",
+		Name:      "test-key",
+		KeyPrefix: "qf_ak_abcd1234",
+		Scopes:    []string{"read:users"},
+		RateLimit: 1000,
+		Status:    "active",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}, nil
+}
+
+func (m *mockAdminAPIKeyService) CreateAPIKey(ctx context.Context, req *api.CreateAPIKeyRequest) (*api.AdminAPIKeyWithSecret, error) {
+	if m.createAPIKeyFn != nil {
+		return m.createAPIKeyFn(ctx, req)
+	}
+	return &api.AdminAPIKeyWithSecret{
+		AdminAPIKey: api.AdminAPIKey{
+			ID:        "new-key",
+			ClientID:  req.ClientID,
+			Name:      req.Name,
+			KeyPrefix: "qf_ak_abcd1234",
+			Scopes:    req.Scopes,
+			RateLimit: 1000,
+			Status:    "active",
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+		Key: "qf_ak_abcdef0123456789abcdef0123456789",
+	}, nil
+}
+
+func (m *mockAdminAPIKeyService) UpdateAPIKey(ctx context.Context, keyID string, req *api.UpdateAPIKeyRequest) (*api.AdminAPIKey, error) {
+	if m.updateAPIKeyFn != nil {
+		return m.updateAPIKeyFn(ctx, keyID, req)
+	}
+	name := "test-key"
+	if req.Name != nil {
+		name = *req.Name
+	}
+	rateLimit := 1000
+	if req.RateLimit != nil {
+		rateLimit = *req.RateLimit
+	}
+	return &api.AdminAPIKey{
+		ID:        keyID,
+		ClientID:  "c1",
+		Name:      name,
+		KeyPrefix: "qf_ak_abcd1234",
+		Scopes:    req.Scopes,
+		RateLimit: rateLimit,
+		Status:    "active",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}, nil
+}
+
+func (m *mockAdminAPIKeyService) RevokeAPIKey(ctx context.Context, keyID string) error {
+	if m.revokeAPIKeyFn != nil {
+		return m.revokeAPIKeyFn(ctx, keyID)
+	}
+	return nil
+}
+
+func (m *mockAdminAPIKeyService) RotateAPIKey(ctx context.Context, keyID string) (*api.AdminAPIKeyWithSecret, error) {
+	if m.rotateAPIKeyFn != nil {
+		return m.rotateAPIKeyFn(ctx, keyID)
+	}
+	graceEnd := time.Now().Add(24 * time.Hour)
+	return &api.AdminAPIKeyWithSecret{
+		AdminAPIKey: api.AdminAPIKey{
+			ID:        keyID,
+			ClientID:  "c1",
+			Name:      "test-key",
+			KeyPrefix: "qf_ak_abcd1234",
+			Scopes:    []string{"read:users"},
+			RateLimit: 1000,
+			Status:    "active",
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+		Key:             "qf_ak_new_rotated_key_value_here",
+		GracePeriodEnds: &graceEnd,
+	}, nil
+}
+
+// --- Helper ---
+
+func newAdminAPIKeyRouter(apiKeySvc api.AdminAPIKeyService) *gin.Engine {
+	svc := &api.AdminServices{APIKeys: apiKeySvc}
+	return api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+}
+
+// --- List API Keys ---
+
+func TestAdminListAPIKeys_Success(t *testing.T) {
+	r := newAdminAPIKeyRouter(&mockAdminAPIKeyService{})
+	w := doRequest(r, http.MethodGet, "/admin/apikeys", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminAPIKeyList
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.Total)
+	assert.Len(t, resp.APIKeys, 1)
+}
+
+func TestAdminListAPIKeys_Pagination(t *testing.T) {
+	svc := &mockAdminAPIKeyService{
+		listAPIKeysFn: func(_ context.Context, page, perPage int, clientID string) (*api.AdminAPIKeyList, error) {
+			assert.Equal(t, 2, page)
+			assert.Equal(t, 10, perPage)
+			assert.Equal(t, "", clientID)
+			return &api.AdminAPIKeyList{APIKeys: []api.AdminAPIKey{}, Total: 50, Page: page, PerPage: perPage}, nil
+		},
+	}
+	r := newAdminAPIKeyRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/apikeys?page=2&per_page=10", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminAPIKeyList
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 2, resp.Page)
+	assert.Equal(t, 10, resp.PerPage)
+}
+
+func TestAdminListAPIKeys_FilterByClient(t *testing.T) {
+	svc := &mockAdminAPIKeyService{
+		listAPIKeysFn: func(_ context.Context, page, perPage int, clientID string) (*api.AdminAPIKeyList, error) {
+			assert.Equal(t, "client-123", clientID)
+			return &api.AdminAPIKeyList{APIKeys: []api.AdminAPIKey{}, Total: 0, Page: page, PerPage: perPage}, nil
+		},
+	}
+	r := newAdminAPIKeyRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/apikeys?client_id=client-123", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestAdminListAPIKeys_PerPageCapped(t *testing.T) {
+	svc := &mockAdminAPIKeyService{
+		listAPIKeysFn: func(_ context.Context, page, perPage int, _ string) (*api.AdminAPIKeyList, error) {
+			assert.Equal(t, 1, page)
+			assert.Equal(t, 100, perPage) // Capped at 100
+			return &api.AdminAPIKeyList{APIKeys: []api.AdminAPIKey{}, Total: 0, Page: page, PerPage: perPage}, nil
+		},
+	}
+	r := newAdminAPIKeyRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/apikeys?per_page=999", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// --- Get API Key ---
+
+func TestAdminGetAPIKey_Success(t *testing.T) {
+	r := newAdminAPIKeyRouter(&mockAdminAPIKeyService{})
+	w := doRequest(r, http.MethodGet, "/admin/apikeys/key-1", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminAPIKey
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "key-1", resp.ID)
+}
+
+func TestAdminGetAPIKey_NotFound(t *testing.T) {
+	svc := &mockAdminAPIKeyService{
+		getAPIKeyFn: func(_ context.Context, _ string) (*api.AdminAPIKey, error) {
+			return nil, fmt.Errorf("api key not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminAPIKeyRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/apikeys/nonexistent", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- Create API Key ---
+
+func TestAdminCreateAPIKey_Success(t *testing.T) {
+	r := newAdminAPIKeyRouter(&mockAdminAPIKeyService{})
+	body := map[string]interface{}{
+		"client_id": "550e8400-e29b-41d4-a716-446655440000",
+		"name":      "my-api-key",
+		"scopes":    []string{"read:users", "write:users"},
+	}
+	w := doRequest(r, http.MethodPost, "/admin/apikeys", body)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp api.AdminAPIKeyWithSecret
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "my-api-key", resp.Name)
+	assert.NotEmpty(t, resp.Key, "key must be returned on create")
+}
+
+func TestAdminCreateAPIKey_MissingName(t *testing.T) {
+	r := newAdminAPIKeyRouter(&mockAdminAPIKeyService{})
+	body := map[string]interface{}{
+		"client_id": "550e8400-e29b-41d4-a716-446655440000",
+	}
+	w := doRequest(r, http.MethodPost, "/admin/apikeys", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestAdminCreateAPIKey_MissingClientID(t *testing.T) {
+	r := newAdminAPIKeyRouter(&mockAdminAPIKeyService{})
+	body := map[string]interface{}{
+		"name": "my-key",
+	}
+	w := doRequest(r, http.MethodPost, "/admin/apikeys", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestAdminCreateAPIKey_InvalidJSON(t *testing.T) {
+	r := newAdminAPIKeyRouter(&mockAdminAPIKeyService{})
+	w := doRequest(r, http.MethodPost, "/admin/apikeys", nil)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminCreateAPIKey_InvalidClientID(t *testing.T) {
+	r := newAdminAPIKeyRouter(&mockAdminAPIKeyService{})
+	body := map[string]interface{}{
+		"client_id": "not-a-uuid",
+		"name":      "my-key",
+	}
+	w := doRequest(r, http.MethodPost, "/admin/apikeys", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestAdminCreateAPIKey_ServiceError(t *testing.T) {
+	svc := &mockAdminAPIKeyService{
+		createAPIKeyFn: func(_ context.Context, _ *api.CreateAPIKeyRequest) (*api.AdminAPIKeyWithSecret, error) {
+			return nil, fmt.Errorf("create failed: %w", api.ErrInternalError)
+		},
+	}
+	r := newAdminAPIKeyRouter(svc)
+	body := map[string]interface{}{
+		"client_id": "550e8400-e29b-41d4-a716-446655440000",
+		"name":      "my-key",
+	}
+	w := doRequest(r, http.MethodPost, "/admin/apikeys", body)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- Update API Key ---
+
+func TestAdminUpdateAPIKey_Success(t *testing.T) {
+	r := newAdminAPIKeyRouter(&mockAdminAPIKeyService{})
+	name := "updated-key"
+	body := map[string]interface{}{"name": name}
+	w := doRequest(r, http.MethodPatch, "/admin/apikeys/key-1", body)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminAPIKey
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "updated-key", resp.Name)
+}
+
+func TestAdminUpdateAPIKey_NotFound(t *testing.T) {
+	svc := &mockAdminAPIKeyService{
+		updateAPIKeyFn: func(_ context.Context, _ string, _ *api.UpdateAPIKeyRequest) (*api.AdminAPIKey, error) {
+			return nil, fmt.Errorf("api key not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminAPIKeyRouter(svc)
+	body := map[string]interface{}{"name": "nope"}
+	w := doRequest(r, http.MethodPatch, "/admin/apikeys/nonexistent", body)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestAdminUpdateAPIKey_InvalidJSON(t *testing.T) {
+	r := newAdminAPIKeyRouter(&mockAdminAPIKeyService{})
+	w := doRequest(r, http.MethodPatch, "/admin/apikeys/key-1", nil)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminUpdateAPIKey_WithRateLimit(t *testing.T) {
+	svc := &mockAdminAPIKeyService{
+		updateAPIKeyFn: func(_ context.Context, keyID string, req *api.UpdateAPIKeyRequest) (*api.AdminAPIKey, error) {
+			assert.Equal(t, "key-1", keyID)
+			require.NotNil(t, req.RateLimit)
+			assert.Equal(t, 500, *req.RateLimit)
+			return &api.AdminAPIKey{
+				ID:        keyID,
+				ClientID:  "c1",
+				Name:      "test-key",
+				KeyPrefix: "qf_ak_abcd1234",
+				Scopes:    []string{},
+				RateLimit: 500,
+				Status:    "active",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			}, nil
+		},
+	}
+	r := newAdminAPIKeyRouter(svc)
+	body := map[string]interface{}{"rate_limit": 500}
+	w := doRequest(r, http.MethodPatch, "/admin/apikeys/key-1", body)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// --- Delete (Revoke) API Key ---
+
+func TestAdminDeleteAPIKey_Success(t *testing.T) {
+	r := newAdminAPIKeyRouter(&mockAdminAPIKeyService{})
+	w := doRequest(r, http.MethodDelete, "/admin/apikeys/key-1", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestAdminDeleteAPIKey_NotFound(t *testing.T) {
+	svc := &mockAdminAPIKeyService{
+		revokeAPIKeyFn: func(_ context.Context, _ string) error {
+			return fmt.Errorf("api key not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminAPIKeyRouter(svc)
+	w := doRequest(r, http.MethodDelete, "/admin/apikeys/nonexistent", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestAdminDeleteAPIKey_AlreadyRevoked(t *testing.T) {
+	svc := &mockAdminAPIKeyService{
+		revokeAPIKeyFn: func(_ context.Context, _ string) error {
+			return fmt.Errorf("api key already revoked: %w", api.ErrConflict)
+		},
+	}
+	r := newAdminAPIKeyRouter(svc)
+	w := doRequest(r, http.MethodDelete, "/admin/apikeys/revoked-key", nil)
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+// --- Rotate API Key ---
+
+func TestAdminRotateAPIKey_Success(t *testing.T) {
+	r := newAdminAPIKeyRouter(&mockAdminAPIKeyService{})
+	w := doRequest(r, http.MethodPost, "/admin/apikeys/key-1/rotate", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminAPIKeyWithSecret
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.Key, "new key must be returned on rotation")
+	assert.NotNil(t, resp.GracePeriodEnds, "grace period must be set on rotation")
+}
+
+func TestAdminRotateAPIKey_NotFound(t *testing.T) {
+	svc := &mockAdminAPIKeyService{
+		rotateAPIKeyFn: func(_ context.Context, _ string) (*api.AdminAPIKeyWithSecret, error) {
+			return nil, fmt.Errorf("api key not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminAPIKeyRouter(svc)
+	w := doRequest(r, http.MethodPost, "/admin/apikeys/nonexistent/rotate", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/internal/api/admin_router.go
+++ b/internal/api/admin_router.go
@@ -75,6 +75,20 @@ func NewAdminRouter(svc *AdminServices, deps *AdminDeps) *gin.Engine {
 		}
 	}
 
+	// API key management.
+	if svc.APIKeys != nil {
+		keyH := NewAdminAPIKeyHandlers(svc.APIKeys)
+		apikeys := admin.Group("/apikeys")
+		{
+			apikeys.GET("", keyH.List)
+			apikeys.GET("/:id", keyH.Get)
+			apikeys.POST("", keyH.Create)
+			apikeys.PATCH("/:id", keyH.Update)
+			apikeys.DELETE("/:id", keyH.Delete)
+			apikeys.POST("/:id/rotate", keyH.Rotate)
+		}
+	}
+
 	// Token introspection.
 	if svc.Tokens != nil {
 		tokenH := NewAdminTokenHandlers(svc.Tokens)

--- a/internal/api/admin_services.go
+++ b/internal/api/admin_services.go
@@ -56,6 +56,36 @@ type AdminClientList struct {
 	PerPage int           `json:"per_page"`
 }
 
+// AdminAPIKey represents an API key in admin API responses.
+type AdminAPIKey struct {
+	ID         string     `json:"id"`
+	ClientID   string     `json:"client_id"`
+	Name       string     `json:"name"`
+	KeyPrefix  string     `json:"key_prefix"`
+	Scopes     []string   `json:"scopes"`
+	RateLimit  int        `json:"rate_limit"`
+	Status     string     `json:"status"`
+	ExpiresAt  *time.Time `json:"expires_at,omitempty"`
+	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
+	CreatedAt  time.Time  `json:"created_at"`
+	UpdatedAt  time.Time  `json:"updated_at"`
+}
+
+// AdminAPIKeyWithSecret is returned only on create and key rotation.
+type AdminAPIKeyWithSecret struct {
+	AdminAPIKey
+	Key             string     `json:"key"`
+	GracePeriodEnds *time.Time `json:"grace_period_ends,omitempty"`
+}
+
+// AdminAPIKeyList is the paginated response for listing API keys.
+type AdminAPIKeyList struct {
+	APIKeys []AdminAPIKey `json:"api_keys"`
+	Total   int           `json:"total"`
+	Page    int           `json:"page"`
+	PerPage int           `json:"per_page"`
+}
+
 // IntrospectionResponse follows RFC 7662 token introspection.
 type IntrospectionResponse struct {
 	Active     bool   `json:"active"`
@@ -112,6 +142,22 @@ type IntrospectRequest struct {
 	Token string `json:"token" validate:"required"`
 }
 
+// CreateAPIKeyRequest is the request body for creating an API key.
+type CreateAPIKeyRequest struct {
+	ClientID  string   `json:"client_id"  validate:"required,uuid"`
+	Name      string   `json:"name"       validate:"required,min=1,max=255"`
+	Scopes    []string `json:"scopes"     validate:"omitempty"`
+	RateLimit *int     `json:"rate_limit" validate:"omitempty,min=0,max=100000"`
+	ExpiresAt *string  `json:"expires_at" validate:"omitempty"`
+}
+
+// UpdateAPIKeyRequest is the request body for updating an API key.
+type UpdateAPIKeyRequest struct {
+	Name      *string  `json:"name"       validate:"omitempty,min=1,max=255"`
+	Scopes    []string `json:"scopes"     validate:"omitempty"`
+	RateLimit *int     `json:"rate_limit" validate:"omitempty,min=0,max=100000"`
+}
+
 // --- Admin service interfaces ---
 
 // AdminUserService defines admin operations for user management.
@@ -140,9 +186,20 @@ type AdminTokenService interface {
 	Introspect(ctx context.Context, token string) (*IntrospectionResponse, error)
 }
 
+// AdminAPIKeyService defines admin operations for API key management.
+type AdminAPIKeyService interface {
+	ListAPIKeys(ctx context.Context, page, perPage int, clientID string) (*AdminAPIKeyList, error)
+	GetAPIKey(ctx context.Context, keyID string) (*AdminAPIKey, error)
+	CreateAPIKey(ctx context.Context, req *CreateAPIKeyRequest) (*AdminAPIKeyWithSecret, error)
+	UpdateAPIKey(ctx context.Context, keyID string, req *UpdateAPIKeyRequest) (*AdminAPIKey, error)
+	RevokeAPIKey(ctx context.Context, keyID string) error
+	RotateAPIKey(ctx context.Context, keyID string) (*AdminAPIKeyWithSecret, error)
+}
+
 // AdminServices aggregates all admin service interfaces required by admin API handlers.
 type AdminServices struct {
 	Users   AdminUserService
 	Clients AdminClientService
 	Tokens  AdminTokenService
+	APIKeys AdminAPIKeyService
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -71,8 +71,11 @@ func NewPublicRouter(svc *Services, mw *MiddlewareStack, healthSvc *health.Servi
 		pw.POST("/reset/confirm", validateReq(v, &domain.PasswordResetConfirmRequest{}), authH.ConfirmPasswordReset)
 	}
 
-	// Protected auth routes (require auth middleware).
+	// Protected auth routes (require API key or auth middleware).
 	protected := r.Group("/auth")
+	if mw != nil && mw.APIKey != nil {
+		protected.Use(mw.APIKey)
+	}
 	if mw != nil && mw.Auth != nil {
 		protected.Use(mw.Auth)
 	}

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -88,6 +88,7 @@ type MiddlewareStack struct {
 	SecurityHeaders gin.HandlerFunc
 	RateLimit       gin.HandlerFunc
 	RequestSize     gin.HandlerFunc
+	APIKey          gin.HandlerFunc
 	Auth            gin.HandlerFunc
 	Metrics         gin.HandlerFunc
 }

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -31,7 +31,11 @@ const (
 	EventAdminClientUpdate  = "admin_client_update"
 	EventAdminClientDelete  = "admin_client_delete"
 	EventAdminClientRotate  = "admin_client_rotate_secret"
-	EventTokenIntrospect    = "token_introspect"
+	EventTokenIntrospect       = "token_introspect"
+	EventAdminAPIKeyCreate     = "admin_apikey_create"
+	EventAdminAPIKeyUpdate     = "admin_apikey_update"
+	EventAdminAPIKeyRevoke     = "admin_apikey_revoke"
+	EventAdminAPIKeyRotate     = "admin_apikey_rotate"
 )
 
 // Event represents a single audit log entry.

--- a/internal/domain/apikey.go
+++ b/internal/domain/apikey.go
@@ -1,0 +1,42 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// APIKeyStatus constants.
+const (
+	APIKeyStatusActive  = "active"
+	APIKeyStatusRevoked = "revoked"
+)
+
+// APIKey represents an API key for service-to-service or agent authentication.
+type APIKey struct {
+	ID                      uuid.UUID  `json:"id"                          db:"id"`
+	ClientID                uuid.UUID  `json:"client_id"                   db:"client_id"`
+	Name                    string     `json:"name"                        db:"name"`
+	KeyHash                 string     `json:"-"                           db:"key_hash"`
+	PreviousKeyHash         string     `json:"-"                           db:"previous_key_hash"`
+	PreviousKeyExpiresAt    *time.Time `json:"-"                           db:"previous_key_expires_at"`
+	KeyPrefix               string     `json:"key_prefix"                  db:"key_prefix"`
+	Scopes                  []string   `json:"scopes"                      db:"scopes"`
+	RateLimit               int        `json:"rate_limit"                  db:"rate_limit"`
+	Status                  string     `json:"status"                      db:"status"`
+	ExpiresAt               *time.Time `json:"expires_at,omitempty"        db:"expires_at"`
+	LastUsedAt              *time.Time `json:"last_used_at,omitempty"      db:"last_used_at"`
+	CreatedAt               time.Time  `json:"created_at"                  db:"created_at"`
+	UpdatedAt               time.Time  `json:"updated_at"                  db:"updated_at"`
+}
+
+// IsActive returns true if the API key status is active and not expired.
+func (k *APIKey) IsActive() bool {
+	if k.Status != APIKeyStatusActive {
+		return false
+	}
+	if k.ExpiresAt != nil && k.ExpiresAt.Before(time.Now()) {
+		return false
+	}
+	return true
+}

--- a/internal/middleware/apikey.go
+++ b/internal/middleware/apikey.go
@@ -1,0 +1,71 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+const (
+	apiKeyHeader       = "X-API-Key"
+	clientIDContextKey = "client_id"
+	scopesContextKey   = "scopes"
+)
+
+// APIKeyValidator defines the operations required by APIKeyMiddleware
+// to validate an API key and retrieve its associated metadata.
+type APIKeyValidator interface {
+	ValidateAPIKey(ctx context.Context, rawKey string) (*APIKeyInfo, error)
+}
+
+// APIKeyInfo contains the validated API key metadata set into the request context.
+type APIKeyInfo struct {
+	ClientID  string
+	Scopes    []string
+	RateLimit int
+}
+
+// APIKeyMiddleware returns a Gin middleware that authenticates requests via
+// the X-API-Key header. If no X-API-Key header is present, the middleware
+// falls through (calls c.Next()) so the existing Bearer token auth middleware
+// can handle authentication. If the header is present but invalid, the
+// middleware returns 401.
+//
+// On success it sets "claims" (synthesized *domain.TokenClaims), "client_id",
+// "scopes", and rate limit headers into the context.
+func APIKeyMiddleware(validator APIKeyValidator) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		raw := c.GetHeader(apiKeyHeader)
+		if raw == "" {
+			// No API key header — fall through to Bearer token auth.
+			c.Next()
+			return
+		}
+
+		info, err := validator.ValidateAPIKey(c.Request.Context(), raw)
+		if err != nil {
+			domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized,
+				"invalid or expired API key")
+			return
+		}
+
+		// Set claims-compatible context so downstream handlers work uniformly.
+		claims := &domain.TokenClaims{
+			Subject:    info.ClientID,
+			Scopes:     info.Scopes,
+			ClientType: domain.ClientTypeService,
+		}
+		c.Set(claimsContextKey, claims)
+		c.Set(clientIDContextKey, info.ClientID)
+		c.Set(scopesContextKey, info.Scopes)
+
+		// Set rate limit headers for downstream consumption.
+		c.Header("X-RateLimit-Limit", strconv.Itoa(info.RateLimit))
+
+		c.Next()
+	}
+}

--- a/internal/middleware/apikey_test.go
+++ b/internal/middleware/apikey_test.go
@@ -1,0 +1,84 @@
+package middleware_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/middleware"
+)
+
+type mockAPIKeyValidator struct {
+	validateFn func(ctx context.Context, rawKey string) (*middleware.APIKeyInfo, error)
+}
+
+func (m *mockAPIKeyValidator) ValidateAPIKey(ctx context.Context, rawKey string) (*middleware.APIKeyInfo, error) {
+	if m.validateFn != nil {
+		return m.validateFn(ctx, rawKey)
+	}
+	return &middleware.APIKeyInfo{
+		ClientID:  "client-123",
+		Scopes:    []string{"read:users"},
+		RateLimit: 1000,
+	}, nil
+}
+
+func setupAPIKeyRouter(validator middleware.APIKeyValidator) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.APIKeyMiddleware(validator))
+	r.GET("/test", func(c *gin.Context) {
+		claims, exists := c.Get("claims")
+		if exists {
+			tc := claims.(*domain.TokenClaims)
+			c.JSON(http.StatusOK, gin.H{"subject": tc.Subject, "authenticated": true})
+		} else {
+			c.JSON(http.StatusOK, gin.H{"authenticated": false})
+		}
+	})
+	return r
+}
+
+func TestAPIKeyMiddleware_ValidKey(t *testing.T) {
+	r := setupAPIKeyRouter(&mockAPIKeyValidator{})
+	req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+	req.Header.Set("X-API-Key", "qf_ak_validkey123")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"authenticated":true`)
+	assert.Contains(t, w.Body.String(), `"subject":"client-123"`)
+	assert.Equal(t, "1000", w.Header().Get("X-RateLimit-Limit"))
+}
+
+func TestAPIKeyMiddleware_NoHeader_FallThrough(t *testing.T) {
+	r := setupAPIKeyRouter(&mockAPIKeyValidator{})
+	req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"authenticated":false`)
+}
+
+func TestAPIKeyMiddleware_InvalidKey(t *testing.T) {
+	validator := &mockAPIKeyValidator{
+		validateFn: func(_ context.Context, _ string) (*middleware.APIKeyInfo, error) {
+			return nil, fmt.Errorf("invalid key")
+		},
+	}
+	r := setupAPIKeyRouter(validator)
+	req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+	req.Header.Set("X-API-Key", "qf_ak_badkey")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -41,6 +41,12 @@ type TokenValidator interface {
 // Returns 401 on any authentication failure.
 func AuthMiddleware(validator TokenValidator) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// Skip if already authenticated (e.g., by APIKeyMiddleware).
+		if _, exists := c.Get(claimsContextKey); exists {
+			c.Next()
+			return
+		}
+
 		raw := extractBearer(c)
 		if raw == "" {
 			domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized,

--- a/internal/storage/apikey_repository.go
+++ b/internal/storage/apikey_repository.go
@@ -1,0 +1,218 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// APIKeyRepository defines persistence operations for API key management.
+type APIKeyRepository interface {
+	List(ctx context.Context, limit, offset int, clientID string) ([]*domain.APIKey, int, error)
+	FindByID(ctx context.Context, id uuid.UUID) (*domain.APIKey, error)
+	FindByKeyHash(ctx context.Context, keyHash string) (*domain.APIKey, error)
+	Create(ctx context.Context, key *domain.APIKey) (*domain.APIKey, error)
+	Update(ctx context.Context, key *domain.APIKey) (*domain.APIKey, error)
+	Revoke(ctx context.Context, id uuid.UUID) error
+	RotateKey(ctx context.Context, id uuid.UUID, newKeyHash string, gracePeriodEnds time.Time) error
+	UpdateLastUsed(ctx context.Context, id uuid.UUID) error
+}
+
+const apiKeyColumns = `id, client_id, name, key_hash, previous_key_hash, previous_key_expires_at, key_prefix, scopes, rate_limit, status, expires_at, last_used_at, created_at, updated_at`
+
+func scanAPIKey(row pgx.Row) (*domain.APIKey, error) {
+	k := &domain.APIKey{}
+	err := row.Scan(
+		&k.ID, &k.ClientID, &k.Name, &k.KeyHash,
+		&k.PreviousKeyHash, &k.PreviousKeyExpiresAt,
+		&k.KeyPrefix, &k.Scopes, &k.RateLimit, &k.Status,
+		&k.ExpiresAt, &k.LastUsedAt, &k.CreatedAt, &k.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return k, nil
+}
+
+// PostgresAPIKeyRepository implements APIKeyRepository using PostgreSQL.
+type PostgresAPIKeyRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresAPIKeyRepository creates a new PostgreSQL-backed API key repository.
+func NewPostgresAPIKeyRepository(pool *pgxpool.Pool) *PostgresAPIKeyRepository {
+	return &PostgresAPIKeyRepository{pool: pool}
+}
+
+// List returns a paginated list of API keys, optionally filtered by client_id.
+func (r *PostgresAPIKeyRepository) List(ctx context.Context, limit, offset int, clientID string) ([]*domain.APIKey, int, error) {
+	conditions := []string{}
+	args := []interface{}{}
+
+	if clientID != "" {
+		args = append(args, clientID)
+		conditions = append(conditions, fmt.Sprintf("client_id = $%d", len(args)))
+	}
+
+	whereClause := ""
+	if len(conditions) > 0 {
+		whereClause = "WHERE " + conditions[0]
+		for _, cond := range conditions[1:] {
+			whereClause += " AND " + cond
+		}
+	}
+
+	countQuery := fmt.Sprintf(`SELECT COUNT(*) FROM api_keys %s`, whereClause)
+	var total int
+	if err := r.pool.QueryRow(ctx, countQuery, args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count api keys: %w", err)
+	}
+
+	paginationOffset := len(args)
+	args = append(args, limit, offset)
+	query := fmt.Sprintf(`SELECT %s FROM api_keys %s ORDER BY created_at DESC LIMIT $%d OFFSET $%d`,
+		apiKeyColumns, whereClause, paginationOffset+1, paginationOffset+2)
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list api keys: %w", err)
+	}
+	defer rows.Close()
+
+	var keys []*domain.APIKey
+	for rows.Next() {
+		k := &domain.APIKey{}
+		if err := rows.Scan(
+			&k.ID, &k.ClientID, &k.Name, &k.KeyHash,
+			&k.PreviousKeyHash, &k.PreviousKeyExpiresAt,
+			&k.KeyPrefix, &k.Scopes, &k.RateLimit, &k.Status,
+			&k.ExpiresAt, &k.LastUsedAt, &k.CreatedAt, &k.UpdatedAt,
+		); err != nil {
+			return nil, 0, fmt.Errorf("scan api key: %w", err)
+		}
+		keys = append(keys, k)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate api keys: %w", err)
+	}
+
+	return keys, total, nil
+}
+
+// FindByID retrieves an API key by primary key.
+func (r *PostgresAPIKeyRepository) FindByID(ctx context.Context, id uuid.UUID) (*domain.APIKey, error) {
+	query := fmt.Sprintf(`SELECT %s FROM api_keys WHERE id = $1`, apiKeyColumns)
+	k, err := scanAPIKey(r.pool.QueryRow(ctx, query, id))
+	if err != nil {
+		return nil, fmt.Errorf("find api key %s: %w", id, err)
+	}
+	return k, nil
+}
+
+// FindByKeyHash retrieves an API key by its hashed key value.
+func (r *PostgresAPIKeyRepository) FindByKeyHash(ctx context.Context, keyHash string) (*domain.APIKey, error) {
+	query := fmt.Sprintf(`SELECT %s FROM api_keys WHERE key_hash = $1 OR (previous_key_hash = $1 AND previous_key_expires_at > NOW())`, apiKeyColumns)
+	k, err := scanAPIKey(r.pool.QueryRow(ctx, query, keyHash))
+	if err != nil {
+		return nil, fmt.Errorf("find api key by hash: %w", err)
+	}
+	return k, nil
+}
+
+// Create inserts a new API key.
+func (r *PostgresAPIKeyRepository) Create(ctx context.Context, key *domain.APIKey) (*domain.APIKey, error) {
+	query := fmt.Sprintf(`
+		INSERT INTO api_keys (id, client_id, name, key_hash, key_prefix, scopes, rate_limit, status, expires_at, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		RETURNING %s`, apiKeyColumns)
+
+	k, err := scanAPIKey(r.pool.QueryRow(ctx, query,
+		key.ID, key.ClientID, key.Name, key.KeyHash,
+		key.KeyPrefix, key.Scopes, key.RateLimit, key.Status,
+		key.ExpiresAt, key.CreatedAt, key.UpdatedAt,
+	))
+	if err != nil {
+		return nil, fmt.Errorf("insert api key: %w", err)
+	}
+	return k, nil
+}
+
+// Update modifies mutable fields of an API key (name, scopes, rate_limit).
+func (r *PostgresAPIKeyRepository) Update(ctx context.Context, key *domain.APIKey) (*domain.APIKey, error) {
+	query := fmt.Sprintf(`
+		UPDATE api_keys SET name = $1, scopes = $2, rate_limit = $3, updated_at = $4
+		WHERE id = $5 AND status = 'active'
+		RETURNING %s`, apiKeyColumns)
+
+	k, err := scanAPIKey(r.pool.QueryRow(ctx, query,
+		key.Name, key.Scopes, key.RateLimit, time.Now().UTC(), key.ID,
+	))
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, fmt.Errorf("api key %s: %w", key.ID, ErrNotFound)
+		}
+		return nil, fmt.Errorf("update api key: %w", err)
+	}
+	return k, nil
+}
+
+// Revoke marks an API key as revoked.
+func (r *PostgresAPIKeyRepository) Revoke(ctx context.Context, id uuid.UUID) error {
+	query := `UPDATE api_keys SET status = 'revoked', updated_at = $1 WHERE id = $2 AND status = 'active'`
+	now := time.Now().UTC()
+
+	tag, err := r.pool.Exec(ctx, query, now, id)
+	if err != nil {
+		return fmt.Errorf("revoke api key %s: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		var exists bool
+		_ = r.pool.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM api_keys WHERE id = $1)`, id).Scan(&exists)
+		if exists {
+			return fmt.Errorf("api key %s already revoked: %w", id, ErrAlreadyDeleted)
+		}
+		return fmt.Errorf("api key %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
+// RotateKey moves the current key hash to previous_key_hash with a grace period,
+// then sets the new key hash.
+func (r *PostgresAPIKeyRepository) RotateKey(ctx context.Context, id uuid.UUID, newKeyHash string, gracePeriodEnds time.Time) error {
+	query := `
+		UPDATE api_keys
+		SET previous_key_hash = key_hash,
+		    previous_key_expires_at = $1,
+		    key_hash = $2,
+		    updated_at = $3
+		WHERE id = $4 AND status = 'active'`
+
+	now := time.Now().UTC()
+	tag, err := r.pool.Exec(ctx, query, gracePeriodEnds, newKeyHash, now, id)
+	if err != nil {
+		return fmt.Errorf("rotate api key: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("api key %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
+// UpdateLastUsed sets the last_used_at timestamp for the given API key.
+func (r *PostgresAPIKeyRepository) UpdateLastUsed(ctx context.Context, id uuid.UUID) error {
+	query := `UPDATE api_keys SET last_used_at = $1 WHERE id = $2`
+	_, err := r.pool.Exec(ctx, query, time.Now().UTC(), id)
+	if err != nil {
+		return fmt.Errorf("update last used: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-200.

Closes #200

## Changes

Add the `AdminAPIKeyService` interface to `internal/api/admin_services.go` and add it to the `AdminServices` struct. Create `internal/api/admin_apikey_handlers.go` with CRUD handlers: `POST /admin/apikeys` (create), `GET /admin/apikeys` (list by client, paginated), `GET /admin/apikeys/:id` (get), `PATCH /admin/apikeys/:id` (update name/scopes/rate_limit), `DELETE /admin/apikeys/:id` (revoke), `POST /admin/apikeys/:id/rotate` (rotate). Register routes in `internal/api/admin_router.go` following the existing clients group pattern. Create request/response DTOs with validation tags. Wire everything in `cmd/server/main.go`: instantiate `PostgresAPIKeyRepository`, create `APIKeyService`, add to `AdminServices`, and insert the `APIKeyMiddleware` into the public middleware stack (before `AuthMiddleware`). Include handler tests.