### PR TITLE
GH-206: Admin API for policy and role management

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/qf-studio/auth-service/internal/admin"
 	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/rbac"
 	"github.com/qf-studio/auth-service/internal/audit"
 	"github.com/qf-studio/auth-service/internal/auth"
 	"github.com/qf-studio/auth-service/internal/config"
@@ -127,11 +128,14 @@ func run(log *zap.Logger, cfg *config.Config) error {
 	adminUserSvc := admin.NewUserService(adminUserRepo, hasher, log, auditSvc)
 	adminClientSvc := admin.NewClientService(clientRepo, hasher, log, auditSvc)
 	adminTokenSvc := admin.NewTokenService(tokenSvc, refreshTokenRepo, "auth-service", log, auditSvc)
+	rbacRepo := rbac.NewMemoryRepository()
+	adminRBACSvc := admin.NewRBACService(rbacRepo, log, auditSvc)
 
 	adminServices := &api.AdminServices{
 		Users:   adminUserSvc,
 		Clients: adminClientSvc,
 		Tokens:  adminTokenSvc,
+		RBAC:    adminRBACSvc,
 	}
 
 	adminDeps := &api.AdminDeps{

--- a/internal/admin/rbac_service.go
+++ b/internal/admin/rbac_service.go
@@ -1,0 +1,129 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/audit"
+	"github.com/qf-studio/auth-service/internal/rbac"
+)
+
+// RBACService implements api.AdminRBACService using a PolicyRepository.
+type RBACService struct {
+	repo   rbac.PolicyRepository
+	logger *zap.Logger
+	audit  audit.EventLogger
+}
+
+// NewRBACService creates a new admin RBAC service.
+func NewRBACService(repo rbac.PolicyRepository, logger *zap.Logger, auditor audit.EventLogger) *RBACService {
+	return &RBACService{
+		repo:   repo,
+		logger: logger,
+		audit:  auditor,
+	}
+}
+
+// ListPolicies returns all RBAC policy rules.
+func (s *RBACService) ListPolicies(ctx context.Context) (*api.AdminPolicyList, error) {
+	policies, err := s.repo.ListPolicies(ctx)
+	if err != nil {
+		s.logger.Error("list policies failed", zap.Error(err))
+		return nil, fmt.Errorf("list policies: %w", api.ErrInternalError)
+	}
+
+	result := &api.AdminPolicyList{
+		Policies: make([]api.AdminPolicy, 0, len(policies)),
+		Total:    len(policies),
+	}
+	for _, p := range policies {
+		result.Policies = append(result.Policies, api.AdminPolicy{
+			Subject: p.Subject,
+			Object:  p.Object,
+			Action:  p.Action,
+		})
+	}
+	return result, nil
+}
+
+// CreatePolicy adds a new (subject, object, action) rule.
+func (s *RBACService) CreatePolicy(ctx context.Context, req *api.CreatePolicyRequest) (*api.AdminPolicy, error) {
+	p := rbac.Policy{
+		Subject: req.Subject,
+		Object:  req.Object,
+		Action:  req.Action,
+	}
+
+	if err := s.repo.AddPolicy(ctx, p); err != nil {
+		s.logger.Error("add policy failed", zap.Error(err))
+		return nil, fmt.Errorf("create policy: %w", api.ErrInternalError)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminRBACCreate,
+		Metadata: map[string]string{"subject": p.Subject, "object": p.Object, "action": p.Action},
+	})
+
+	return &api.AdminPolicy{Subject: p.Subject, Object: p.Object, Action: p.Action}, nil
+}
+
+// DeletePolicy removes the matching (subject, object, action) rule.
+func (s *RBACService) DeletePolicy(ctx context.Context, req *api.DeletePolicyRequest) error {
+	p := rbac.Policy{
+		Subject: req.Subject,
+		Object:  req.Object,
+		Action:  req.Action,
+	}
+
+	if err := s.repo.RemovePolicy(ctx, p); err != nil {
+		if errors.Is(err, rbac.ErrPolicyNotFound) {
+			return fmt.Errorf("policy not found: %w", api.ErrNotFound)
+		}
+		s.logger.Error("remove policy failed", zap.Error(err))
+		return fmt.Errorf("delete policy: %w", api.ErrInternalError)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminRBACDelete,
+		Metadata: map[string]string{"subject": p.Subject, "object": p.Object, "action": p.Action},
+	})
+
+	return nil
+}
+
+// GetUserRoles returns all roles assigned to the given user.
+func (s *RBACService) GetUserRoles(ctx context.Context, user string) (*api.AdminUserRoles, error) {
+	roles, err := s.repo.GetRolesForUser(ctx, user)
+	if err != nil {
+		s.logger.Error("get user roles failed", zap.String("user", user), zap.Error(err))
+		return nil, fmt.Errorf("get user roles: %w", api.ErrInternalError)
+	}
+
+	return &api.AdminUserRoles{User: user, Roles: roles}, nil
+}
+
+// AssignRole assigns role to user and returns the updated role list.
+func (s *RBACService) AssignRole(ctx context.Context, req *api.AssignRoleRequest) (*api.AdminUserRoles, error) {
+	if err := s.repo.AddRoleForUser(ctx, req.User, req.Role); err != nil {
+		s.logger.Error("assign role failed", zap.String("user", req.User), zap.String("role", req.Role), zap.Error(err))
+		return nil, fmt.Errorf("assign role: %w", api.ErrInternalError)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminRBACRoleAssign,
+		TargetID: req.User,
+		Metadata: map[string]string{"role": req.Role},
+	})
+
+	roles, err := s.repo.GetRolesForUser(ctx, req.User)
+	if err != nil {
+		s.logger.Error("get roles after assign failed", zap.String("user", req.User), zap.Error(err))
+		return nil, fmt.Errorf("get roles: %w", api.ErrInternalError)
+	}
+
+	return &api.AdminUserRoles{User: req.User, Roles: roles}, nil
+}

--- a/internal/api/admin_rbac_handlers.go
+++ b/internal/api/admin_rbac_handlers.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// AdminRBACHandlers groups HTTP handlers for admin RBAC policy and role endpoints.
+type AdminRBACHandlers struct {
+	rbac AdminRBACService
+}
+
+// NewAdminRBACHandlers creates a new AdminRBACHandlers with the given AdminRBACService.
+func NewAdminRBACHandlers(rbac AdminRBACService) *AdminRBACHandlers {
+	return &AdminRBACHandlers{rbac: rbac}
+}
+
+// ListPolicies handles GET /admin/rbac/policies.
+func (h *AdminRBACHandlers) ListPolicies(c *gin.Context) {
+	result, err := h.rbac.ListPolicies(c.Request.Context())
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+// CreatePolicy handles POST /admin/rbac/policies.
+func (h *AdminRBACHandlers) CreatePolicy(c *gin.Context) {
+	var req CreatePolicyRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid request body")
+		return
+	}
+
+	if err := adminValidator.Struct(req); err != nil {
+		handleValidationError(c, err)
+		return
+	}
+
+	policy, err := h.rbac.CreatePolicy(c.Request.Context(), &req)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, policy)
+}
+
+// DeletePolicy handles DELETE /admin/rbac/policies.
+// The policy to remove is specified in the request body.
+func (h *AdminRBACHandlers) DeletePolicy(c *gin.Context) {
+	var req DeletePolicyRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid request body")
+		return
+	}
+
+	if err := adminValidator.Struct(req); err != nil {
+		handleValidationError(c, err)
+		return
+	}
+
+	if err := h.rbac.DeletePolicy(c.Request.Context(), &req); err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "policy deleted"})
+}
+
+// GetUserRoles handles GET /admin/rbac/roles/:user.
+func (h *AdminRBACHandlers) GetUserRoles(c *gin.Context) {
+	user := c.Param("user")
+
+	result, err := h.rbac.GetUserRoles(c.Request.Context(), user)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// AssignRole handles POST /admin/rbac/roles.
+func (h *AdminRBACHandlers) AssignRole(c *gin.Context) {
+	var req AssignRoleRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid request body")
+		return
+	}
+
+	if err := adminValidator.Struct(req); err != nil {
+		handleValidationError(c, err)
+		return
+	}
+
+	result, err := h.rbac.AssignRole(c.Request.Context(), &req)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, result)
+}

--- a/internal/api/admin_rbac_handlers_test.go
+++ b/internal/api/admin_rbac_handlers_test.go
@@ -1,0 +1,299 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/health"
+)
+
+// --- Mock AdminRBACService ---
+
+type mockAdminRBACService struct {
+	listPoliciesFn func(ctx context.Context) (*api.AdminPolicyList, error)
+	createPolicyFn func(ctx context.Context, req *api.CreatePolicyRequest) (*api.AdminPolicy, error)
+	deletePolicyFn func(ctx context.Context, req *api.DeletePolicyRequest) error
+	getUserRolesFn func(ctx context.Context, user string) (*api.AdminUserRoles, error)
+	assignRoleFn   func(ctx context.Context, req *api.AssignRoleRequest) (*api.AdminUserRoles, error)
+}
+
+func (m *mockAdminRBACService) ListPolicies(ctx context.Context) (*api.AdminPolicyList, error) {
+	if m.listPoliciesFn != nil {
+		return m.listPoliciesFn(ctx)
+	}
+	return &api.AdminPolicyList{
+		Policies: []api.AdminPolicy{{Subject: "user:alice", Object: "/api/data", Action: "read"}},
+		Total:    1,
+	}, nil
+}
+
+func (m *mockAdminRBACService) CreatePolicy(ctx context.Context, req *api.CreatePolicyRequest) (*api.AdminPolicy, error) {
+	if m.createPolicyFn != nil {
+		return m.createPolicyFn(ctx, req)
+	}
+	return &api.AdminPolicy{Subject: req.Subject, Object: req.Object, Action: req.Action}, nil
+}
+
+func (m *mockAdminRBACService) DeletePolicy(ctx context.Context, req *api.DeletePolicyRequest) error {
+	if m.deletePolicyFn != nil {
+		return m.deletePolicyFn(ctx, req)
+	}
+	return nil
+}
+
+func (m *mockAdminRBACService) GetUserRoles(ctx context.Context, user string) (*api.AdminUserRoles, error) {
+	if m.getUserRolesFn != nil {
+		return m.getUserRolesFn(ctx, user)
+	}
+	return &api.AdminUserRoles{User: user, Roles: []string{"admin"}}, nil
+}
+
+func (m *mockAdminRBACService) AssignRole(ctx context.Context, req *api.AssignRoleRequest) (*api.AdminUserRoles, error) {
+	if m.assignRoleFn != nil {
+		return m.assignRoleFn(ctx, req)
+	}
+	return &api.AdminUserRoles{User: req.User, Roles: []string{req.Role}}, nil
+}
+
+// --- Helper ---
+
+func newAdminRBACRouter(rbacSvc api.AdminRBACService) *gin.Engine {
+	svc := &api.AdminServices{RBAC: rbacSvc}
+	return api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+}
+
+// --- List Policies ---
+
+func TestAdminListPolicies_Success(t *testing.T) {
+	r := newAdminRBACRouter(&mockAdminRBACService{})
+	w := doRequest(r, http.MethodGet, "/admin/rbac/policies", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminPolicyList
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.Total)
+	assert.Len(t, resp.Policies, 1)
+	assert.Equal(t, "user:alice", resp.Policies[0].Subject)
+}
+
+func TestAdminListPolicies_Empty(t *testing.T) {
+	svc := &mockAdminRBACService{
+		listPoliciesFn: func(_ context.Context) (*api.AdminPolicyList, error) {
+			return &api.AdminPolicyList{Policies: []api.AdminPolicy{}, Total: 0}, nil
+		},
+	}
+	r := newAdminRBACRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/rbac/policies", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminPolicyList
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 0, resp.Total)
+	assert.Empty(t, resp.Policies)
+}
+
+func TestAdminListPolicies_ServiceError(t *testing.T) {
+	svc := &mockAdminRBACService{
+		listPoliciesFn: func(_ context.Context) (*api.AdminPolicyList, error) {
+			return nil, fmt.Errorf("db error: %w", api.ErrInternalError)
+		},
+	}
+	r := newAdminRBACRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/rbac/policies", nil)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- Create Policy ---
+
+func TestAdminCreatePolicy_Success(t *testing.T) {
+	r := newAdminRBACRouter(&mockAdminRBACService{})
+	body := map[string]string{
+		"subject": "user:alice",
+		"object":  "/api/data",
+		"action":  "read",
+	}
+	w := doRequest(r, http.MethodPost, "/admin/rbac/policies", body)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp api.AdminPolicy
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "user:alice", resp.Subject)
+	assert.Equal(t, "/api/data", resp.Object)
+	assert.Equal(t, "read", resp.Action)
+}
+
+func TestAdminCreatePolicy_ValidationError(t *testing.T) {
+	r := newAdminRBACRouter(&mockAdminRBACService{})
+	// Missing required fields
+	body := map[string]string{"subject": "user:alice"}
+	w := doRequest(r, http.MethodPost, "/admin/rbac/policies", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestAdminCreatePolicy_InvalidJSON(t *testing.T) {
+	r := newAdminRBACRouter(&mockAdminRBACService{})
+	w := doRequest(r, http.MethodPost, "/admin/rbac/policies", nil)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminCreatePolicy_ServiceError(t *testing.T) {
+	svc := &mockAdminRBACService{
+		createPolicyFn: func(_ context.Context, _ *api.CreatePolicyRequest) (*api.AdminPolicy, error) {
+			return nil, fmt.Errorf("db error: %w", api.ErrInternalError)
+		},
+	}
+	r := newAdminRBACRouter(svc)
+	body := map[string]string{"subject": "user:alice", "object": "/api/data", "action": "read"}
+	w := doRequest(r, http.MethodPost, "/admin/rbac/policies", body)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- Delete Policy ---
+
+func TestAdminDeletePolicy_Success(t *testing.T) {
+	r := newAdminRBACRouter(&mockAdminRBACService{})
+	body := map[string]string{
+		"subject": "user:alice",
+		"object":  "/api/data",
+		"action":  "read",
+	}
+	w := doRequest(r, http.MethodDelete, "/admin/rbac/policies", body)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "policy deleted", resp["message"])
+}
+
+func TestAdminDeletePolicy_NotFound(t *testing.T) {
+	svc := &mockAdminRBACService{
+		deletePolicyFn: func(_ context.Context, _ *api.DeletePolicyRequest) error {
+			return fmt.Errorf("policy not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminRBACRouter(svc)
+	body := map[string]string{"subject": "user:alice", "object": "/api/data", "action": "read"}
+	w := doRequest(r, http.MethodDelete, "/admin/rbac/policies", body)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestAdminDeletePolicy_ValidationError(t *testing.T) {
+	r := newAdminRBACRouter(&mockAdminRBACService{})
+	body := map[string]string{"subject": "user:alice"}
+	w := doRequest(r, http.MethodDelete, "/admin/rbac/policies", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestAdminDeletePolicy_InvalidJSON(t *testing.T) {
+	r := newAdminRBACRouter(&mockAdminRBACService{})
+	w := doRequest(r, http.MethodDelete, "/admin/rbac/policies", nil)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// --- Get User Roles ---
+
+func TestAdminGetUserRoles_Success(t *testing.T) {
+	r := newAdminRBACRouter(&mockAdminRBACService{})
+	w := doRequest(r, http.MethodGet, "/admin/rbac/roles/user:alice", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminUserRoles
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "user:alice", resp.User)
+	assert.Contains(t, resp.Roles, "admin")
+}
+
+func TestAdminGetUserRoles_NoRoles(t *testing.T) {
+	svc := &mockAdminRBACService{
+		getUserRolesFn: func(_ context.Context, user string) (*api.AdminUserRoles, error) {
+			return &api.AdminUserRoles{User: user, Roles: []string{}}, nil
+		},
+	}
+	r := newAdminRBACRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/rbac/roles/user:bob", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminUserRoles
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "user:bob", resp.User)
+	assert.Empty(t, resp.Roles)
+}
+
+func TestAdminGetUserRoles_ServiceError(t *testing.T) {
+	svc := &mockAdminRBACService{
+		getUserRolesFn: func(_ context.Context, _ string) (*api.AdminUserRoles, error) {
+			return nil, fmt.Errorf("db error: %w", api.ErrInternalError)
+		},
+	}
+	r := newAdminRBACRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/rbac/roles/user:alice", nil)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- Assign Role ---
+
+func TestAdminAssignRole_Success(t *testing.T) {
+	r := newAdminRBACRouter(&mockAdminRBACService{})
+	body := map[string]string{
+		"user": "user:alice",
+		"role": "editor",
+	}
+	w := doRequest(r, http.MethodPost, "/admin/rbac/roles", body)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp api.AdminUserRoles
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "user:alice", resp.User)
+	assert.Contains(t, resp.Roles, "editor")
+}
+
+func TestAdminAssignRole_ValidationError(t *testing.T) {
+	r := newAdminRBACRouter(&mockAdminRBACService{})
+	body := map[string]string{"user": "user:alice"}
+	w := doRequest(r, http.MethodPost, "/admin/rbac/roles", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestAdminAssignRole_InvalidJSON(t *testing.T) {
+	r := newAdminRBACRouter(&mockAdminRBACService{})
+	w := doRequest(r, http.MethodPost, "/admin/rbac/roles", nil)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminAssignRole_ServiceError(t *testing.T) {
+	svc := &mockAdminRBACService{
+		assignRoleFn: func(_ context.Context, _ *api.AssignRoleRequest) (*api.AdminUserRoles, error) {
+			return nil, fmt.Errorf("db error: %w", api.ErrInternalError)
+		},
+	}
+	r := newAdminRBACRouter(svc)
+	body := map[string]string{"user": "user:alice", "role": "editor"}
+	w := doRequest(r, http.MethodPost, "/admin/rbac/roles", body)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/internal/api/admin_router.go
+++ b/internal/api/admin_router.go
@@ -81,6 +81,22 @@ func NewAdminRouter(svc *AdminServices, deps *AdminDeps) *gin.Engine {
 		admin.POST("/tokens/introspect", tokenH.Introspect)
 	}
 
+	// RBAC policy and role management.
+	if svc.RBAC != nil {
+		rbacH := NewAdminRBACHandlers(svc.RBAC)
+		policies := admin.Group("/rbac/policies")
+		{
+			policies.GET("", rbacH.ListPolicies)
+			policies.POST("", rbacH.CreatePolicy)
+			policies.DELETE("", rbacH.DeletePolicy)
+		}
+		roles := admin.Group("/rbac/roles")
+		{
+			roles.GET("/:user", rbacH.GetUserRoles)
+			roles.POST("", rbacH.AssignRole)
+		}
+	}
+
 	return r
 }
 

--- a/internal/api/admin_services.go
+++ b/internal/api/admin_services.go
@@ -140,9 +140,62 @@ type AdminTokenService interface {
 	Introspect(ctx context.Context, token string) (*IntrospectionResponse, error)
 }
 
+// --- RBAC response types ---
+
+// AdminPolicy represents a single (subject, object, action) authorization rule.
+type AdminPolicy struct {
+	Subject string `json:"subject"`
+	Object  string `json:"object"`
+	Action  string `json:"action"`
+}
+
+// AdminPolicyList is the response for listing all policies.
+type AdminPolicyList struct {
+	Policies []AdminPolicy `json:"policies"`
+	Total    int           `json:"total"`
+}
+
+// AdminUserRoles represents the role assignments for a user.
+type AdminUserRoles struct {
+	User  string   `json:"user"`
+	Roles []string `json:"roles"`
+}
+
+// --- RBAC request types ---
+
+// CreatePolicyRequest is the request body for adding a policy rule.
+type CreatePolicyRequest struct {
+	Subject string `json:"subject" validate:"required"`
+	Object  string `json:"object"  validate:"required"`
+	Action  string `json:"action"  validate:"required"`
+}
+
+// DeletePolicyRequest is the request body for removing a policy rule.
+type DeletePolicyRequest struct {
+	Subject string `json:"subject" validate:"required"`
+	Object  string `json:"object"  validate:"required"`
+	Action  string `json:"action"  validate:"required"`
+}
+
+// AssignRoleRequest is the request body for assigning a role to a user.
+type AssignRoleRequest struct {
+	User string `json:"user" validate:"required"`
+	Role string `json:"role" validate:"required"`
+}
+
+// AdminRBACService defines admin operations for RBAC policy and role management.
+type AdminRBACService interface {
+	ListPolicies(ctx context.Context) (*AdminPolicyList, error)
+	CreatePolicy(ctx context.Context, req *CreatePolicyRequest) (*AdminPolicy, error)
+	DeletePolicy(ctx context.Context, req *DeletePolicyRequest) error
+	GetUserRoles(ctx context.Context, user string) (*AdminUserRoles, error)
+	AssignRole(ctx context.Context, req *AssignRoleRequest) (*AdminUserRoles, error)
+}
+
 // AdminServices aggregates all admin service interfaces required by admin API handlers.
 type AdminServices struct {
 	Users   AdminUserService
 	Clients AdminClientService
 	Tokens  AdminTokenService
+	RBAC    AdminRBACService
 }

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -32,6 +32,9 @@ const (
 	EventAdminClientDelete  = "admin_client_delete"
 	EventAdminClientRotate  = "admin_client_rotate_secret"
 	EventTokenIntrospect    = "token_introspect"
+	EventAdminRBACCreate    = "admin_rbac_policy_create"
+	EventAdminRBACDelete    = "admin_rbac_policy_delete"
+	EventAdminRBACRoleAssign = "admin_rbac_role_assign"
 )
 
 // Event represents a single audit log entry.

--- a/internal/rbac/memory.go
+++ b/internal/rbac/memory.go
@@ -1,0 +1,90 @@
+package rbac
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// ErrPolicyNotFound is returned when a policy to be removed does not exist.
+var ErrPolicyNotFound = errors.New("policy not found")
+
+// MemoryRepository is a thread-safe in-memory implementation of PolicyRepository.
+// It is intended for development and testing; replace with a PostgreSQL-backed
+// implementation (e.g., via Casbin's pgx adapter) for production.
+type MemoryRepository struct {
+	mu      sync.RWMutex
+	policies []Policy
+	roles    map[string][]string // user → []role
+}
+
+// NewMemoryRepository creates an empty MemoryRepository.
+func NewMemoryRepository() *MemoryRepository {
+	return &MemoryRepository{
+		roles: make(map[string][]string),
+	}
+}
+
+// ListPolicies returns a copy of all stored policy rules.
+func (r *MemoryRepository) ListPolicies(_ context.Context) ([]Policy, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]Policy, len(r.policies))
+	copy(result, r.policies)
+	return result, nil
+}
+
+// AddPolicy inserts a policy rule if it does not already exist.
+func (r *MemoryRepository) AddPolicy(_ context.Context, p Policy) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, existing := range r.policies {
+		if existing == p {
+			return nil // idempotent
+		}
+	}
+	r.policies = append(r.policies, p)
+	return nil
+}
+
+// RemovePolicy deletes the matching policy rule.
+// Returns ErrPolicyNotFound if no matching rule exists.
+func (r *MemoryRepository) RemovePolicy(_ context.Context, p Policy) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for i, existing := range r.policies {
+		if existing == p {
+			r.policies = append(r.policies[:i], r.policies[i+1:]...)
+			return nil
+		}
+	}
+	return ErrPolicyNotFound
+}
+
+// GetRolesForUser returns a copy of roles assigned to user.
+func (r *MemoryRepository) GetRolesForUser(_ context.Context, user string) ([]string, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	roles := r.roles[user]
+	result := make([]string, len(roles))
+	copy(result, roles)
+	return result, nil
+}
+
+// AddRoleForUser assigns role to user if not already present.
+func (r *MemoryRepository) AddRoleForUser(_ context.Context, user, role string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, existing := range r.roles[user] {
+		if existing == role {
+			return nil // idempotent
+		}
+	}
+	r.roles[user] = append(r.roles[user], role)
+	return nil
+}

--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -1,2 +1,29 @@
 // Package rbac provides role-based access control enforcement.
 package rbac
+
+import "context"
+
+// Policy represents a Casbin-style (subject, object, action) authorization rule.
+type Policy struct {
+	Subject string
+	Object  string
+	Action  string
+}
+
+// PolicyRepository defines storage operations for RBAC policies and role assignments.
+type PolicyRepository interface {
+	// ListPolicies returns all (subject, object, action) policy rules.
+	ListPolicies(ctx context.Context) ([]Policy, error)
+
+	// AddPolicy inserts a new policy rule. No-ops on duplicate.
+	AddPolicy(ctx context.Context, p Policy) error
+
+	// RemovePolicy deletes a policy rule. Returns ErrNotFound if it does not exist.
+	RemovePolicy(ctx context.Context, p Policy) error
+
+	// GetRolesForUser returns all roles assigned to the given user.
+	GetRolesForUser(ctx context.Context, user string) ([]string, error)
+
+	// AddRoleForUser assigns a role to a user. No-ops on duplicate.
+	AddRoleForUser(ctx context.Context, user, role string) error
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-206.

Closes #206

## Changes

Add the admin service layer in `internal/admin/` and HTTP handlers + route registration in `internal/api/` for policy CRUD and role assignment. Endpoints: `GET/POST/DELETE /admin/rbac/policies`, `GET /admin/rbac/roles/:user`, `POST /admin/rbac/roles`. Follows the existing admin pattern (separate port, no auth middleware, CorrelationID only). Includes handler tests.
- **Packages**: `internal/admin/`, `internal/api/`