### PR TITLE
GH-219: Domain models for RFC 8693 token exchange (`internal/domain/`)

### DIFF
--- a/internal/domain/token_exchange.go
+++ b/internal/domain/token_exchange.go
@@ -1,0 +1,29 @@
+package domain
+
+// RFC 8693 grant type URI for token exchange.
+// https://www.rfc-editor.org/rfc/rfc8693#section-2.1
+const GrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+// RFC 8693 token type URI constants used in subject_token_type, actor_token_type,
+// and requested_token_type fields.
+// https://www.rfc-editor.org/rfc/rfc8693#section-3
+const (
+	TokenTypeAccessToken  = "urn:ietf:params:oauth:token-type:access_token"
+	TokenTypeRefreshToken = "urn:ietf:params:oauth:token-type:refresh_token"
+	TokenTypeIDToken      = "urn:ietf:params:oauth:token-type:id_token"
+	TokenTypeSAML1        = "urn:ietf:params:oauth:token-type:saml1"
+	TokenTypeSAML2        = "urn:ietf:params:oauth:token-type:saml2"
+	TokenTypeJWT          = "urn:ietf:params:oauth:token-type:jwt"
+)
+
+// ActorClaim represents the nested `act` (actor) claim in a JWT per RFC 8693 §4.1.
+// It enables delegation chains where one identity acts on behalf of another.
+// Nested Act fields support multi-hop delegation (A acts as B acts as C).
+type ActorClaim struct {
+	// Subject identifies the actor (the delegating principal).
+	Subject string `json:"sub,omitempty"`
+	// Issuer identifies the issuer that asserted the actor's identity.
+	Issuer string `json:"iss,omitempty"`
+	// Act is an optional nested actor for multi-hop delegation chains.
+	Act *ActorClaim `json:"act,omitempty"`
+}

--- a/internal/domain/validation.go
+++ b/internal/domain/validation.go
@@ -45,12 +45,27 @@ type PasswordResetConfirmRequest struct {
 }
 
 // TokenRequest is the validated request body for the unified /auth/token endpoint.
-// It dispatches based on grant_type: "refresh_token" or "client_credentials".
+// It dispatches based on grant_type: "refresh_token", "client_credentials", or
+// the RFC 8693 token-exchange grant type (urn:ietf:params:oauth:grant-type:token-exchange).
 type TokenRequest struct {
-	GrantType    string `json:"grant_type"    validate:"required,oneof=refresh_token client_credentials"`
+	GrantType    string `json:"grant_type"    validate:"required,oneof=refresh_token client_credentials urn:ietf:params:oauth:grant-type:token-exchange"`
 	RefreshToken string `json:"refresh_token" validate:"required_if=GrantType refresh_token"`
 	ClientID     string `json:"client_id"     validate:"required_if=GrantType client_credentials"`
 	ClientSecret string `json:"client_secret" validate:"required_if=GrantType client_credentials"`
+}
+
+// TokenExchangeRequest is the validated request body for RFC 8693 token exchange.
+// subject_token and subject_token_type are required per §2.1.
+// actor_token_type is required when actor_token is present.
+// https://www.rfc-editor.org/rfc/rfc8693#section-2.1
+type TokenExchangeRequest struct {
+	SubjectToken       string `json:"subject_token"        validate:"required"`
+	SubjectTokenType   string `json:"subject_token_type"   validate:"required"`
+	ActorToken         string `json:"actor_token,omitempty"`
+	ActorTokenType     string `json:"actor_token_type,omitempty" validate:"required_with=ActorToken"`
+	Audience           string `json:"audience,omitempty"`
+	Scope              string `json:"scope,omitempty"`
+	RequestedTokenType string `json:"requested_token_type,omitempty"`
 }
 
 // RevokeRequest is the validated request body for token revocation.

--- a/internal/domain/validation_test.go
+++ b/internal/domain/validation_test.go
@@ -461,6 +461,129 @@ func TestValidateRequest_LoginRequest(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestNewValidator_TokenRequest_TokenExchangeGrantType(t *testing.T) {
+	v := domain.NewValidator()
+
+	tests := []struct {
+		name    string
+		req     domain.TokenRequest
+		wantErr bool
+	}{
+		{
+			name:    "token-exchange grant type accepted",
+			req:     domain.TokenRequest{GrantType: domain.GrantTypeTokenExchange},
+			wantErr: false,
+		},
+		{
+			name:    "refresh_token grant type still accepted",
+			req:     domain.TokenRequest{GrantType: "refresh_token", RefreshToken: "qf_rt_abc"},
+			wantErr: false,
+		},
+		{
+			name:    "client_credentials grant type still accepted",
+			req:     domain.TokenRequest{GrantType: "client_credentials", ClientID: "id", ClientSecret: "secret"},
+			wantErr: false,
+		},
+		{
+			name:    "unknown grant type rejected",
+			req:     domain.TokenRequest{GrantType: "password"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.Struct(tt.req)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNewValidator_TokenExchangeRequest(t *testing.T) {
+	v := domain.NewValidator()
+
+	tests := []struct {
+		name    string
+		req     domain.TokenExchangeRequest
+		wantErr bool
+	}{
+		{
+			name: "valid minimal request",
+			req: domain.TokenExchangeRequest{
+				SubjectToken:     "qf_at_abc123",
+				SubjectTokenType: domain.TokenTypeAccessToken,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid full request with actor",
+			req: domain.TokenExchangeRequest{
+				SubjectToken:       "qf_at_subject",
+				SubjectTokenType:   domain.TokenTypeAccessToken,
+				ActorToken:         "qf_at_actor",
+				ActorTokenType:     domain.TokenTypeAccessToken,
+				Audience:           "https://api.example.com",
+				Scope:              "read:users",
+				RequestedTokenType: domain.TokenTypeAccessToken,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid request with requested_token_type only",
+			req: domain.TokenExchangeRequest{
+				SubjectToken:       "qf_at_abc123",
+				SubjectTokenType:   domain.TokenTypeJWT,
+				RequestedTokenType: domain.TokenTypeIDToken,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "missing subject_token",
+			req:     domain.TokenExchangeRequest{SubjectTokenType: domain.TokenTypeAccessToken},
+			wantErr: true,
+		},
+		{
+			name:    "missing subject_token_type",
+			req:     domain.TokenExchangeRequest{SubjectToken: "qf_at_abc123"},
+			wantErr: true,
+		},
+		{
+			name: "actor_token present but actor_token_type missing",
+			req: domain.TokenExchangeRequest{
+				SubjectToken:     "qf_at_subject",
+				SubjectTokenType: domain.TokenTypeAccessToken,
+				ActorToken:       "qf_at_actor",
+				// ActorTokenType intentionally omitted
+			},
+			wantErr: true,
+		},
+		{
+			name: "actor_token_type without actor_token is allowed",
+			req: domain.TokenExchangeRequest{
+				SubjectToken:     "qf_at_abc123",
+				SubjectTokenType: domain.TokenTypeAccessToken,
+				ActorTokenType:   domain.TokenTypeAccessToken,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.Struct(tt.req)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestValidateRequest_EmptyBody(t *testing.T) {
 	v := domain.NewValidator()
 	router := gin.New()


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-219.

Closes #219

## Changes

Add `TokenExchangeRequest` validation struct with all RFC 8693 parameters (`subject_token`, `subject_token_type`, `actor_token`, `actor_token_type`, `audience`, `scope`, `requested_token_type`). Add `ActorClaim` struct to support nested `act` claims in JWT tokens. Add RFC 8693 token type URI constants (e.g., `urn:ietf:params:oauth:oauth-token-type:access_token`). Update `TokenRequest.GrantType` validation to accept `urn:ietf:params:oauth:grant-type:token-exchange`. Include unit tests for validation logic.