### PR TITLE
GH-234: MFA storage repository (`internal/storage/`)

### DIFF
--- a/internal/storage/mocks/mfa_repository.go
+++ b/internal/storage/mocks/mfa_repository.go
@@ -1,0 +1,59 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// MockMFARepository is a configurable mock for storage.MFARepository.
+type MockMFARepository struct {
+	SaveSecretFn      func(ctx context.Context, secret *domain.MFASecret) (*domain.MFASecret, error)
+	GetSecretFn       func(ctx context.Context, userID string) (*domain.MFASecret, error)
+	ConfirmSecretFn   func(ctx context.Context, userID string) error
+	DeleteSecretFn    func(ctx context.Context, userID string) error
+	SaveBackupCodesFn func(ctx context.Context, userID string, codes []domain.BackupCode) error
+	GetBackupCodesFn  func(ctx context.Context, userID string) ([]domain.BackupCode, error)
+	ConsumeBackupCodeFn func(ctx context.Context, userID, codeHash string) error
+	GetMFAStatusFn    func(ctx context.Context, userID string) (*domain.MFAStatus, error)
+}
+
+// SaveSecret delegates to SaveSecretFn.
+func (m *MockMFARepository) SaveSecret(ctx context.Context, secret *domain.MFASecret) (*domain.MFASecret, error) {
+	return m.SaveSecretFn(ctx, secret)
+}
+
+// GetSecret delegates to GetSecretFn.
+func (m *MockMFARepository) GetSecret(ctx context.Context, userID string) (*domain.MFASecret, error) {
+	return m.GetSecretFn(ctx, userID)
+}
+
+// ConfirmSecret delegates to ConfirmSecretFn.
+func (m *MockMFARepository) ConfirmSecret(ctx context.Context, userID string) error {
+	return m.ConfirmSecretFn(ctx, userID)
+}
+
+// DeleteSecret delegates to DeleteSecretFn.
+func (m *MockMFARepository) DeleteSecret(ctx context.Context, userID string) error {
+	return m.DeleteSecretFn(ctx, userID)
+}
+
+// SaveBackupCodes delegates to SaveBackupCodesFn.
+func (m *MockMFARepository) SaveBackupCodes(ctx context.Context, userID string, codes []domain.BackupCode) error {
+	return m.SaveBackupCodesFn(ctx, userID, codes)
+}
+
+// GetBackupCodes delegates to GetBackupCodesFn.
+func (m *MockMFARepository) GetBackupCodes(ctx context.Context, userID string) ([]domain.BackupCode, error) {
+	return m.GetBackupCodesFn(ctx, userID)
+}
+
+// ConsumeBackupCode delegates to ConsumeBackupCodeFn.
+func (m *MockMFARepository) ConsumeBackupCode(ctx context.Context, userID, codeHash string) error {
+	return m.ConsumeBackupCodeFn(ctx, userID, codeHash)
+}
+
+// GetMFAStatus delegates to GetMFAStatusFn.
+func (m *MockMFARepository) GetMFAStatus(ctx context.Context, userID string) (*domain.MFAStatus, error) {
+	return m.GetMFAStatusFn(ctx, userID)
+}

--- a/internal/storage/mocks/mocks_test.go
+++ b/internal/storage/mocks/mocks_test.go
@@ -13,4 +13,5 @@ func TestInterfaceCompliance(t *testing.T) {
 	var _ storage.AdminUserRepository = (*mocks.MockAdminUserRepository)(nil)
 	var _ storage.ClientRepository = (*mocks.MockClientRepository)(nil)
 	var _ storage.RefreshTokenRepository = (*mocks.MockRefreshTokenRepository)(nil)
+	var _ storage.MFARepository = (*mocks.MockMFARepository)(nil)
 }

--- a/internal/storage/mocks/redis_mfa_store.go
+++ b/internal/storage/mocks/redis_mfa_store.go
@@ -1,0 +1,37 @@
+package mocks
+
+import "context"
+
+// MockRedisMFAStore is a configurable mock for storage.RedisMFAStore.
+type MockRedisMFAStore struct {
+	StoreMFATokenFn      func(ctx context.Context, token, userID string) error
+	ConsumeMFATokenFn    func(ctx context.Context, token string) (string, error)
+	RecordFailedAttemptFn func(ctx context.Context, userID string) (int, error)
+	GetFailedAttemptsFn  func(ctx context.Context, userID string) (int, error)
+	ClearFailedAttemptsFn func(ctx context.Context, userID string) error
+}
+
+// StoreMFAToken delegates to StoreMFATokenFn.
+func (m *MockRedisMFAStore) StoreMFAToken(ctx context.Context, token, userID string) error {
+	return m.StoreMFATokenFn(ctx, token, userID)
+}
+
+// ConsumeMFAToken delegates to ConsumeMFATokenFn.
+func (m *MockRedisMFAStore) ConsumeMFAToken(ctx context.Context, token string) (string, error) {
+	return m.ConsumeMFATokenFn(ctx, token)
+}
+
+// RecordFailedAttempt delegates to RecordFailedAttemptFn.
+func (m *MockRedisMFAStore) RecordFailedAttempt(ctx context.Context, userID string) (int, error) {
+	return m.RecordFailedAttemptFn(ctx, userID)
+}
+
+// GetFailedAttempts delegates to GetFailedAttemptsFn.
+func (m *MockRedisMFAStore) GetFailedAttempts(ctx context.Context, userID string) (int, error) {
+	return m.GetFailedAttemptsFn(ctx, userID)
+}
+
+// ClearFailedAttempts delegates to ClearFailedAttemptsFn.
+func (m *MockRedisMFAStore) ClearFailedAttempts(ctx context.Context, userID string) error {
+	return m.ClearFailedAttemptsFn(ctx, userID)
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-234.

Closes #234

## Changes

Database persistence layer. Create `internal/storage/mfa_repository.go` with `MFARepository` interface (`StoreMFASecret`, `GetMFASecret`, `ConfirmMFASecret`, `DeleteMFASecret`, `StoreBackupCodes`, `GetBackupCodes`, `ConsumeBackupCode`) and `PostgresMFARepository` implementation using pgx/v5 pool. Follow existing repository patterns (constructor takes `*pgxpool.Pool`, structured errors with `fmt.Errorf("operation: %w", err)`, context propagation). Add Redis operations for MFA login tokens (`mfa_token:<hash>` key with 5-min TTL, storing user_id + partial auth state). Unit tests with mock pool.