### PR TITLE
GH-211: Core DPoP proof validation package (`internal/dpop/`) - Create the new `internal/dpop/` package with all DPoP proof logic: parse DPoP proof JWT from header (typ=`dpop+jwt`, alg allowlist, htm/htu matching), verify proof signature against embedded JWK, compute JWK thumbprint per RFC 7638, Redis-backed jti uniqueness checking (5-min window with `dpop:jti:<hash>` keys), and nonce generation/validation (issue via `DPoP-Nonce` header, verify on subsequent requests). Include comprehensive unit tests: proof generation/validation round-trip, replay protection (duplicate jti rejected), nonce flow, invalid proofs rejected. This package has no dependencies on other DPoP changes

### DIFF
--- a/internal/dpop/dpop.go
+++ b/internal/dpop/dpop.go
@@ -1,0 +1,536 @@
+// Package dpop implements DPoP (Demonstration of Proof-of-Possession) proof
+// validation per RFC 9449. It provides JTI replay protection (Redis-backed),
+// server nonce issuance, and JWK Thumbprint computation (RFC 7638).
+package dpop
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"math/big"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+)
+
+const (
+	// dpopType is the required typ header value for DPoP proofs.
+	dpopType = "dpop+jwt"
+
+	// jtiKeyPrefix is the Redis key prefix for DPoP proof JTI deduplication.
+	jtiKeyPrefix = "dpop_jti:"
+
+	// nonceKeyPrefix is the Redis key prefix for server-issued DPoP nonces.
+	nonceKeyPrefix = "dpop_nonce:"
+
+	// nonceBytes is the number of random bytes for nonce generation (16 bytes = 128 bits).
+	nonceBytes = 16
+
+	// defaultJTIWindow is the default deduplication window for DPoP proof JTIs.
+	defaultJTIWindow = 5 * time.Minute
+
+	// defaultNonceTTL is the default lifetime for server-issued nonces.
+	defaultNonceTTL = 5 * time.Minute
+
+	// defaultMaxClockSkew is the maximum allowed clock skew for iat validation.
+	defaultMaxClockSkew = 60 * time.Second
+)
+
+// Error codes per RFC 9449 section 7.
+var (
+	ErrInvalidProof = fmt.Errorf("invalid_dpop_proof")
+	ErrUseNonce     = fmt.Errorf("use_dpop_nonce")
+)
+
+// Config holds DPoP validation settings.
+type Config struct {
+	// NonceRequired requires a server-issued nonce in every DPoP proof.
+	NonceRequired bool
+	// JTIWindow is the deduplication window for proof JTIs (default: 5 min).
+	JTIWindow time.Duration
+	// NonceTTL is the lifetime for server-issued nonces (default: 5 min).
+	NonceTTL time.Duration
+	// MaxClockSkew is the maximum allowed clock skew for iat (default: 60s).
+	MaxClockSkew time.Duration
+	// AllowedAlgorithms lists permitted signing algorithms (default: ES256, EdDSA).
+	AllowedAlgorithms []string
+}
+
+func (c Config) jtiWindow() time.Duration {
+	if c.JTIWindow > 0 {
+		return c.JTIWindow
+	}
+	return defaultJTIWindow
+}
+
+func (c Config) nonceTTL() time.Duration {
+	if c.NonceTTL > 0 {
+		return c.NonceTTL
+	}
+	return defaultNonceTTL
+}
+
+func (c Config) maxClockSkew() time.Duration {
+	if c.MaxClockSkew > 0 {
+		return c.MaxClockSkew
+	}
+	return defaultMaxClockSkew
+}
+
+func (c Config) allowedAlgorithms() []string {
+	if len(c.AllowedAlgorithms) > 0 {
+		return c.AllowedAlgorithms
+	}
+	return []string{"ES256", "EdDSA"}
+}
+
+// Proof represents a validated DPoP proof.
+type Proof struct {
+	// JWKThumbprint is the base64url-encoded SHA-256 JWK Thumbprint (RFC 7638).
+	// Used as the cnf.jkt value when binding tokens.
+	JWKThumbprint string
+	// PublicKey is the client's public key extracted from the proof.
+	PublicKey crypto.PublicKey
+	// JTI is the unique identifier of the proof.
+	JTI string
+	// HTM is the HTTP method from the proof.
+	HTM string
+	// HTU is the HTTP URI from the proof.
+	HTU string
+	// IssuedAt is the proof creation time.
+	IssuedAt time.Time
+	// AccessTokenHash is the ath claim (base64url SHA-256 of access token), if present.
+	AccessTokenHash string
+	// Nonce is the server-issued nonce included in the proof, if any.
+	Nonce string
+}
+
+// Validator validates DPoP proofs per RFC 9449.
+type Validator struct {
+	redis  *redis.Client
+	logger *zap.Logger
+	cfg    Config
+}
+
+// NewValidator creates a DPoP proof Validator.
+func NewValidator(cfg Config, redisClient *redis.Client, logger *zap.Logger) *Validator {
+	return &Validator{
+		redis:  redisClient,
+		logger: logger,
+		cfg:    cfg,
+	}
+}
+
+// proofClaims holds the extracted and validated claims from a DPoP proof JWT.
+type proofClaims struct {
+	jti   string
+	htm   string
+	htu   string
+	iat   time.Time
+	ath   string
+	nonce string
+}
+
+// ValidateProof parses and validates a DPoP proof JWT per RFC 9449 section 4.3.
+// httpMethod and httpURL must match the current request.
+// accessToken may be empty for token-request proofs (where ath is not required).
+func (v *Validator) ValidateProof(ctx context.Context, proofJWT, httpMethod, httpURL, accessToken string) (*Proof, error) {
+	// Parse, verify headers, extract public key, and verify signature.
+	pubKey, claims, err := v.parseAndVerify(proofJWT)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract and validate all proof claims against the request context.
+	pc, err := v.validateClaims(claims, httpMethod, httpURL, accessToken)
+	if err != nil {
+		return nil, err
+	}
+
+	// Nonce validation (server-issued, one-time use).
+	if err := v.handleNonce(ctx, pc.nonce); err != nil {
+		return nil, err
+	}
+
+	// JTI replay protection (Redis SetNX with TTL).
+	if err := v.checkAndStoreJTI(ctx, pc.jti); err != nil {
+		return nil, err
+	}
+
+	// Compute JWK Thumbprint (RFC 7638) for token binding.
+	thumbprint, err := JWKThumbprint(pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("%w: compute thumbprint: %v", ErrInvalidProof, err)
+	}
+
+	return &Proof{
+		JWKThumbprint:   thumbprint,
+		PublicKey:       pubKey,
+		JTI:             pc.jti,
+		HTM:             pc.htm,
+		HTU:             pc.htu,
+		IssuedAt:        pc.iat,
+		AccessTokenHash: pc.ath,
+		Nonce:           pc.nonce,
+	}, nil
+}
+
+// parseAndVerify validates the JOSE headers (typ, alg, jwk) and verifies the
+// proof signature with the embedded public key.
+func (v *Validator) parseAndVerify(proofJWT string) (crypto.PublicKey, jwt.MapClaims, error) {
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	unverified, _, err := parser.ParseUnverified(proofJWT, jwt.MapClaims{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: parse failed: %v", ErrInvalidProof, err)
+	}
+
+	// Validate typ header.
+	typ, _ := unverified.Header["typ"].(string)
+	if !strings.EqualFold(typ, dpopType) {
+		return nil, nil, fmt.Errorf("%w: typ must be dpop+jwt", ErrInvalidProof)
+	}
+
+	// Validate alg header is in the allowed list.
+	alg, _ := unverified.Header["alg"].(string)
+	if alg == "" {
+		return nil, nil, fmt.Errorf("%w: missing alg header", ErrInvalidProof)
+	}
+	if !v.isAllowedAlgorithm(alg) {
+		return nil, nil, fmt.Errorf("%w: algorithm %q not allowed", ErrInvalidProof, alg)
+	}
+
+	// Extract and parse the jwk header into a public key.
+	jwkRaw, ok := unverified.Header["jwk"]
+	if !ok {
+		return nil, nil, fmt.Errorf("%w: missing jwk header", ErrInvalidProof)
+	}
+	pubKey, err := parseJWK(jwkRaw)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: invalid jwk: %v", ErrInvalidProof, err)
+	}
+
+	// Re-parse with full signature verification using the embedded public key.
+	verified, err := jwt.Parse(proofJWT, func(t *jwt.Token) (interface{}, error) {
+		if t.Method.Alg() != alg {
+			return nil, fmt.Errorf("unexpected signing method: %s", t.Method.Alg())
+		}
+		return pubKey, nil
+	}, jwt.WithValidMethods([]string{alg}), jwt.WithoutClaimsValidation())
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: signature verification failed: %v", ErrInvalidProof, err)
+	}
+
+	claims, ok := verified.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, nil, fmt.Errorf("%w: invalid claims", ErrInvalidProof)
+	}
+
+	return pubKey, claims, nil
+}
+
+// validateClaims extracts and validates all required DPoP proof claims.
+func (v *Validator) validateClaims(claims jwt.MapClaims, httpMethod, httpURL, accessToken string) (*proofClaims, error) {
+	jti, _ := claims["jti"].(string)
+	if jti == "" {
+		return nil, fmt.Errorf("%w: missing jti claim", ErrInvalidProof)
+	}
+
+	htm, _ := claims["htm"].(string)
+	if htm == "" {
+		return nil, fmt.Errorf("%w: missing htm claim", ErrInvalidProof)
+	}
+
+	htu, _ := claims["htu"].(string)
+	if htu == "" {
+		return nil, fmt.Errorf("%w: missing htu claim", ErrInvalidProof)
+	}
+
+	iatFloat, ok := claims["iat"].(float64)
+	if !ok {
+		return nil, fmt.Errorf("%w: missing or invalid iat claim", ErrInvalidProof)
+	}
+	iat := time.Unix(int64(iatFloat), 0)
+
+	// htm must match the HTTP method.
+	if !strings.EqualFold(htm, httpMethod) {
+		return nil, fmt.Errorf("%w: htm %q does not match HTTP method %q", ErrInvalidProof, htm, httpMethod)
+	}
+
+	// htu must match scheme + host + path (query/fragment ignored per RFC 9449).
+	if err := matchHTU(htu, httpURL); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidProof, err)
+	}
+
+	// iat must be within acceptable time window.
+	now := time.Now()
+	skew := v.cfg.maxClockSkew()
+	if iat.After(now.Add(skew)) {
+		return nil, fmt.Errorf("%w: iat is in the future", ErrInvalidProof)
+	}
+	if iat.Before(now.Add(-v.cfg.jtiWindow())) {
+		return nil, fmt.Errorf("%w: iat is too old", ErrInvalidProof)
+	}
+
+	// If access token provided, validate ath claim.
+	ath, _ := claims["ath"].(string)
+	if accessToken != "" {
+		expectedATH := ComputeATH(accessToken)
+		if ath != expectedATH {
+			return nil, fmt.Errorf("%w: ath mismatch", ErrInvalidProof)
+		}
+	}
+
+	nonce, _ := claims["nonce"].(string)
+
+	return &proofClaims{
+		jti:   jti,
+		htm:   htm,
+		htu:   htu,
+		iat:   iat,
+		ath:   ath,
+		nonce: nonce,
+	}, nil
+}
+
+// handleNonce validates the nonce claim based on the server's nonce policy.
+func (v *Validator) handleNonce(ctx context.Context, nonce string) error {
+	if v.cfg.NonceRequired {
+		if nonce == "" {
+			return ErrUseNonce
+		}
+		valid, err := v.validateNonce(ctx, nonce)
+		if err != nil {
+			return fmt.Errorf("%w: nonce check failed: %v", ErrInvalidProof, err)
+		}
+		if !valid {
+			return ErrUseNonce
+		}
+		return nil
+	}
+
+	if nonce != "" {
+		// Nonce provided voluntarily — still validate it.
+		valid, err := v.validateNonce(ctx, nonce)
+		if err != nil {
+			v.logger.Warn("dpop nonce validation error", zap.Error(err))
+		} else if !valid {
+			return fmt.Errorf("%w: invalid nonce", ErrInvalidProof)
+		}
+	}
+	return nil
+}
+
+// GenerateNonce creates a new server nonce and stores it in Redis.
+// The nonce should be returned to the client via the DPoP-Nonce response header.
+func (v *Validator) GenerateNonce(ctx context.Context) (string, error) {
+	b := make([]byte, nonceBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate nonce: %w", err)
+	}
+
+	nonce := base64.RawURLEncoding.EncodeToString(b)
+	key := nonceKeyPrefix + nonce
+	if err := v.redis.Set(ctx, key, "1", v.cfg.nonceTTL()).Err(); err != nil {
+		return "", fmt.Errorf("store nonce: %w", err)
+	}
+
+	return nonce, nil
+}
+
+// JWKThumbprint computes the JWK Thumbprint per RFC 7638 using SHA-256.
+// The result is base64url-encoded and suitable for use as a cnf.jkt claim.
+func JWKThumbprint(pub crypto.PublicKey) (string, error) {
+	var thumbprintInput string
+
+	switch k := pub.(type) {
+	case *ecdsa.PublicKey:
+		if k.Curve != elliptic.P256() {
+			return "", fmt.Errorf("unsupported EC curve for thumbprint")
+		}
+		byteLen := (k.Curve.Params().BitSize + 7) / 8
+		xBytes := padLeft(k.X.Bytes(), byteLen)
+		yBytes := padLeft(k.Y.Bytes(), byteLen)
+		// RFC 7638: members sorted lexicographically by key name.
+		// String concatenation used intentionally to produce canonical JSON —
+		// fmt.Sprintf %q adds Go-style escaping which breaks the canonical form.
+		xEnc := base64.RawURLEncoding.EncodeToString(xBytes)
+		yEnc := base64.RawURLEncoding.EncodeToString(yBytes)
+		thumbprintInput = `{"crv":"P-256","kty":"EC","x":"` + xEnc + `","y":"` + yEnc + `"}`
+	case ed25519.PublicKey:
+		xEnc := base64.RawURLEncoding.EncodeToString([]byte(k))
+		thumbprintInput = `{"crv":"Ed25519","kty":"OKP","x":"` + xEnc + `"}`
+	default:
+		return "", fmt.Errorf("unsupported key type for thumbprint: %T", pub)
+	}
+
+	hash := sha256.Sum256([]byte(thumbprintInput))
+	return base64.RawURLEncoding.EncodeToString(hash[:]), nil
+}
+
+// ComputeATH computes the base64url-encoded SHA-256 hash of an access token
+// for the DPoP ath claim (RFC 9449 section 4.2).
+func ComputeATH(accessToken string) string {
+	hash := sha256.Sum256([]byte(accessToken))
+	return base64.RawURLEncoding.EncodeToString(hash[:])
+}
+
+// ── Internal ────────────────────────────────────────────────────────────────
+
+func (v *Validator) isAllowedAlgorithm(alg string) bool {
+	for _, a := range v.cfg.allowedAlgorithms() {
+		if a == alg {
+			return true
+		}
+	}
+	return false
+}
+
+// checkAndStoreJTI atomically checks for JTI replay and stores the JTI with TTL.
+func (v *Validator) checkAndStoreJTI(ctx context.Context, jti string) error {
+	key := jtiKeyPrefix + jti
+	result, err := v.redis.SetArgs(ctx, key, "1", redis.SetArgs{
+		Mode: "NX",
+		TTL:  v.cfg.jtiWindow(),
+	}).Result()
+	if err == redis.Nil {
+		return fmt.Errorf("%w: jti already used (replay)", ErrInvalidProof)
+	}
+	if err != nil {
+		return fmt.Errorf("%w: jti check failed: %v", ErrInvalidProof, err)
+	}
+	_ = result
+	return nil
+}
+
+// validateNonce checks whether a nonce exists in Redis and deletes it (one-time use).
+func (v *Validator) validateNonce(ctx context.Context, nonce string) (bool, error) {
+	key := nonceKeyPrefix + nonce
+	n, err := v.redis.Exists(ctx, key).Result()
+	if err != nil {
+		return false, fmt.Errorf("check nonce: %w", err)
+	}
+	if n > 0 {
+		// Nonces are single-use.
+		v.redis.Del(ctx, key)
+	}
+	return n > 0, nil
+}
+
+// matchHTU validates that the htu claim matches the expected URL.
+// Per RFC 9449 section 4.3: compare scheme, host, and path (ignore query and fragment).
+func matchHTU(htu, expected string) error {
+	htuParsed, err := url.Parse(htu)
+	if err != nil {
+		return fmt.Errorf("htu is not a valid URL: %v", err)
+	}
+	expParsed, err := url.Parse(expected)
+	if err != nil {
+		return fmt.Errorf("expected URL is not valid: %v", err)
+	}
+
+	if !strings.EqualFold(htuParsed.Scheme, expParsed.Scheme) {
+		return fmt.Errorf("htu scheme %q does not match %q", htuParsed.Scheme, expParsed.Scheme)
+	}
+	if !strings.EqualFold(htuParsed.Host, expParsed.Host) {
+		return fmt.Errorf("htu host %q does not match %q", htuParsed.Host, expParsed.Host)
+	}
+	if htuParsed.Path != expParsed.Path {
+		return fmt.Errorf("htu path %q does not match %q", htuParsed.Path, expParsed.Path)
+	}
+	return nil
+}
+
+// parseJWK parses a JWK from the JWT header into a crypto.PublicKey.
+// Only asymmetric key types (EC, OKP) are supported per RFC 9449.
+func parseJWK(raw interface{}) (crypto.PublicKey, error) {
+	jwkMap, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("jwk is not an object")
+	}
+
+	kty, _ := jwkMap["kty"].(string)
+	switch kty {
+	case "EC":
+		return parseECPublicKey(jwkMap)
+	case "OKP":
+		return parseOKPPublicKey(jwkMap)
+	default:
+		return nil, fmt.Errorf("unsupported key type: %q", kty)
+	}
+}
+
+func parseECPublicKey(jwk map[string]interface{}) (*ecdsa.PublicKey, error) {
+	crv, _ := jwk["crv"].(string)
+	if crv != "P-256" {
+		return nil, fmt.Errorf("unsupported EC curve: %q", crv)
+	}
+
+	xStr, _ := jwk["x"].(string)
+	yStr, _ := jwk["y"].(string)
+	if xStr == "" || yStr == "" {
+		return nil, fmt.Errorf("missing x or y coordinate")
+	}
+
+	xBytes, err := base64.RawURLEncoding.DecodeString(xStr)
+	if err != nil {
+		return nil, fmt.Errorf("decode x: %w", err)
+	}
+	yBytes, err := base64.RawURLEncoding.DecodeString(yStr)
+	if err != nil {
+		return nil, fmt.Errorf("decode y: %w", err)
+	}
+
+	pub := &ecdsa.PublicKey{
+		Curve: elliptic.P256(),
+		X:     new(big.Int).SetBytes(xBytes),
+		Y:     new(big.Int).SetBytes(yBytes),
+	}
+
+	if !pub.IsOnCurve(pub.X, pub.Y) {
+		return nil, fmt.Errorf("EC point is not on curve")
+	}
+
+	return pub, nil
+}
+
+func parseOKPPublicKey(jwk map[string]interface{}) (ed25519.PublicKey, error) {
+	crv, _ := jwk["crv"].(string)
+	if crv != "Ed25519" {
+		return nil, fmt.Errorf("unsupported OKP curve: %q", crv)
+	}
+
+	xStr, _ := jwk["x"].(string)
+	if xStr == "" {
+		return nil, fmt.Errorf("missing x coordinate")
+	}
+
+	xBytes, err := base64.RawURLEncoding.DecodeString(xStr)
+	if err != nil {
+		return nil, fmt.Errorf("decode x: %w", err)
+	}
+
+	if len(xBytes) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("invalid Ed25519 public key length: %d", len(xBytes))
+	}
+
+	return ed25519.PublicKey(xBytes), nil
+}
+
+func padLeft(b []byte, size int) []byte {
+	if len(b) >= size {
+		return b
+	}
+	padded := make([]byte, size)
+	copy(padded[size-len(b):], b)
+	return padded
+}

--- a/internal/dpop/dpop_test.go
+++ b/internal/dpop/dpop_test.go
@@ -1,0 +1,702 @@
+package dpop_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/dpop"
+)
+
+// ── Test helpers ────────────────────────────────────────────────────────────
+
+const (
+	testMethod = "POST"
+	testURL    = "https://auth.example.com/token"
+)
+
+func newTestRedis(t *testing.T) (*miniredis.Miniredis, *redis.Client) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return mr, client
+}
+
+func defaultConfig() dpop.Config {
+	return dpop.Config{
+		JTIWindow:         5 * time.Minute,
+		NonceTTL:          5 * time.Minute,
+		MaxClockSkew:      60 * time.Second,
+		AllowedAlgorithms: []string{"ES256", "EdDSA"},
+	}
+}
+
+func newValidator(t *testing.T, cfg dpop.Config) (*dpop.Validator, *miniredis.Miniredis) {
+	t.Helper()
+	mr, rc := newTestRedis(t)
+	v := dpop.NewValidator(cfg, rc, zap.NewNop())
+	return v, mr
+}
+
+func generateES256Key(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	return key
+}
+
+func generateEdDSAKey(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	return priv
+}
+
+// buildProof creates a signed DPoP proof JWT for testing.
+type proofBuilder struct {
+	t       *testing.T
+	header  map[string]interface{}
+	claims  jwt.MapClaims
+	signKey interface{}
+	method  jwt.SigningMethod
+}
+
+func newES256ProofBuilder(t *testing.T, key *ecdsa.PrivateKey) *proofBuilder {
+	t.Helper()
+	pub := key.PublicKey
+	byteLen := (pub.Curve.Params().BitSize + 7) / 8
+	xBytes := padLeftTest(pub.X.Bytes(), byteLen)
+	yBytes := padLeftTest(pub.Y.Bytes(), byteLen)
+
+	return &proofBuilder{
+		t: t,
+		header: map[string]interface{}{
+			"typ": "dpop+jwt",
+			"alg": "ES256",
+			"jwk": map[string]interface{}{
+				"kty": "EC",
+				"crv": "P-256",
+				"x":   base64.RawURLEncoding.EncodeToString(xBytes),
+				"y":   base64.RawURLEncoding.EncodeToString(yBytes),
+			},
+		},
+		claims: jwt.MapClaims{
+			"jti": fmt.Sprintf("test-jti-%d", time.Now().UnixNano()),
+			"htm": testMethod,
+			"htu": testURL,
+			"iat": float64(time.Now().Unix()),
+		},
+		signKey: key,
+		method:  jwt.SigningMethodES256,
+	}
+}
+
+func newEdDSAProofBuilder(t *testing.T, key ed25519.PrivateKey) *proofBuilder {
+	t.Helper()
+	pub := key.Public().(ed25519.PublicKey)
+
+	return &proofBuilder{
+		t: t,
+		header: map[string]interface{}{
+			"typ": "dpop+jwt",
+			"alg": "EdDSA",
+			"jwk": map[string]interface{}{
+				"kty": "OKP",
+				"crv": "Ed25519",
+				"x":   base64.RawURLEncoding.EncodeToString([]byte(pub)),
+			},
+		},
+		claims: jwt.MapClaims{
+			"jti": fmt.Sprintf("test-jti-%d", time.Now().UnixNano()),
+			"htm": testMethod,
+			"htu": testURL,
+			"iat": float64(time.Now().Unix()),
+		},
+		signKey: key,
+		method:  jwt.SigningMethodEdDSA,
+	}
+}
+
+func (b *proofBuilder) withJTI(jti string) *proofBuilder {
+	b.claims["jti"] = jti
+	return b
+}
+
+func (b *proofBuilder) withHTM(htm string) *proofBuilder {
+	b.claims["htm"] = htm
+	return b
+}
+
+func (b *proofBuilder) withHTU(htu string) *proofBuilder {
+	b.claims["htu"] = htu
+	return b
+}
+
+func (b *proofBuilder) withIAT(iat time.Time) *proofBuilder {
+	b.claims["iat"] = float64(iat.Unix())
+	return b
+}
+
+func (b *proofBuilder) withATH(ath string) *proofBuilder {
+	b.claims["ath"] = ath
+	return b
+}
+
+func (b *proofBuilder) withNonce(nonce string) *proofBuilder {
+	b.claims["nonce"] = nonce
+	return b
+}
+
+func (b *proofBuilder) withHeader(key string, value interface{}) *proofBuilder {
+	b.header[key] = value
+	return b
+}
+
+func (b *proofBuilder) withoutClaim(key string) *proofBuilder {
+	delete(b.claims, key)
+	return b
+}
+
+func (b *proofBuilder) withoutHeader(key string) *proofBuilder {
+	delete(b.header, key)
+	return b
+}
+
+func (b *proofBuilder) build() string {
+	b.t.Helper()
+	token := jwt.NewWithClaims(b.method, b.claims)
+	for k, v := range b.header {
+		token.Header[k] = v
+	}
+	signed, err := token.SignedString(b.signKey)
+	require.NoError(b.t, err)
+	return signed
+}
+
+func padLeftTest(b []byte, size int) []byte {
+	if len(b) >= size {
+		return b
+	}
+	padded := make([]byte, size)
+	copy(padded[size-len(b):], b)
+	return padded
+}
+
+// ── ValidateProof tests ─────────────────────────────────────────────────────
+
+func TestValidateProof_ES256_Success(t *testing.T) {
+	v, _ := newValidator(t, defaultConfig())
+	key := generateES256Key(t)
+	proofJWT := newES256ProofBuilder(t, key).build()
+
+	proof, err := v.ValidateProof(context.Background(), proofJWT, testMethod, testURL, "")
+	require.NoError(t, err)
+	assert.NotEmpty(t, proof.JWKThumbprint)
+	assert.Equal(t, testMethod, proof.HTM)
+	assert.Equal(t, testURL, proof.HTU)
+	assert.NotEmpty(t, proof.JTI)
+	assert.NotNil(t, proof.PublicKey)
+}
+
+func TestValidateProof_EdDSA_Success(t *testing.T) {
+	v, _ := newValidator(t, defaultConfig())
+	key := generateEdDSAKey(t)
+	proofJWT := newEdDSAProofBuilder(t, key).build()
+
+	proof, err := v.ValidateProof(context.Background(), proofJWT, testMethod, testURL, "")
+	require.NoError(t, err)
+	assert.NotEmpty(t, proof.JWKThumbprint)
+	assert.Equal(t, testMethod, proof.HTM)
+	assert.Equal(t, testURL, proof.HTU)
+}
+
+func TestValidateProof_Errors(t *testing.T) {
+	tests := []struct {
+		name       string
+		buildProof func(t *testing.T) string
+		method     string
+		url        string
+		token      string
+		errContain string
+	}{
+		{
+			name:       "invalid JWT",
+			buildProof: func(_ *testing.T) string { return "not-a-jwt" },
+			method:     testMethod,
+			url:        testURL,
+			errContain: "invalid_dpop_proof",
+		},
+		{
+			name: "wrong typ header",
+			buildProof: func(t *testing.T) string {
+				key := generateES256Key(t)
+				return newES256ProofBuilder(t, key).withHeader("typ", "JWT").build()
+			},
+			method:     testMethod,
+			url:        testURL,
+			errContain: "typ must be dpop+jwt",
+		},
+		{
+			name: "missing typ header",
+			buildProof: func(t *testing.T) string {
+				key := generateES256Key(t)
+				return newES256ProofBuilder(t, key).withoutHeader("typ").build()
+			},
+			method:     testMethod,
+			url:        testURL,
+			errContain: "typ must be dpop+jwt",
+		},
+		{
+			name: "disallowed algorithm",
+			buildProof: func(t *testing.T) string {
+				key := generateES256Key(t)
+				// Build with ES256 but set header to claim RS256
+				return newES256ProofBuilder(t, key).withHeader("alg", "RS256").build()
+			},
+			method:     testMethod,
+			url:        testURL,
+			errContain: "not allowed",
+		},
+		{
+			name: "missing jwk header",
+			buildProof: func(t *testing.T) string {
+				key := generateES256Key(t)
+				return newES256ProofBuilder(t, key).withoutHeader("jwk").build()
+			},
+			method:     testMethod,
+			url:        testURL,
+			errContain: "missing jwk header",
+		},
+		{
+			name: "invalid jwk (not object)",
+			buildProof: func(t *testing.T) string {
+				key := generateES256Key(t)
+				return newES256ProofBuilder(t, key).withHeader("jwk", "not-an-object").build()
+			},
+			method:     testMethod,
+			url:        testURL,
+			errContain: "invalid jwk",
+		},
+		{
+			name: "missing jti claim",
+			buildProof: func(t *testing.T) string {
+				key := generateES256Key(t)
+				return newES256ProofBuilder(t, key).withoutClaim("jti").build()
+			},
+			method:     testMethod,
+			url:        testURL,
+			errContain: "missing jti claim",
+		},
+		{
+			name: "missing htm claim",
+			buildProof: func(t *testing.T) string {
+				key := generateES256Key(t)
+				return newES256ProofBuilder(t, key).withoutClaim("htm").build()
+			},
+			method:     testMethod,
+			url:        testURL,
+			errContain: "missing htm claim",
+		},
+		{
+			name: "missing htu claim",
+			buildProof: func(t *testing.T) string {
+				key := generateES256Key(t)
+				return newES256ProofBuilder(t, key).withoutClaim("htu").build()
+			},
+			method:     testMethod,
+			url:        testURL,
+			errContain: "missing htu claim",
+		},
+		{
+			name: "missing iat claim",
+			buildProof: func(t *testing.T) string {
+				key := generateES256Key(t)
+				return newES256ProofBuilder(t, key).withoutClaim("iat").build()
+			},
+			method:     testMethod,
+			url:        testURL,
+			errContain: "missing or invalid iat claim",
+		},
+		{
+			name: "htm mismatch",
+			buildProof: func(t *testing.T) string {
+				key := generateES256Key(t)
+				return newES256ProofBuilder(t, key).withHTM("GET").build()
+			},
+			method:     testMethod,
+			url:        testURL,
+			errContain: "does not match HTTP method",
+		},
+		{
+			name: "htu mismatch (different path)",
+			buildProof: func(t *testing.T) string {
+				key := generateES256Key(t)
+				return newES256ProofBuilder(t, key).withHTU("https://auth.example.com/other").build()
+			},
+			method:     testMethod,
+			url:        testURL,
+			errContain: "htu path",
+		},
+		{
+			name: "htu mismatch (different host)",
+			buildProof: func(t *testing.T) string {
+				key := generateES256Key(t)
+				return newES256ProofBuilder(t, key).withHTU("https://evil.example.com/token").build()
+			},
+			method:     testMethod,
+			url:        testURL,
+			errContain: "htu host",
+		},
+		{
+			name: "iat in the future",
+			buildProof: func(t *testing.T) string {
+				key := generateES256Key(t)
+				return newES256ProofBuilder(t, key).withIAT(time.Now().Add(5 * time.Minute)).build()
+			},
+			method:     testMethod,
+			url:        testURL,
+			errContain: "iat is in the future",
+		},
+		{
+			name: "iat too old",
+			buildProof: func(t *testing.T) string {
+				key := generateES256Key(t)
+				return newES256ProofBuilder(t, key).withIAT(time.Now().Add(-10 * time.Minute)).build()
+			},
+			method:     testMethod,
+			url:        testURL,
+			errContain: "iat is too old",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, _ := newValidator(t, defaultConfig())
+			proofJWT := tt.buildProof(t)
+			_, err := v.ValidateProof(context.Background(), proofJWT, tt.method, tt.url, tt.token)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, dpop.ErrInvalidProof)
+			assert.Contains(t, err.Error(), tt.errContain)
+		})
+	}
+}
+
+func TestValidateProof_ATH(t *testing.T) {
+	t.Run("valid ath", func(t *testing.T) {
+		v, _ := newValidator(t, defaultConfig())
+		key := generateES256Key(t)
+		accessToken := "qf_at_test-access-token" //nolint:gosec // test value
+		ath := dpop.ComputeATH(accessToken)
+
+		proofJWT := newES256ProofBuilder(t, key).withATH(ath).build()
+		proof, err := v.ValidateProof(context.Background(), proofJWT, testMethod, testURL, accessToken)
+		require.NoError(t, err)
+		assert.Equal(t, ath, proof.AccessTokenHash)
+	})
+
+	t.Run("ath mismatch", func(t *testing.T) {
+		v, _ := newValidator(t, defaultConfig())
+		key := generateES256Key(t)
+		proofJWT := newES256ProofBuilder(t, key).withATH("wrong-ath").build()
+
+		_, err := v.ValidateProof(context.Background(), proofJWT, testMethod, testURL, "qf_at_some-token")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ath mismatch")
+	})
+
+	t.Run("no ath required when no access token", func(t *testing.T) {
+		v, _ := newValidator(t, defaultConfig())
+		key := generateES256Key(t)
+		proofJWT := newES256ProofBuilder(t, key).build()
+
+		proof, err := v.ValidateProof(context.Background(), proofJWT, testMethod, testURL, "")
+		require.NoError(t, err)
+		assert.Empty(t, proof.AccessTokenHash)
+	})
+}
+
+func TestValidateProof_SignatureVerification(t *testing.T) {
+	t.Run("wrong key in jwk", func(t *testing.T) {
+		v, _ := newValidator(t, defaultConfig())
+		signingKey := generateES256Key(t)
+		differentKey := generateES256Key(t)
+
+		// Build proof with differentKey's public key in the header but sign with signingKey
+		pub := differentKey.PublicKey
+		byteLen := (pub.Curve.Params().BitSize + 7) / 8
+		xBytes := padLeftTest(pub.X.Bytes(), byteLen)
+		yBytes := padLeftTest(pub.Y.Bytes(), byteLen)
+
+		proofJWT := newES256ProofBuilder(t, signingKey).
+			withHeader("jwk", map[string]interface{}{
+				"kty": "EC",
+				"crv": "P-256",
+				"x":   base64.RawURLEncoding.EncodeToString(xBytes),
+				"y":   base64.RawURLEncoding.EncodeToString(yBytes),
+			}).
+			build()
+
+		_, err := v.ValidateProof(context.Background(), proofJWT, testMethod, testURL, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "signature verification failed")
+	})
+}
+
+// ── JTI Replay Protection ───────────────────────────────────────────────────
+
+func TestValidateProof_JTIReplay(t *testing.T) {
+	v, _ := newValidator(t, defaultConfig())
+	key := generateES256Key(t)
+
+	jti := "unique-jti-for-replay-test"
+	proofJWT1 := newES256ProofBuilder(t, key).withJTI(jti).build()
+
+	// First use succeeds.
+	_, err := v.ValidateProof(context.Background(), proofJWT1, testMethod, testURL, "")
+	require.NoError(t, err)
+
+	// Replay with same JTI fails.
+	proofJWT2 := newES256ProofBuilder(t, key).withJTI(jti).build()
+	_, err = v.ValidateProof(context.Background(), proofJWT2, testMethod, testURL, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "jti already used")
+}
+
+// ── Nonce tests ─────────────────────────────────────────────────────────────
+
+func TestValidateProof_NonceRequired(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.NonceRequired = true
+
+	t.Run("missing nonce returns use_dpop_nonce", func(t *testing.T) {
+		v, _ := newValidator(t, cfg)
+		key := generateES256Key(t)
+		proofJWT := newES256ProofBuilder(t, key).build()
+
+		_, err := v.ValidateProof(context.Background(), proofJWT, testMethod, testURL, "")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, dpop.ErrUseNonce)
+	})
+
+	t.Run("valid nonce accepted", func(t *testing.T) {
+		v, _ := newValidator(t, cfg)
+		ctx := context.Background()
+		key := generateES256Key(t)
+
+		nonce, err := v.GenerateNonce(ctx)
+		require.NoError(t, err)
+
+		proofJWT := newES256ProofBuilder(t, key).withNonce(nonce).build()
+		proof, err := v.ValidateProof(ctx, proofJWT, testMethod, testURL, "")
+		require.NoError(t, err)
+		assert.Equal(t, nonce, proof.Nonce)
+	})
+
+	t.Run("invalid nonce returns use_dpop_nonce", func(t *testing.T) {
+		v, _ := newValidator(t, cfg)
+		key := generateES256Key(t)
+		proofJWT := newES256ProofBuilder(t, key).withNonce("bogus-nonce").build()
+
+		_, err := v.ValidateProof(context.Background(), proofJWT, testMethod, testURL, "")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, dpop.ErrUseNonce)
+	})
+
+	t.Run("nonce is single-use", func(t *testing.T) {
+		v, _ := newValidator(t, cfg)
+		ctx := context.Background()
+		key := generateES256Key(t)
+
+		nonce, err := v.GenerateNonce(ctx)
+		require.NoError(t, err)
+
+		// First proof with nonce succeeds.
+		proofJWT1 := newES256ProofBuilder(t, key).withNonce(nonce).build()
+		_, err = v.ValidateProof(ctx, proofJWT1, testMethod, testURL, "")
+		require.NoError(t, err)
+
+		// Second proof with same nonce fails (nonce consumed).
+		proofJWT2 := newES256ProofBuilder(t, key).withNonce(nonce).build()
+		_, err = v.ValidateProof(ctx, proofJWT2, testMethod, testURL, "")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, dpop.ErrUseNonce)
+	})
+}
+
+func TestValidateProof_NonceOptional(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.NonceRequired = false
+
+	t.Run("no nonce is fine", func(t *testing.T) {
+		v, _ := newValidator(t, cfg)
+		key := generateES256Key(t)
+		proofJWT := newES256ProofBuilder(t, key).build()
+
+		_, err := v.ValidateProof(context.Background(), proofJWT, testMethod, testURL, "")
+		require.NoError(t, err)
+	})
+
+	t.Run("valid voluntary nonce accepted", func(t *testing.T) {
+		v, _ := newValidator(t, cfg)
+		ctx := context.Background()
+		key := generateES256Key(t)
+
+		nonce, err := v.GenerateNonce(ctx)
+		require.NoError(t, err)
+
+		proofJWT := newES256ProofBuilder(t, key).withNonce(nonce).build()
+		_, err = v.ValidateProof(ctx, proofJWT, testMethod, testURL, "")
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid voluntary nonce rejected", func(t *testing.T) {
+		v, _ := newValidator(t, cfg)
+		key := generateES256Key(t)
+		proofJWT := newES256ProofBuilder(t, key).withNonce("bogus").build()
+
+		_, err := v.ValidateProof(context.Background(), proofJWT, testMethod, testURL, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid nonce")
+	})
+}
+
+// ── GenerateNonce ───────────────────────────────────────────────────────────
+
+func TestGenerateNonce(t *testing.T) {
+	v, _ := newValidator(t, defaultConfig())
+	ctx := context.Background()
+
+	nonce1, err := v.GenerateNonce(ctx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, nonce1)
+
+	nonce2, err := v.GenerateNonce(ctx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, nonce2)
+
+	assert.NotEqual(t, nonce1, nonce2, "nonces must be unique")
+}
+
+// ── JWKThumbprint ───────────────────────────────────────────────────────────
+
+func TestJWKThumbprint_EC(t *testing.T) {
+	key := generateES256Key(t)
+	tp, err := dpop.JWKThumbprint(&key.PublicKey)
+	require.NoError(t, err)
+	assert.NotEmpty(t, tp)
+
+	// Same key produces same thumbprint (deterministic).
+	tp2, err := dpop.JWKThumbprint(&key.PublicKey)
+	require.NoError(t, err)
+	assert.Equal(t, tp, tp2)
+
+	// Different key produces different thumbprint.
+	key2 := generateES256Key(t)
+	tp3, err := dpop.JWKThumbprint(&key2.PublicKey)
+	require.NoError(t, err)
+	assert.NotEqual(t, tp, tp3)
+}
+
+func TestJWKThumbprint_EdDSA(t *testing.T) {
+	key := generateEdDSAKey(t)
+	pub := key.Public().(ed25519.PublicKey)
+	tp, err := dpop.JWKThumbprint(pub)
+	require.NoError(t, err)
+	assert.NotEmpty(t, tp)
+
+	// Deterministic.
+	tp2, err := dpop.JWKThumbprint(pub)
+	require.NoError(t, err)
+	assert.Equal(t, tp, tp2)
+}
+
+// ── ComputeATH ──────────────────────────────────────────────────────────────
+
+func TestComputeATH(t *testing.T) {
+	token := "qf_at_test-access-token" //nolint:gosec // test value
+	ath := dpop.ComputeATH(token)
+
+	// Verify it's base64url(SHA-256(token)).
+	hash := sha256.Sum256([]byte(token))
+	expected := base64.RawURLEncoding.EncodeToString(hash[:])
+	assert.Equal(t, expected, ath)
+}
+
+// ── HTU matching ────────────────────────────────────────────────────────────
+
+func TestValidateProof_HTU_IgnoresQueryAndFragment(t *testing.T) {
+	v, _ := newValidator(t, defaultConfig())
+	key := generateES256Key(t)
+
+	// Proof htu has no query, request URL has query — should still match.
+	proofJWT := newES256ProofBuilder(t, key).
+		withHTU("https://auth.example.com/token").
+		build()
+
+	_, err := v.ValidateProof(context.Background(), proofJWT, testMethod, "https://auth.example.com/token?grant_type=authorization_code", "")
+	require.NoError(t, err)
+}
+
+// ── Config defaults ─────────────────────────────────────────────────────────
+
+func TestValidateProof_DefaultAlgorithms(t *testing.T) {
+	cfg := dpop.Config{} // all zero values → defaults apply
+	mr, rc := newTestRedis(t)
+	_ = mr
+	v := dpop.NewValidator(cfg, rc, zap.NewNop())
+
+	// ES256 should be allowed by default.
+	key := generateES256Key(t)
+	proofJWT := newES256ProofBuilder(t, key).build()
+	_, err := v.ValidateProof(context.Background(), proofJWT, testMethod, testURL, "")
+	require.NoError(t, err)
+}
+
+// ── Edge cases ──────────────────────────────────────────────────────────────
+
+func TestValidateProof_UnsupportedKeyType(t *testing.T) {
+	v, _ := newValidator(t, defaultConfig())
+
+	// Build a proof with unsupported key type in jwk header.
+	key := generateES256Key(t)
+	proofJWT := newES256ProofBuilder(t, key).
+		withHeader("jwk", map[string]interface{}{
+			"kty": "RSA",
+			"n":   "some-modulus",
+			"e":   "AQAB",
+		}).
+		build()
+
+	_, err := v.ValidateProof(context.Background(), proofJWT, testMethod, testURL, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported key type")
+}
+
+func TestValidateProof_ThumbprintInResult(t *testing.T) {
+	v, _ := newValidator(t, defaultConfig())
+	key := generateES256Key(t)
+	proofJWT := newES256ProofBuilder(t, key).build()
+
+	proof, err := v.ValidateProof(context.Background(), proofJWT, testMethod, testURL, "")
+	require.NoError(t, err)
+
+	// Thumbprint should match independent computation.
+	expectedTP, err := dpop.JWKThumbprint(&key.PublicKey)
+	require.NoError(t, err)
+	assert.Equal(t, expectedTP, proof.JWKThumbprint)
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-211.

Closes #211

## Changes

it only needs Redis and the JWT library already in go.mod.