### PR TITLE
GH-213: DPoP verification middleware (`internal/middleware/`)

### DIFF
--- a/internal/domain/claims.go
+++ b/internal/domain/claims.go
@@ -34,4 +34,10 @@ type TokenClaims struct {
 	// IssuedAt is the token issuance time from the JWT iat claim.
 	// Zero value means not set.
 	IssuedAt time.Time
+
+	// DPoPThumbprint is the JWK thumbprint from the cnf.jkt claim.
+	// When set, the token is DPoP-bound and requests must include a
+	// valid DPoP proof whose public key matches this thumbprint.
+	// Empty string means the token is a plain Bearer token.
+	DPoPThumbprint string
 }

--- a/internal/middleware/dpop.go
+++ b/internal/middleware/dpop.go
@@ -1,0 +1,84 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// DPoPVerifier validates a DPoP proof JWT and returns the JWK thumbprint
+// of the proof's embedded public key. The dpop package implements this
+// interface. httpMethod and httpURL are the request's method and full URL,
+// used to verify the htm and htu claims inside the proof.
+type DPoPVerifier interface {
+	VerifyProof(ctx context.Context, proofHeader, httpMethod, httpURL string) (thumbprint string, err error)
+}
+
+// DPoPMiddleware returns a Gin middleware that enforces DPoP
+// proof-of-possession on DPoP-bound tokens. It must run AFTER
+// AuthMiddleware so that *domain.TokenClaims is available in context.
+//
+// Behaviour:
+//   - If the token has a cnf.jkt claim (DPoPThumbprint is set), the
+//     request MUST include a valid DPoP header whose embedded public key
+//     thumbprint matches the token's cnf.jkt. Returns 401 on missing
+//     proof, invalid proof, or thumbprint mismatch.
+//   - If the token has no cnf.jkt claim (plain Bearer), the middleware
+//     passes through without requiring a DPoP header (backwards-compatible).
+func DPoPMiddleware(verifier DPoPVerifier) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		claims, err := GetClaims(c)
+		if err != nil {
+			// No claims means AuthMiddleware didn't run or failed;
+			// let downstream handlers deal with it.
+			c.Next()
+			return
+		}
+
+		// Plain Bearer token — no DPoP binding required.
+		if claims.DPoPThumbprint == "" {
+			c.Next()
+			return
+		}
+
+		// Token is DPoP-bound — require a valid proof header.
+		proofHeader := c.GetHeader("DPoP")
+		if proofHeader == "" {
+			domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized,
+				"missing DPoP proof header for bound token")
+			return
+		}
+
+		thumbprint, err := verifier.VerifyProof(
+			c.Request.Context(),
+			proofHeader,
+			c.Request.Method,
+			requestURL(c.Request),
+		)
+		if err != nil {
+			domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized,
+				"invalid DPoP proof")
+			return
+		}
+
+		if thumbprint != claims.DPoPThumbprint {
+			domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized,
+				"DPoP proof key does not match token binding")
+			return
+		}
+
+		c.Next()
+	}
+}
+
+// requestURL reconstructs the full request URL used for htm/htu verification.
+func requestURL(r *http.Request) string {
+	scheme := "https"
+	if r.TLS == nil {
+		scheme = "http"
+	}
+	return scheme + "://" + r.Host + r.RequestURI
+}

--- a/internal/middleware/dpop_test.go
+++ b/internal/middleware/dpop_test.go
@@ -1,0 +1,138 @@
+package middleware_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/middleware"
+)
+
+// mockDPoPVerifier implements middleware.DPoPVerifier for testing.
+type mockDPoPVerifier struct {
+	thumbprint string
+	err        error
+}
+
+func (m *mockDPoPVerifier) VerifyProof(_ context.Context, _, _, _ string) (string, error) {
+	return m.thumbprint, m.err
+}
+
+// newDPoPTestRouter builds a router with AuthMiddleware (using a mock validator
+// that injects the given claims) followed by DPoPMiddleware.
+func newDPoPTestRouter(claims *domain.TokenClaims, verifier middleware.DPoPVerifier) *gin.Engine {
+	r := gin.New()
+
+	// Inject claims into context (simulates AuthMiddleware).
+	r.Use(func(c *gin.Context) {
+		if claims != nil {
+			c.Set("claims", claims)
+			c.Set("user_id", claims.Subject)
+		}
+		c.Next()
+	})
+
+	r.Use(middleware.DPoPMiddleware(verifier))
+	r.GET("/protected", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+	return r
+}
+
+func TestDPoPMiddleware(t *testing.T) {
+	const correctThumbprint = "abc123thumbprint"
+
+	tests := []struct {
+		name             string
+		claims           *domain.TokenClaims
+		verifier         *mockDPoPVerifier
+		dpopHeader       string
+		wantStatus       int
+		wantBodyContains string
+	}{
+		{
+			name: "bound token without DPoP proof header is rejected",
+			claims: &domain.TokenClaims{
+				Subject:        "user-1",
+				DPoPThumbprint: correctThumbprint,
+			},
+			verifier:         &mockDPoPVerifier{thumbprint: correctThumbprint},
+			dpopHeader:       "",
+			wantStatus:       http.StatusUnauthorized,
+			wantBodyContains: "missing DPoP proof header",
+		},
+		{
+			name: "bound token with wrong key is rejected",
+			claims: &domain.TokenClaims{
+				Subject:        "user-2",
+				DPoPThumbprint: correctThumbprint,
+			},
+			verifier:         &mockDPoPVerifier{thumbprint: "wrong-thumbprint"},
+			dpopHeader:       "valid-proof-wrong-key",
+			wantStatus:       http.StatusUnauthorized,
+			wantBodyContains: "does not match token binding",
+		},
+		{
+			name: "bound token with invalid proof is rejected",
+			claims: &domain.TokenClaims{
+				Subject:        "user-3",
+				DPoPThumbprint: correctThumbprint,
+			},
+			verifier:         &mockDPoPVerifier{err: errors.New("bad signature")},
+			dpopHeader:       "invalid-proof",
+			wantStatus:       http.StatusUnauthorized,
+			wantBodyContains: "invalid DPoP proof",
+		},
+		{
+			name: "bound token with correct proof passes",
+			claims: &domain.TokenClaims{
+				Subject:        "user-4",
+				DPoPThumbprint: correctThumbprint,
+			},
+			verifier:   &mockDPoPVerifier{thumbprint: correctThumbprint},
+			dpopHeader: "valid-proof-correct-key",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "unbound Bearer token passes without DPoP header",
+			claims: &domain.TokenClaims{
+				Subject:        "user-5",
+				DPoPThumbprint: "",
+			},
+			verifier:   &mockDPoPVerifier{thumbprint: "anything"},
+			dpopHeader: "",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "no claims in context passes through",
+			claims:     nil,
+			verifier:   &mockDPoPVerifier{},
+			dpopHeader: "",
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			router := newDPoPTestRouter(tc.claims, tc.verifier)
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/protected", http.NoBody)
+			if tc.dpopHeader != "" {
+				req.Header.Set("DPoP", tc.dpopHeader)
+			}
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+			if tc.wantBodyContains != "" {
+				assert.Contains(t, w.Body.String(), tc.wantBodyContains)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-213.

Closes #213

## Changes

Create `internal/middleware/dpop.go` with a new `DPoPMiddleware` that enforces proof-of-possession on protected routes. If the validated token (from `AuthMiddleware`) has a `cnf.jkt` claim, require a valid `DPoP` proof header; verify the proof's embedded public key thumbprint matches the token's `cnf.jkt`; reject requests with missing proof or thumbprint mismatch (401). If the token has no `cnf.jkt`, pass through (backwards-compatible with plain Bearer tokens). Define a `DPoPVerifier` interface for the dpop package to satisfy. Add tests: bound token without proof → rejected, bound token with wrong key → rejected, bound token with correct proof → passes, unbound Bearer token → passes.