### PR TITLE
GH-221: API endpoint integration and wiring (`internal/api/` + `cmd/server/main.go`)

### DIFF
--- a/internal/api/auth_handlers.go
+++ b/internal/api/auth_handlers.go
@@ -158,6 +158,7 @@ func extractBearerToken(c *gin.Context) string {
 
 // Sentinel errors that service implementations should return.
 var (
+	ErrBadRequest    = errors.New("bad request")
 	ErrUnauthorized  = errors.New("unauthorized")
 	ErrNotFound      = errors.New("not found")
 	ErrConflict      = errors.New("conflict")
@@ -168,6 +169,8 @@ var (
 // handleServiceError maps service-layer sentinel errors to HTTP error responses.
 func handleServiceError(c *gin.Context, err error) {
 	switch {
+	case errors.Is(err, ErrBadRequest):
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, err.Error())
 	case errors.Is(err, ErrUnauthorized):
 		domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized, err.Error())
 	case errors.Is(err, ErrNotFound):

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -99,6 +99,7 @@ func (m *mockAuthService) LogoutAll(ctx context.Context, userID string) error {
 type mockTokenService struct {
 	refreshFn           func(ctx context.Context, refreshToken string) (*api.AuthResult, error)
 	clientCredentialsFn func(ctx context.Context, clientID, clientSecret string) (*api.AuthResult, error)
+	tokenExchangeFn     func(ctx context.Context, req *api.TokenExchangeRequest) (*api.TokenExchangeResult, error)
 	revokeFn            func(ctx context.Context, token string) error
 	jwksFn              func(ctx context.Context) (*api.JWKSResponse, error)
 }
@@ -123,6 +124,18 @@ func (m *mockTokenService) ClientCredentials(ctx context.Context, clientID, clie
 		AccessToken: "qf_at_client",
 		TokenType:   "Bearer",
 		ExpiresIn:   3600,
+	}, nil
+}
+
+func (m *mockTokenService) TokenExchange(ctx context.Context, req *api.TokenExchangeRequest) (*api.TokenExchangeResult, error) {
+	if m.tokenExchangeFn != nil {
+		return m.tokenExchangeFn(ctx, req)
+	}
+	return &api.TokenExchangeResult{
+		AccessToken:     "qf_at_exchanged",
+		IssuedTokenType: "urn:ietf:params:oauth:token-type:access_token",
+		TokenType:       "Bearer",
+		ExpiresIn:       3600,
 	}, nil
 }
 
@@ -401,6 +414,104 @@ func TestToken_RefreshServiceError(t *testing.T) {
 	w := doRequest(router, http.MethodPost, "/auth/token", body)
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// --- Token Exchange tests ---
+
+func TestToken_TokenExchangeGrant(t *testing.T) {
+	router := newTestRouter(&mockAuthService{}, &mockTokenService{})
+
+	body := map[string]string{
+		"grant_type":         "urn:ietf:params:oauth:grant-type:token-exchange",
+		"subject_token":      "qf_at_some_access_token",
+		"subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
+	}
+	w := doRequest(router, http.MethodPost, "/auth/token", body)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.TokenExchangeResult
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "qf_at_exchanged", resp.AccessToken)
+	assert.Equal(t, "urn:ietf:params:oauth:token-type:access_token", resp.IssuedTokenType)
+	assert.Equal(t, "Bearer", resp.TokenType)
+	assert.Equal(t, 3600, resp.ExpiresIn)
+}
+
+func TestToken_TokenExchangeMissingSubjectToken(t *testing.T) {
+	router := newTestRouter(&mockAuthService{}, &mockTokenService{})
+
+	body := map[string]string{
+		"grant_type":         "urn:ietf:params:oauth:grant-type:token-exchange",
+		"subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
+	}
+	w := doRequest(router, http.MethodPost, "/auth/token", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestToken_TokenExchangeMissingSubjectTokenType(t *testing.T) {
+	router := newTestRouter(&mockAuthService{}, &mockTokenService{})
+
+	body := map[string]string{
+		"grant_type":    "urn:ietf:params:oauth:grant-type:token-exchange",
+		"subject_token": "qf_at_some_access_token",
+	}
+	w := doRequest(router, http.MethodPost, "/auth/token", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestToken_TokenExchangeServiceError(t *testing.T) {
+	tokenSvc := &mockTokenService{
+		tokenExchangeFn: func(_ context.Context, _ *api.TokenExchangeRequest) (*api.TokenExchangeResult, error) {
+			return nil, fmt.Errorf("invalid subject_token: %w", api.ErrUnauthorized)
+		},
+	}
+	router := newTestRouter(&mockAuthService{}, tokenSvc)
+
+	body := map[string]string{
+		"grant_type":         "urn:ietf:params:oauth:grant-type:token-exchange",
+		"subject_token":      "qf_at_expired",
+		"subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
+	}
+	w := doRequest(router, http.MethodPost, "/auth/token", body)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestToken_TokenExchangeWithOptionalParams(t *testing.T) {
+	var captured *api.TokenExchangeRequest
+	tokenSvc := &mockTokenService{
+		tokenExchangeFn: func(_ context.Context, req *api.TokenExchangeRequest) (*api.TokenExchangeResult, error) {
+			captured = req
+			return &api.TokenExchangeResult{
+				AccessToken:     "qf_at_exchanged_scoped",
+				IssuedTokenType: "urn:ietf:params:oauth:token-type:access_token",
+				TokenType:       "Bearer",
+				ExpiresIn:       1800,
+			}, nil
+		},
+	}
+	router := newTestRouter(&mockAuthService{}, tokenSvc)
+
+	body := map[string]string{
+		"grant_type":           "urn:ietf:params:oauth:grant-type:token-exchange",
+		"subject_token":        "qf_at_some_access_token",
+		"subject_token_type":   "urn:ietf:params:oauth:token-type:access_token",
+		"audience":             "https://api.example.com",
+		"scope":                "read write",
+		"requested_token_type": "urn:ietf:params:oauth:token-type:access_token",
+	}
+	w := doRequest(router, http.MethodPost, "/auth/token", body)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, captured)
+	assert.Equal(t, "qf_at_some_access_token", captured.SubjectToken)
+	assert.Equal(t, "urn:ietf:params:oauth:token-type:access_token", captured.SubjectTokenType)
+	assert.Equal(t, "https://api.example.com", captured.Audience)
+	assert.Equal(t, "read write", captured.Scope)
+	assert.Equal(t, "urn:ietf:params:oauth:token-type:access_token", captured.RequestedTokenType)
 }
 
 // --- Revoke tests ---

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -28,6 +28,14 @@ type JWKSResponse struct {
 	Keys []interface{} `json:"keys"`
 }
 
+// TokenExchangeResult is the RFC 8693 response for a token exchange.
+type TokenExchangeResult struct {
+	AccessToken     string `json:"access_token"`
+	IssuedTokenType string `json:"issued_token_type"`
+	TokenType       string `json:"token_type"`
+	ExpiresIn       int    `json:"expires_in"`
+}
+
 // AuthService defines the operations for authentication and user management.
 type AuthService interface {
 	Register(ctx context.Context, email, password, name string) (*UserInfo, error)
@@ -40,10 +48,22 @@ type AuthService interface {
 	LogoutAll(ctx context.Context, userID string) error
 }
 
+// TokenExchangeRequest contains the RFC 8693 token exchange parameters.
+type TokenExchangeRequest struct {
+	SubjectToken     string
+	SubjectTokenType string
+	ActorToken       string
+	ActorTokenType   string
+	RequestedTokenType string
+	Audience         string
+	Scope            string
+}
+
 // TokenService defines the operations for token management.
 type TokenService interface {
 	Refresh(ctx context.Context, refreshToken string) (*AuthResult, error)
 	ClientCredentials(ctx context.Context, clientID, clientSecret string) (*AuthResult, error)
+	TokenExchange(ctx context.Context, req *TokenExchangeRequest) (*TokenExchangeResult, error)
 	Revoke(ctx context.Context, token string) error
 	JWKS(ctx context.Context) (*JWKSResponse, error)
 }

--- a/internal/api/token_handlers.go
+++ b/internal/api/token_handlers.go
@@ -22,6 +22,16 @@ func NewTokenHandlers(token TokenService) *TokenHandlers {
 func (h *TokenHandlers) Token(c *gin.Context) {
 	req := c.MustGet("validated_request").(*domain.TokenRequest)
 
+	switch req.GrantType {
+	case domain.GrantTypeTokenExchange:
+		h.handleTokenExchange(c, req)
+	default:
+		h.handleStandardGrant(c, req)
+	}
+}
+
+// handleStandardGrant dispatches refresh_token and client_credentials grants.
+func (h *TokenHandlers) handleStandardGrant(c *gin.Context, req *domain.TokenRequest) {
 	var result *AuthResult
 	var err error
 
@@ -35,6 +45,27 @@ func (h *TokenHandlers) Token(c *gin.Context) {
 		return
 	}
 
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// handleTokenExchange handles the RFC 8693 token exchange grant type.
+func (h *TokenHandlers) handleTokenExchange(c *gin.Context, req *domain.TokenRequest) {
+	exchangeReq := &TokenExchangeRequest{
+		SubjectToken:       req.SubjectToken,
+		SubjectTokenType:   req.SubjectTokenType,
+		ActorToken:         req.ActorToken,
+		ActorTokenType:     req.ActorTokenType,
+		RequestedTokenType: req.RequestedTokenType,
+		Audience:           req.Audience,
+		Scope:              req.Scope,
+	}
+
+	result, err := h.token.TokenExchange(c.Request.Context(), exchangeReq)
 	if err != nil {
 		handleServiceError(c, err)
 		return

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -36,6 +36,7 @@ const (
 	EventAdminAPIKeyUpdate     = "admin_apikey_update"
 	EventAdminAPIKeyRevoke     = "admin_apikey_revoke"
 	EventAdminAPIKeyRotate     = "admin_apikey_rotate"
+	EventTokenExchange         = "token_exchange"
 )
 
 // Event represents a single audit log entry.

--- a/internal/domain/token.go
+++ b/internal/domain/token.go
@@ -7,3 +7,14 @@ type TokenPair struct {
 	TokenType    string `json:"token_type"`
 	ExpiresIn    int    `json:"expires_in"` // seconds
 }
+
+// RFC 8693 token type URIs.
+const (
+	TokenTypeAccessToken  = "urn:ietf:params:oauth:token-type:access_token"
+	TokenTypeRefreshToken = "urn:ietf:params:oauth:token-type:refresh_token"
+	TokenTypeIDToken      = "urn:ietf:params:oauth:token-type:id_token"
+	TokenTypeJWT          = "urn:ietf:params:oauth:token-type:jwt"
+
+	// GrantTypeTokenExchange is the grant_type value for RFC 8693 token exchange.
+	GrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
+)

--- a/internal/domain/validation.go
+++ b/internal/domain/validation.go
@@ -45,12 +45,20 @@ type PasswordResetConfirmRequest struct {
 }
 
 // TokenRequest is the validated request body for the unified /auth/token endpoint.
-// It dispatches based on grant_type: "refresh_token" or "client_credentials".
+// It dispatches based on grant_type: "refresh_token", "client_credentials",
+// or "urn:ietf:params:oauth:grant-type:token-exchange" (RFC 8693).
 type TokenRequest struct {
-	GrantType    string `json:"grant_type"    validate:"required,oneof=refresh_token client_credentials"`
-	RefreshToken string `json:"refresh_token" validate:"required_if=GrantType refresh_token"`
-	ClientID     string `json:"client_id"     validate:"required_if=GrantType client_credentials"`
-	ClientSecret string `json:"client_secret" validate:"required_if=GrantType client_credentials"`
+	GrantType          string `json:"grant_type"           validate:"required,oneof=refresh_token client_credentials urn:ietf:params:oauth:grant-type:token-exchange"`
+	RefreshToken       string `json:"refresh_token"        validate:"required_if=GrantType refresh_token"`
+	ClientID           string `json:"client_id"            validate:"required_if=GrantType client_credentials"`
+	ClientSecret       string `json:"client_secret"        validate:"required_if=GrantType client_credentials"`
+	SubjectToken       string `json:"subject_token"        validate:"required_if=GrantType urn:ietf:params:oauth:grant-type:token-exchange"`
+	SubjectTokenType   string `json:"subject_token_type"   validate:"required_if=GrantType urn:ietf:params:oauth:grant-type:token-exchange"`
+	ActorToken         string `json:"actor_token,omitempty"`
+	ActorTokenType     string `json:"actor_token_type,omitempty"`
+	RequestedTokenType string `json:"requested_token_type,omitempty"`
+	Audience           string `json:"audience,omitempty"`
+	Scope              string `json:"scope,omitempty"`
 }
 
 // RevokeRequest is the validated request body for token revocation.

--- a/internal/token/service.go
+++ b/internal/token/service.go
@@ -160,6 +160,63 @@ func (s *Service) ClientCredentials(_ context.Context, _, _ string) (*api.AuthRe
 	return nil, fmt.Errorf("client credentials not yet implemented: %w", api.ErrInternalError)
 }
 
+// TokenExchange implements RFC 8693 token exchange. It validates the subject
+// token, then issues a new access token for the subject. Only access_token
+// subject_token_type is supported in Phase 1.
+func (s *Service) TokenExchange(ctx context.Context, req *api.TokenExchangeRequest) (*api.TokenExchangeResult, error) {
+	// Phase 1: only accept access tokens as subject tokens.
+	if req.SubjectTokenType != domain.TokenTypeAccessToken {
+		return nil, fmt.Errorf("unsupported subject_token_type: %w", api.ErrBadRequest)
+	}
+
+	// Determine the requested token type; default to access_token per RFC 8693 §2.1.
+	requestedType := req.RequestedTokenType
+	if requestedType == "" {
+		requestedType = domain.TokenTypeAccessToken
+	}
+	if requestedType != domain.TokenTypeAccessToken {
+		return nil, fmt.Errorf("unsupported requested_token_type: %w", api.ErrBadRequest)
+	}
+
+	// Validate the incoming subject token.
+	subjectClaims, err := s.ValidateToken(ctx, strings.TrimPrefix(req.SubjectToken, accessTokenPrefix))
+	if err != nil {
+		return nil, fmt.Errorf("invalid subject_token: %w", api.ErrUnauthorized)
+	}
+
+	// Check revocation.
+	revoked, err := s.IsRevoked(ctx, subjectClaims.TokenID)
+	if err != nil {
+		return nil, fmt.Errorf("check revocation: %w", err)
+	}
+	if revoked {
+		return nil, fmt.Errorf("subject_token revoked: %w", api.ErrUnauthorized)
+	}
+
+	// Issue a new access token for the same subject.
+	accessToken, err := s.issueAccessToken(subjectClaims.Subject, subjectClaims.Roles, subjectClaims.Scopes, subjectClaims.ClientType)
+	if err != nil {
+		return nil, fmt.Errorf("issue exchanged token: %w", err)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventTokenExchange,
+		ActorID:  subjectClaims.Subject,
+		TargetID: subjectClaims.Subject,
+		Metadata: map[string]string{
+			"subject_token_type":   req.SubjectTokenType,
+			"requested_token_type": requestedType,
+		},
+	})
+
+	return &api.TokenExchangeResult{
+		AccessToken:     accessToken,
+		IssuedTokenType: domain.TokenTypeAccessToken,
+		TokenType:       "Bearer",
+		ExpiresIn:       int(s.cfg.AccessTokenTTL.Seconds()),
+	}, nil
+}
+
 // Revoke invalidates a token by adding its JTI to the Redis blocklist.
 func (s *Service) Revoke(ctx context.Context, rawToken string) error {
 	// Try as access token first.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-221.

Closes #221

## Changes

Extend `TokenService` interface in `services.go` with the `TokenExchange` method. Add `urn:ietf:params:oauth:grant-type:token-exchange` case to the grant dispatcher in `token_handlers.go`. Parse and pass RFC 8693 request parameters from the handler to the service. Return RFC 8693 compliant response (`access_token`, `issued_token_type`, `token_type`, `expires_in`). Add new audit event type for token exchange. Update DI wiring in `main.go` if needed (likely minimal since `token.Service` already satisfies the interface). Include handler-level tests for the new grant type dispatch.