### PR TITLE
GH-212: Token binding with cnf claim (`internal/token/`, `internal/domain/`)

### DIFF
--- a/internal/domain/claims.go
+++ b/internal/domain/claims.go
@@ -34,4 +34,8 @@ type TokenClaims struct {
 	// IssuedAt is the token issuance time from the JWT iat claim.
 	// Zero value means not set.
 	IssuedAt time.Time
+
+	// DPoPThumbprint is the JWK thumbprint (cnf.jkt) from a DPoP-bound token.
+	// Empty string means the token is not DPoP-bound (plain Bearer).
+	DPoPThumbprint string
 }

--- a/internal/token/service.go
+++ b/internal/token/service.go
@@ -109,7 +109,19 @@ func NewServiceFromKey(cfg config.JWTConfig, privateKey crypto.Signer, redisClie
 
 // IssueTokenPair generates an access/refresh token pair for the given subject.
 func (s *Service) IssueTokenPair(ctx context.Context, subject string, roles, scopes []string, clientType domain.ClientType) (*api.AuthResult, error) {
-	accessToken, err := s.issueAccessToken(subject, roles, scopes, clientType)
+	return s.issueTokenPairInternal(ctx, subject, roles, scopes, clientType, "")
+}
+
+// IssueTokenPairWithDPoP generates a DPoP-bound access/refresh token pair.
+// The dpopThumbprint is the JWK thumbprint (RFC 7638) of the client's DPoP key;
+// it is embedded as the cnf.jkt claim in the access token and the token_type
+// is set to "DPoP" instead of "Bearer".
+func (s *Service) IssueTokenPairWithDPoP(ctx context.Context, subject string, roles, scopes []string, clientType domain.ClientType, dpopThumbprint string) (*api.AuthResult, error) {
+	return s.issueTokenPairInternal(ctx, subject, roles, scopes, clientType, dpopThumbprint)
+}
+
+func (s *Service) issueTokenPairInternal(ctx context.Context, subject string, roles, scopes []string, clientType domain.ClientType, dpopThumbprint string) (*api.AuthResult, error) {
+	accessToken, err := s.issueAccessToken(subject, roles, scopes, clientType, dpopThumbprint)
 	if err != nil {
 		return nil, fmt.Errorf("issue access token: %w", err)
 	}
@@ -119,10 +131,15 @@ func (s *Service) IssueTokenPair(ctx context.Context, subject string, roles, sco
 		return nil, fmt.Errorf("issue refresh token: %w", err)
 	}
 
+	tokenType := "Bearer"
+	if dpopThumbprint != "" {
+		tokenType = "DPoP"
+	}
+
 	return &api.AuthResult{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
-		TokenType:    "Bearer",
+		TokenType:    tokenType,
 		ExpiresIn:    int(s.cfg.AccessTokenTTL.Seconds()),
 	}, nil
 }
@@ -239,12 +256,18 @@ func (s *Service) IsRevoked(ctx context.Context, tokenID string) (bool, error) {
 
 // ── Internal: Access Token ───────────────────────────────────────────────────
 
+// cnfClaim represents the JWT Confirmation (cnf) claim used for DPoP binding (RFC 9449).
+type cnfClaim struct {
+	JKT string `json:"jkt"`
+}
+
 // customClaims extends jwt.RegisteredClaims with our application-specific fields.
 type customClaims struct {
 	jwt.RegisteredClaims
 	Roles      []string `json:"roles,omitempty"`
 	Scopes     []string `json:"scopes,omitempty"`
 	ClientType string   `json:"client_type"`
+	Cnf        *cnfClaim `json:"cnf,omitempty"`
 }
 
 // GetJTI is a helper to extract the JTI from RegisteredClaims.
@@ -252,7 +275,7 @@ func (c *customClaims) GetJTI() (string, error) {
 	return c.ID, nil
 }
 
-func (s *Service) issueAccessToken(subject string, roles, scopes []string, clientType domain.ClientType) (string, error) {
+func (s *Service) issueAccessToken(subject string, roles, scopes []string, clientType domain.ClientType, dpopThumbprint string) (string, error) {
 	jti, err := generateRandomID(jtiBytes)
 	if err != nil {
 		return "", fmt.Errorf("generate jti: %w", err)
@@ -270,6 +293,10 @@ func (s *Service) issueAccessToken(subject string, roles, scopes []string, clien
 		Roles:      roles,
 		Scopes:     scopes,
 		ClientType: string(clientType),
+	}
+
+	if dpopThumbprint != "" {
+		claims.Cnf = &cnfClaim{JKT: dpopThumbprint}
 	}
 
 	token := jwt.NewWithClaims(s.signingMethod, claims)
@@ -333,6 +360,9 @@ func claimsToDomain(c *customClaims) (*domain.TokenClaims, error) {
 	}
 	if c.IssuedAt != nil {
 		claims.IssuedAt = c.IssuedAt.Time
+	}
+	if c.Cnf != nil {
+		claims.DPoPThumbprint = c.Cnf.JKT
 	}
 
 	return claims, nil

--- a/internal/token/service_test.go
+++ b/internal/token/service_test.go
@@ -623,3 +623,80 @@ func TestIssueTokenPair_UniqueJTI(t *testing.T) {
 		jtis[claims.TokenID] = true
 	}
 }
+
+// ── DPoP Binding ────────────────────────────────────────────────────────────
+
+func TestIssueTokenPairWithDPoP_ContainsCnfClaim(t *testing.T) {
+	svc, _ := newES256Service(t)
+	ctx := context.Background()
+
+	thumbprint := "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I"
+
+	result, err := svc.IssueTokenPairWithDPoP(ctx, "user-123", []string{"admin"}, []string{"read:users"}, domain.ClientTypeUser, thumbprint)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "DPoP", result.TokenType)
+	assert.True(t, strings.HasPrefix(result.AccessToken, "qf_at_"))
+	assert.True(t, strings.HasPrefix(result.RefreshToken, "qf_rt_"))
+
+	// Validate token and check cnf.jkt round-trip.
+	rawJWT := strings.TrimPrefix(result.AccessToken, "qf_at_")
+	claims, err := svc.ValidateToken(ctx, rawJWT)
+	require.NoError(t, err)
+	assert.Equal(t, thumbprint, claims.DPoPThumbprint)
+	assert.Equal(t, "user-123", claims.Subject)
+}
+
+func TestIssueTokenPairWithDPoP_EdDSA(t *testing.T) {
+	svc, _ := newEdDSAService(t)
+	ctx := context.Background()
+
+	thumbprint := "abc123-test-thumbprint"
+
+	result, err := svc.IssueTokenPairWithDPoP(ctx, "svc-456", []string{"service"}, nil, domain.ClientTypeService, thumbprint)
+	require.NoError(t, err)
+	assert.Equal(t, "DPoP", result.TokenType)
+
+	rawJWT := strings.TrimPrefix(result.AccessToken, "qf_at_")
+	claims, err := svc.ValidateToken(ctx, rawJWT)
+	require.NoError(t, err)
+	assert.Equal(t, thumbprint, claims.DPoPThumbprint)
+}
+
+func TestIssueTokenPair_WithoutDPoP_RemainsBearer(t *testing.T) {
+	svc, _ := newES256Service(t)
+	ctx := context.Background()
+
+	result, err := svc.IssueTokenPair(ctx, "user-123", []string{"user"}, nil, domain.ClientTypeUser)
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer", result.TokenType)
+
+	rawJWT := strings.TrimPrefix(result.AccessToken, "qf_at_")
+	claims, err := svc.ValidateToken(ctx, rawJWT)
+	require.NoError(t, err)
+	assert.Empty(t, claims.DPoPThumbprint)
+}
+
+func TestValidateToken_PreservesDPoPThumbprint(t *testing.T) {
+	svc, _ := newES256Service(t)
+	ctx := context.Background()
+
+	thumbprint := "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I"
+
+	result, err := svc.IssueTokenPairWithDPoP(ctx, "user-dpop", []string{"admin"}, []string{"write:all"}, domain.ClientTypeUser, thumbprint)
+	require.NoError(t, err)
+
+	// Parse and validate — thumbprint must survive round-trip.
+	rawJWT := strings.TrimPrefix(result.AccessToken, "qf_at_")
+	claims, err := svc.ValidateToken(ctx, rawJWT)
+	require.NoError(t, err)
+
+	assert.Equal(t, "user-dpop", claims.Subject)
+	assert.Equal(t, thumbprint, claims.DPoPThumbprint)
+	assert.Equal(t, []string{"admin"}, claims.Roles)
+	assert.Equal(t, []string{"write:all"}, claims.Scopes)
+	assert.Equal(t, domain.ClientTypeUser, claims.ClientType)
+	assert.False(t, claims.ExpiresAt.IsZero())
+	assert.False(t, claims.IssuedAt.IsZero())
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-212.

Closes #212

## Changes

Modify the token service to support DPoP binding. Add a `DPoPThumbprint` (cnf.jkt) field to `domain.TokenClaims`. Extend `IssueTokenPair` (or add a new method) to accept an optional JWK thumbprint string; when provided, include `cnf.jkt` claim in the access token JWT and set `token_type` to `"DPoP"` instead of `"Bearer"` in `AuthResult`. Update `ValidateToken` to parse and expose the `cnf.jkt` claim from existing tokens. Add tests: tokens issued with DPoP binding contain correct cnf claim, tokens without DPoP remain Bearer, round-trip validation preserves thumbprint.