### PR TITLE
GH-235: API endpoints, auth flow integration, config, and DI wiring

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/qf-studio/auth-service/internal/httpserver"
 	"github.com/qf-studio/auth-service/internal/logger"
 	"github.com/qf-studio/auth-service/internal/metrics"
+	"github.com/qf-studio/auth-service/internal/mfa"
 	"github.com/qf-studio/auth-service/internal/middleware"
 	"github.com/qf-studio/auth-service/internal/password"
 	"github.com/qf-studio/auth-service/internal/session"
@@ -103,11 +104,26 @@ func run(log *zap.Logger, cfg *config.Config) error {
 		)
 	}
 
+	// ── MFA ──────────────────────────────────────────────────────────────
+	mfaRepo := storage.NewPostgresMFARepository(pgPool)
+	mfaStore := storage.NewRedisMFAStore(redisClient)
+	mfaCfg := mfa.Config{
+		Issuer:          cfg.MFA.Issuer,
+		Digits:          cfg.MFA.Digits,
+		Period:          uint(cfg.MFA.Period), //nolint:gosec // non-negative from config
+		BackupCodeCount: cfg.MFA.BackupCodeCount,
+	}
+	mfaSvc := mfa.NewService(mfaCfg, mfaRepo, mfaStore, tokenSvc, log, auditSvc)
+
+	// Inject MFA checker into auth service to enable MFA challenge on login.
+	authSvc.SetMFAChecker(mfaSvc)
+
 	services := &api.Services{
 		Auth:    authSvc,
 		Token:   tokenSvc,
 		Session: sessionSvc,
 		DPoP:    dpopAPISvc,
+		MFA:     mfaSvc,
 	}
 
 	// ── Health ─────────────────────────────────────────────────────────────
@@ -155,6 +171,7 @@ func run(log *zap.Logger, cfg *config.Config) error {
 		Clients: adminClientSvc,
 		Tokens:  adminTokenSvc,
 		APIKeys: adminAPIKeySvc,
+		MFA:     mfaSvc,
 	}
 
 	adminDeps := &api.AdminDeps{

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
+	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
@@ -47,6 +48,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/pquerna/otp v1.5.0 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/alicebob/miniredis/v2 v2.37.0 h1:RheObYW32G1aiJIj81XVt78ZHJpHonHLHW7O
 github.com/alicebob/miniredis/v2 v2.37.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
@@ -125,6 +127,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
+github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
 github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=

--- a/internal/api/admin_mfa_handlers.go
+++ b/internal/api/admin_mfa_handlers.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// AdminMFAHandlers groups HTTP handlers for admin MFA management endpoints.
+type AdminMFAHandlers struct {
+	mfa MFAService
+}
+
+// NewAdminMFAHandlers creates a new AdminMFAHandlers with the given MFAService.
+func NewAdminMFAHandlers(mfa MFAService) *AdminMFAHandlers {
+	return &AdminMFAHandlers{mfa: mfa}
+}
+
+// GetStatus handles GET /admin/users/:id/mfa.
+// Returns the MFA status for a specific user.
+func (h *AdminMFAHandlers) GetStatus(c *gin.Context) {
+	userID := c.Param("id")
+
+	status, err := h.mfa.GetStatus(c.Request.Context(), userID)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, status)
+}
+
+// Reset handles DELETE /admin/users/:id/mfa.
+// Removes MFA for a specific user (admin reset).
+func (h *AdminMFAHandlers) Reset(c *gin.Context) {
+	userID := c.Param("id")
+
+	if err := h.mfa.Disable(c.Request.Context(), userID); err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "MFA reset for user"})
+}

--- a/internal/api/admin_router.go
+++ b/internal/api/admin_router.go
@@ -61,6 +61,14 @@ func NewAdminRouter(svc *AdminServices, deps *AdminDeps) *gin.Engine {
 		}
 	}
 
+	// User MFA management (nested under users).
+	if svc.Users != nil && svc.MFA != nil {
+		mfaH := NewAdminMFAHandlers(svc.MFA)
+		users := admin.Group("/users")
+		users.GET("/:id/mfa", mfaH.GetStatus)
+		users.DELETE("/:id/mfa", mfaH.Reset)
+	}
+
 	// Client management.
 	if svc.Clients != nil {
 		clientH := NewAdminClientHandlers(svc.Clients)

--- a/internal/api/admin_services.go
+++ b/internal/api/admin_services.go
@@ -202,4 +202,5 @@ type AdminServices struct {
 	Clients AdminClientService
 	Tokens  AdminTokenService
 	APIKeys AdminAPIKeyService
+	MFA     MFAService
 }

--- a/internal/api/auth_handlers.go
+++ b/internal/api/auth_handlers.go
@@ -44,6 +44,12 @@ func (h *AuthHandlers) Login(c *gin.Context) {
 		return
 	}
 
+	// If MFA is required, return the challenge without creating a session.
+	if result.MFARequired {
+		c.JSON(http.StatusOK, result)
+		return
+	}
+
 	// Create a session record if the session service is available.
 	if h.session != nil && result.UserID != "" {
 		ip := c.ClientIP()

--- a/internal/api/mfa_handlers.go
+++ b/internal/api/mfa_handlers.go
@@ -1,0 +1,128 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// MFAHandlers groups HTTP handlers for MFA endpoints.
+type MFAHandlers struct {
+	mfa MFAService
+}
+
+// NewMFAHandlers creates a new MFAHandlers with the given MFAService.
+func NewMFAHandlers(mfa MFAService) *MFAHandlers {
+	return &MFAHandlers{mfa: mfa}
+}
+
+// Setup handles POST /auth/mfa/setup.
+// Initiates TOTP enrollment for the authenticated user.
+func (h *MFAHandlers) Setup(c *gin.Context) {
+	userID := c.GetString("user_id")
+	if userID == "" {
+		domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized, "missing user identity")
+		return
+	}
+
+	email := c.GetString("user_email")
+
+	result, err := h.mfa.InitiateEnrollment(c.Request.Context(), userID, email)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// mfaConfirmRequest is the request body for confirming MFA enrollment.
+type mfaConfirmRequest struct {
+	Code string `json:"code" binding:"required"`
+}
+
+// Confirm handles POST /auth/mfa/confirm.
+// Validates a TOTP code to confirm enrollment and returns backup codes.
+func (h *MFAHandlers) Confirm(c *gin.Context) {
+	userID := c.GetString("user_id")
+	if userID == "" {
+		domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized, "missing user identity")
+		return
+	}
+
+	var req mfaConfirmRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid request body")
+		return
+	}
+
+	backupCodes, err := h.mfa.ConfirmEnrollment(c.Request.Context(), userID, req.Code)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, MFAConfirmResult{BackupCodes: backupCodes})
+}
+
+// mfaVerifyRequest is the request body for verifying MFA during login.
+type mfaVerifyRequest struct {
+	MFAToken string `json:"mfa_token" binding:"required"`
+	Code     string `json:"code"      binding:"required"`
+	CodeType string `json:"code_type"` // "totp" (default) or "backup"
+}
+
+// Verify handles POST /auth/mfa/verify.
+// Completes the MFA challenge during login by verifying TOTP or backup code.
+func (h *MFAHandlers) Verify(c *gin.Context) {
+	var req mfaVerifyRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid request body")
+		return
+	}
+
+	result, err := h.mfa.CompleteMFALogin(c.Request.Context(), req.MFAToken, req.Code, req.CodeType)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// Disable handles POST /auth/mfa/disable.
+// Removes MFA for the authenticated user.
+func (h *MFAHandlers) Disable(c *gin.Context) {
+	userID := c.GetString("user_id")
+	if userID == "" {
+		domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized, "missing user identity")
+		return
+	}
+
+	if err := h.mfa.Disable(c.Request.Context(), userID); err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "MFA disabled"})
+}
+
+// Status handles GET /auth/mfa/status.
+// Returns the MFA status for the authenticated user.
+func (h *MFAHandlers) Status(c *gin.Context) {
+	userID := c.GetString("user_id")
+	if userID == "" {
+		domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized, "missing user identity")
+		return
+	}
+
+	status, err := h.mfa.GetStatus(c.Request.Context(), userID)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, status)
+}

--- a/internal/api/mfa_handlers_test.go
+++ b/internal/api/mfa_handlers_test.go
@@ -1,0 +1,350 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/health"
+)
+
+// ── Mock MFA Service ─────────────────────────────────────────────────────────
+
+type mockMFAService struct {
+	initiateEnrollmentFn func(ctx context.Context, userID, email string) (*api.MFAEnrollmentResult, error)
+	confirmEnrollmentFn  func(ctx context.Context, userID, code string) ([]string, error)
+	verifyTOTPFn         func(ctx context.Context, userID, code string) error
+	verifyBackupCodeFn   func(ctx context.Context, userID, code string) error
+	completeMFALoginFn   func(ctx context.Context, mfaToken, code, codeType string) (*api.AuthResult, error)
+	disableFn            func(ctx context.Context, userID string) error
+	getStatusFn          func(ctx context.Context, userID string) (*api.MFAStatusResponse, error)
+	isMFAEnabledFn       func(ctx context.Context, userID string) (bool, error)
+	generateMFATokenFn   func(ctx context.Context, userID string) (string, error)
+}
+
+func (m *mockMFAService) InitiateEnrollment(ctx context.Context, userID, email string) (*api.MFAEnrollmentResult, error) {
+	if m.initiateEnrollmentFn != nil {
+		return m.initiateEnrollmentFn(ctx, userID, email)
+	}
+	return &api.MFAEnrollmentResult{Secret: "JBSWY3DPEHPK3PXP", URI: "otpauth://totp/Test:user@test.com?secret=JBSWY3DPEHPK3PXP"}, nil
+}
+
+func (m *mockMFAService) ConfirmEnrollment(ctx context.Context, userID, code string) ([]string, error) {
+	if m.confirmEnrollmentFn != nil {
+		return m.confirmEnrollmentFn(ctx, userID, code)
+	}
+	return []string{"abcd-1234-efgh-5678", "ijkl-9012-mnop-3456"}, nil
+}
+
+func (m *mockMFAService) VerifyTOTP(ctx context.Context, userID, code string) error {
+	if m.verifyTOTPFn != nil {
+		return m.verifyTOTPFn(ctx, userID, code)
+	}
+	return nil
+}
+
+func (m *mockMFAService) VerifyBackupCode(ctx context.Context, userID, code string) error {
+	if m.verifyBackupCodeFn != nil {
+		return m.verifyBackupCodeFn(ctx, userID, code)
+	}
+	return nil
+}
+
+func (m *mockMFAService) CompleteMFALogin(ctx context.Context, mfaToken, code, codeType string) (*api.AuthResult, error) {
+	if m.completeMFALoginFn != nil {
+		return m.completeMFALoginFn(ctx, mfaToken, code, codeType)
+	}
+	return &api.AuthResult{
+		AccessToken:  "qf_at_mfa_access",
+		RefreshToken: "qf_rt_mfa_refresh",
+		TokenType:    "Bearer",
+		ExpiresIn:    900,
+		UserID:       "user-1",
+	}, nil
+}
+
+func (m *mockMFAService) Disable(ctx context.Context, userID string) error {
+	if m.disableFn != nil {
+		return m.disableFn(ctx, userID)
+	}
+	return nil
+}
+
+func (m *mockMFAService) GetStatus(ctx context.Context, userID string) (*api.MFAStatusResponse, error) {
+	if m.getStatusFn != nil {
+		return m.getStatusFn(ctx, userID)
+	}
+	return &api.MFAStatusResponse{Enabled: true, Type: "totp", Confirmed: true, BackupLeft: 10}, nil
+}
+
+func (m *mockMFAService) IsMFAEnabled(ctx context.Context, userID string) (bool, error) {
+	if m.isMFAEnabledFn != nil {
+		return m.isMFAEnabledFn(ctx, userID)
+	}
+	return true, nil
+}
+
+func (m *mockMFAService) GenerateMFAToken(ctx context.Context, userID string) (string, error) {
+	if m.generateMFATokenFn != nil {
+		return m.generateMFATokenFn(ctx, userID)
+	}
+	return "mfa-token-123", nil
+}
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+func newMFATestRouter(mfaSvc api.MFAService) *gin.Engine {
+	svc := &api.Services{
+		Auth:  &mockAuthService{},
+		Token: &mockTokenService{},
+		MFA:   mfaSvc,
+	}
+	authMW := func(c *gin.Context) {
+		userID := c.GetHeader("X-User-ID")
+		if userID == "" {
+			domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized, "missing authentication")
+			return
+		}
+		c.Set("user_id", userID)
+		c.Set("user_email", c.GetHeader("X-User-Email"))
+		c.Next()
+	}
+	mw := &api.MiddlewareStack{Auth: authMW}
+	return api.NewPublicRouter(svc, mw, health.NewService())
+}
+
+// ── MFA Setup Tests ──────────────────────────────────────────────────────────
+
+func TestMFASetup_Success(t *testing.T) {
+	router := newMFATestRouter(&mockMFAService{})
+
+	w := doRequest(router, http.MethodPost, "/auth/mfa/setup", nil, "X-User-ID", "user-1", "X-User-Email", "alice@test.com")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.MFAEnrollmentResult
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.Secret)
+	assert.Contains(t, resp.URI, "otpauth://totp/")
+}
+
+func TestMFASetup_Unauthenticated(t *testing.T) {
+	router := newMFATestRouter(&mockMFAService{})
+	w := doRequest(router, http.MethodPost, "/auth/mfa/setup", nil)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestMFASetup_AlreadyEnrolled(t *testing.T) {
+	mfaSvc := &mockMFAService{
+		initiateEnrollmentFn: func(_ context.Context, _, _ string) (*api.MFAEnrollmentResult, error) {
+			return nil, api.ErrConflict
+		},
+	}
+	router := newMFATestRouter(mfaSvc)
+
+	w := doRequest(router, http.MethodPost, "/auth/mfa/setup", nil, "X-User-ID", "user-1")
+	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+// ── MFA Confirm Tests ────────────────────────────────────────────────────────
+
+func TestMFAConfirm_Success(t *testing.T) {
+	router := newMFATestRouter(&mockMFAService{})
+
+	body := map[string]string{"code": "123456"}
+	w := doRequest(router, http.MethodPost, "/auth/mfa/confirm", body, "X-User-ID", "user-1")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.MFAConfirmResult
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Len(t, resp.BackupCodes, 2)
+}
+
+func TestMFAConfirm_InvalidCode(t *testing.T) {
+	mfaSvc := &mockMFAService{
+		confirmEnrollmentFn: func(_ context.Context, _, _ string) ([]string, error) {
+			return nil, api.ErrUnauthorized
+		},
+	}
+	router := newMFATestRouter(mfaSvc)
+
+	body := map[string]string{"code": "000000"}
+	w := doRequest(router, http.MethodPost, "/auth/mfa/confirm", body, "X-User-ID", "user-1")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestMFAConfirm_MissingCode(t *testing.T) {
+	router := newMFATestRouter(&mockMFAService{})
+
+	w := doRequest(router, http.MethodPost, "/auth/mfa/confirm", map[string]string{}, "X-User-ID", "user-1")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// ── MFA Verify Tests (public, no auth) ──────────────────────────────────────
+
+func TestMFAVerify_Success(t *testing.T) {
+	router := newMFATestRouter(&mockMFAService{})
+
+	body := map[string]string{
+		"mfa_token": "mfa-token-123",
+		"code":      "123456",
+		"code_type": "totp",
+	}
+	w := doRequest(router, http.MethodPost, "/auth/mfa/verify", body)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AuthResult
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "qf_at_mfa_access", resp.AccessToken)
+	assert.Equal(t, "user-1", resp.UserID)
+}
+
+func TestMFAVerify_InvalidToken(t *testing.T) {
+	mfaSvc := &mockMFAService{
+		completeMFALoginFn: func(_ context.Context, _, _, _ string) (*api.AuthResult, error) {
+			return nil, api.ErrUnauthorized
+		},
+	}
+	router := newMFATestRouter(mfaSvc)
+
+	body := map[string]string{
+		"mfa_token": "bad-token",
+		"code":      "123456",
+	}
+	w := doRequest(router, http.MethodPost, "/auth/mfa/verify", body)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestMFAVerify_BackupCode(t *testing.T) {
+	router := newMFATestRouter(&mockMFAService{})
+
+	body := map[string]string{
+		"mfa_token": "mfa-token-123",
+		"code":      "abcd-1234-efgh-5678",
+		"code_type": "backup",
+	}
+	w := doRequest(router, http.MethodPost, "/auth/mfa/verify", body)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestMFAVerify_MissingFields(t *testing.T) {
+	router := newMFATestRouter(&mockMFAService{})
+
+	// Missing mfa_token
+	body := map[string]string{"code": "123456"}
+	w := doRequest(router, http.MethodPost, "/auth/mfa/verify", body)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Missing code
+	body = map[string]string{"mfa_token": "token"}
+	w = doRequest(router, http.MethodPost, "/auth/mfa/verify", body)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// ── MFA Disable Tests ────────────────────────────────────────────────────────
+
+func TestMFADisable_Success(t *testing.T) {
+	router := newMFATestRouter(&mockMFAService{})
+
+	w := doRequest(router, http.MethodPost, "/auth/mfa/disable", nil, "X-User-ID", "user-1")
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestMFADisable_NotEnrolled(t *testing.T) {
+	mfaSvc := &mockMFAService{
+		disableFn: func(_ context.Context, _ string) error {
+			return api.ErrNotFound
+		},
+	}
+	router := newMFATestRouter(mfaSvc)
+
+	w := doRequest(router, http.MethodPost, "/auth/mfa/disable", nil, "X-User-ID", "user-1")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// ── MFA Status Tests ─────────────────────────────────────────────────────────
+
+func TestMFAStatus_Success(t *testing.T) {
+	router := newMFATestRouter(&mockMFAService{})
+
+	w := doRequest(router, http.MethodGet, "/auth/mfa/status", nil, "X-User-ID", "user-1")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.MFAStatusResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.True(t, resp.Enabled)
+	assert.Equal(t, "totp", resp.Type)
+	assert.True(t, resp.Confirmed)
+	assert.Equal(t, 10, resp.BackupLeft)
+}
+
+// ── Login-with-MFA Flow Test ─────────────────────────────────────────────────
+
+func TestLogin_MFAChallenge(t *testing.T) {
+	authSvc := &mockAuthService{
+		loginFn: func(_ context.Context, _, _ string) (*api.AuthResult, error) {
+			return &api.AuthResult{
+				MFARequired: true,
+				MFAToken:    "mfa-challenge-token",
+				UserID:      "user-1",
+			}, nil
+		},
+	}
+
+	svc := &api.Services{
+		Auth:  authSvc,
+		Token: &mockTokenService{},
+		MFA:   &mockMFAService{},
+	}
+	authMW := func(c *gin.Context) {
+		userID := c.GetHeader("X-User-ID")
+		if userID == "" {
+			domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized, "missing authentication")
+			return
+		}
+		c.Set("user_id", userID)
+		c.Next()
+	}
+	mw := &api.MiddlewareStack{Auth: authMW}
+	router := api.NewPublicRouter(svc, mw, health.NewService())
+
+	// Step 1: Login returns MFA challenge
+	body := map[string]string{
+		"email":    "alice@example.com",
+		"password": "secure-password-12345",
+	}
+	w := doRequest(router, http.MethodPost, "/auth/login", body)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var loginResp api.AuthResult
+	err := json.Unmarshal(w.Body.Bytes(), &loginResp)
+	require.NoError(t, err)
+	assert.True(t, loginResp.MFARequired)
+	assert.Equal(t, "mfa-challenge-token", loginResp.MFAToken)
+	assert.Empty(t, loginResp.AccessToken, "should not return access token during MFA challenge")
+
+	// Step 2: Complete MFA verification
+	verifyBody := map[string]string{
+		"mfa_token": loginResp.MFAToken,
+		"code":      "123456",
+		"code_type": "totp",
+	}
+	w = doRequest(router, http.MethodPost, "/auth/mfa/verify", verifyBody)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var verifyResp api.AuthResult
+	err = json.Unmarshal(w.Body.Bytes(), &verifyResp)
+	require.NoError(t, err)
+	assert.Equal(t, "qf_at_mfa_access", verifyResp.AccessToken)
+	assert.False(t, verifyResp.MFARequired)
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -49,6 +49,11 @@ func NewPublicRouter(svc *Services, mw *MiddlewareStack, healthSvc *health.Servi
 		sessionH = NewSessionHandlers(svc.Session)
 	}
 
+	var mfaH *MFAHandlers
+	if svc.MFA != nil {
+		mfaH = NewMFAHandlers(svc.MFA)
+	}
+
 	// Health probes (no middleware beyond global).
 	hh := newHealthHandlers(healthSvc)
 	r.GET("/health", hh.health)
@@ -69,6 +74,11 @@ func NewPublicRouter(svc *Services, mw *MiddlewareStack, healthSvc *health.Servi
 		pw := auth.Group("/password")
 		pw.POST("/reset", validateReq(v, &domain.PasswordResetRequest{}), authH.ResetPassword)
 		pw.POST("/reset/confirm", validateReq(v, &domain.PasswordResetConfirmRequest{}), authH.ConfirmPasswordReset)
+
+		// MFA verify is public (uses mfa_token, not bearer auth).
+		if mfaH != nil {
+			auth.POST("/mfa/verify", mfaH.Verify)
+		}
 	}
 
 	// Protected auth routes (require API key or auth middleware).
@@ -91,6 +101,14 @@ func NewPublicRouter(svc *Services, mw *MiddlewareStack, healthSvc *health.Servi
 		protected.GET("/sessions", sessionH.List)
 		protected.DELETE("/sessions/:id", sessionH.Delete)
 		protected.DELETE("/sessions", sessionH.DeleteAll)
+	}
+
+	if mfaH != nil {
+		mfa := protected.Group("/mfa")
+		mfa.POST("/setup", mfaH.Setup)
+		mfa.POST("/confirm", mfaH.Confirm)
+		mfa.POST("/disable", mfaH.Disable)
+		mfa.GET("/status", mfaH.Status)
 	}
 
 	return r

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -8,12 +8,15 @@ import (
 )
 
 // AuthResult contains the tokens returned after successful authentication.
+// When MFA is required, only MFARequired and MFAToken are populated.
 type AuthResult struct {
-	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token"`
-	TokenType    string `json:"token_type"`
-	ExpiresIn    int    `json:"expires_in"`
+	AccessToken  string `json:"access_token,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	TokenType    string `json:"token_type,omitempty"`
+	ExpiresIn    int    `json:"expires_in,omitempty"`
 	UserID       string `json:"user_id,omitempty"`
+	MFARequired  bool   `json:"mfa_required,omitempty"`
+	MFAToken     string `json:"mfa_token,omitempty"`
 }
 
 // UserInfo represents the authenticated user's profile.
@@ -88,12 +91,45 @@ type SessionService interface {
 	DeleteAllSessions(ctx context.Context, userID string) error
 }
 
+// MFAEnrollmentResult is returned when a user initiates MFA enrollment.
+type MFAEnrollmentResult struct {
+	Secret string `json:"secret"`
+	URI    string `json:"uri"`
+}
+
+// MFAConfirmResult is returned when enrollment is confirmed, containing backup codes.
+type MFAConfirmResult struct {
+	BackupCodes []string `json:"backup_codes"`
+}
+
+// MFAStatusResponse is returned by the MFA status endpoint.
+type MFAStatusResponse struct {
+	Enabled    bool   `json:"enabled"`
+	Type       string `json:"type,omitempty"`
+	Confirmed  bool   `json:"confirmed"`
+	BackupLeft int    `json:"backup_codes_remaining"`
+}
+
+// MFAService defines the operations for multi-factor authentication.
+type MFAService interface {
+	InitiateEnrollment(ctx context.Context, userID, email string) (*MFAEnrollmentResult, error)
+	ConfirmEnrollment(ctx context.Context, userID, code string) ([]string, error)
+	VerifyTOTP(ctx context.Context, userID, code string) error
+	VerifyBackupCode(ctx context.Context, userID, code string) error
+	CompleteMFALogin(ctx context.Context, mfaToken, code, codeType string) (*AuthResult, error)
+	Disable(ctx context.Context, userID string) error
+	GetStatus(ctx context.Context, userID string) (*MFAStatusResponse, error)
+	IsMFAEnabled(ctx context.Context, userID string) (bool, error)
+	GenerateMFAToken(ctx context.Context, userID string) (string, error)
+}
+
 // Services aggregates all service interfaces required by the API handlers.
 type Services struct {
 	Auth    AuthService
 	Token   TokenService
 	Session SessionService
 	DPoP    DPoPService
+	MFA     MFAService
 }
 
 // MiddlewareStack holds middleware handler functions used by the router.

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -39,6 +39,13 @@ type TokenIssuer interface {
 	Revoke(ctx context.Context, token string) error
 }
 
+// MFAChecker abstracts MFA status checking and token generation.
+// This is a narrow interface satisfied by mfa.Service.
+type MFAChecker interface {
+	IsMFAEnabled(ctx context.Context, userID string) (bool, error)
+	GenerateMFAToken(ctx context.Context, userID string) (string, error)
+}
+
 // Service implements api.AuthService with Redis-backed password reset tokens
 // and PostgreSQL-backed user authentication.
 type Service struct {
@@ -50,6 +57,7 @@ type Service struct {
 	issuer   TokenIssuer
 	hasher   password.Hasher
 	breaches hibp.BreachChecker
+	mfa      MFAChecker
 }
 
 // NewService creates a new auth Service.
@@ -73,6 +81,12 @@ func NewService(
 		hasher:   hasher,
 		breaches: breaches,
 	}
+}
+
+// SetMFAChecker injects the MFA checker after construction to break the
+// circular dependency between auth.Service and mfa.Service.
+func (s *Service) SetMFAChecker(mfa MFAChecker) {
+	s.mfa = mfa
 }
 
 // Register creates a new user account.
@@ -142,6 +156,31 @@ func (s *Service) Login(ctx context.Context, email, pwd string) (*api.AuthResult
 			Metadata: map[string]string{"reason": "invalid_password"},
 		})
 		return nil, fmt.Errorf("invalid credentials: %w", api.ErrUnauthorized)
+	}
+
+	// Check MFA status: if enabled, return challenge instead of tokens.
+	if s.mfa != nil {
+		mfaEnabled, mfaErr := s.mfa.IsMFAEnabled(ctx, user.ID)
+		if mfaErr != nil {
+			s.logger.Error("failed to check mfa status", zap.String("user_id", user.ID), zap.Error(mfaErr))
+			// Continue with normal login on MFA check failure (fail-open for availability).
+		} else if mfaEnabled {
+			mfaToken, tokenErr := s.mfa.GenerateMFAToken(ctx, user.ID)
+			if tokenErr != nil {
+				s.logger.Error("failed to generate mfa token", zap.String("user_id", user.ID), zap.Error(tokenErr))
+				return nil, fmt.Errorf("generate mfa token: %w", tokenErr)
+			}
+			s.audit.LogEvent(ctx, audit.Event{
+				Type:     "mfa_challenge_issued",
+				ActorID:  user.ID,
+				TargetID: user.ID,
+			})
+			return &api.AuthResult{
+				MFARequired: true,
+				MFAToken:    mfaToken,
+				UserID:      user.ID,
+			}, nil
+		}
 	}
 
 	// Issue token pair.

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -331,6 +331,92 @@ func TestLogin(t *testing.T) {
 	}
 }
 
+// ── MFA Mocks ───────────────────────────────────────────────────────────────
+
+type mockMFAChecker struct {
+	isMFAEnabledFn       func(ctx context.Context, userID string) (bool, error)
+	generateMFATokenFn   func(ctx context.Context, userID string) (string, error)
+}
+
+func (m *mockMFAChecker) IsMFAEnabled(ctx context.Context, userID string) (bool, error) {
+	if m.isMFAEnabledFn != nil {
+		return m.isMFAEnabledFn(ctx, userID)
+	}
+	return false, nil
+}
+
+func (m *mockMFAChecker) GenerateMFAToken(ctx context.Context, userID string) (string, error) {
+	if m.generateMFATokenFn != nil {
+		return m.generateMFATokenFn(ctx, userID)
+	}
+	return "mfa-token-123", nil
+}
+
+func TestLogin_MFAChallenge(t *testing.T) {
+	activeUser := &domain.User{
+		ID:           "user-1",
+		Email:        "alice@example.com",
+		PasswordHash: "$argon2id$v=19$m=19456,t=2,p=1$dGVzdHNhbHQ$dGVzdGhhc2g",
+		Roles:        []string{"user"},
+	}
+
+	users := &mockUserRepository{
+		findByEmailFn: func(_ context.Context, _ string) (*domain.User, error) {
+			return activeUser, nil
+		},
+	}
+
+	mfaChecker := &mockMFAChecker{
+		isMFAEnabledFn: func(_ context.Context, _ string) (bool, error) {
+			return true, nil
+		},
+		generateMFATokenFn: func(_ context.Context, _ string) (string, error) {
+			return "mfa-challenge-token", nil
+		},
+	}
+
+	svc := newUnitService(t, users, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, &mockHasher{})
+	svc.SetMFAChecker(mfaChecker)
+
+	result, err := svc.Login(context.Background(), "alice@example.com", "correct-password")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.MFARequired, "expected MFA challenge")
+	assert.Equal(t, "mfa-challenge-token", result.MFAToken)
+	assert.Equal(t, "user-1", result.UserID)
+	assert.Empty(t, result.AccessToken, "should not issue access token when MFA required")
+}
+
+func TestLogin_MFANotEnabled_ReturnsTokens(t *testing.T) {
+	activeUser := &domain.User{
+		ID:           "user-1",
+		Email:        "alice@example.com",
+		PasswordHash: "$argon2id$v=19$m=19456,t=2,p=1$dGVzdHNhbHQ$dGVzdGhhc2g",
+		Roles:        []string{"user"},
+	}
+
+	users := &mockUserRepository{
+		findByEmailFn: func(_ context.Context, _ string) (*domain.User, error) {
+			return activeUser, nil
+		},
+	}
+
+	mfaChecker := &mockMFAChecker{
+		isMFAEnabledFn: func(_ context.Context, _ string) (bool, error) {
+			return false, nil
+		},
+	}
+
+	svc := newUnitService(t, users, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, &mockHasher{})
+	svc.SetMFAChecker(mfaChecker)
+
+	result, err := svc.Login(context.Background(), "alice@example.com", "correct-password")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.MFARequired)
+	assert.Equal(t, "qf_at_test-access", result.AccessToken)
+}
+
 func TestLogin_UpdatesLastLogin(t *testing.T) {
 	var lastLoginUpdated bool
 	users := &mockUserRepository{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,15 @@ type Config struct {
 	RequestLimit RequestLimitConfig
 	Email        EmailConfig
 	DPoP         DPoPConfig
+	MFA          MFAConfig
+}
+
+// MFAConfig holds multi-factor authentication settings.
+type MFAConfig struct {
+	Issuer          string // MFA_ISSUER: issuer name shown in authenticator apps
+	Digits          int    // MFA_DIGITS: number of TOTP digits (6 or 8)
+	Period          int    // MFA_PERIOD: TOTP period in seconds
+	BackupCodeCount int    // MFA_BACKUP_CODE_COUNT: number of backup codes to generate
 }
 
 // DPoPConfig holds DPoP (Demonstrating Proof-of-Possession) settings.
@@ -219,6 +228,10 @@ func Load() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	mfaCfg, err := loadMFA(l)
+	if err != nil {
+		return nil, err
+	}
 
 	if len(l.missing) > 0 {
 		return nil, fmt.Errorf("missing required environment variables: %s", strings.Join(l.missing, ", "))
@@ -240,6 +253,7 @@ func Load() (*Config, error) {
 		RequestLimit: reqLimit,
 		Email:        email,
 		DPoP:         dpop,
+		MFA:          mfaCfg,
 	}, nil
 }
 
@@ -504,6 +518,35 @@ func loadDPoP(l *loader) (DPoPConfig, error) {
 		Enabled:   enabled,
 		NonceTTL:  nonceTTL,
 		JTIWindow: jtiWindow,
+	}, nil
+}
+
+func loadMFA(l *loader) (MFAConfig, error) {
+	issuer := l.optStr("MFA_ISSUER", "QuantFlow Studio")
+
+	digits, err := l.optInt("MFA_DIGITS", 6)
+	if err != nil {
+		return MFAConfig{}, err
+	}
+	if digits != 6 && digits != 8 {
+		return MFAConfig{}, fmt.Errorf("MFA_DIGITS: must be 6 or 8, got %d", digits)
+	}
+
+	period, err := l.optInt("MFA_PERIOD", 30)
+	if err != nil {
+		return MFAConfig{}, err
+	}
+
+	backupCount, err := l.optInt("MFA_BACKUP_CODE_COUNT", 10)
+	if err != nil {
+		return MFAConfig{}, err
+	}
+
+	return MFAConfig{
+		Issuer:          issuer,
+		Digits:          digits,
+		Period:          period,
+		BackupCodeCount: backupCount,
 	}, nil
 }
 

--- a/internal/mfa/mfa.go
+++ b/internal/mfa/mfa.go
@@ -1,2 +1,402 @@
-// Package mfa provides multi-factor authentication: TOTP, WebAuthn, backup codes (Phase 2).
+// Package mfa provides multi-factor authentication: TOTP enrollment,
+// verification, backup codes, and admin management.
 package mfa
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pquerna/otp"
+	"github.com/pquerna/otp/totp"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/audit"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+const (
+	// backupCodeBytes is the number of random bytes per backup code (8 bytes = 16 hex chars).
+	backupCodeBytes = 8
+)
+
+// MFATokenStore abstracts temporary MFA token storage (Redis).
+type MFATokenStore interface {
+	StoreMFAToken(ctx context.Context, token, userID string) error
+	ConsumeMFAToken(ctx context.Context, token string) (string, error)
+	RecordFailedAttempt(ctx context.Context, userID string) (int, error)
+	ClearFailedAttempts(ctx context.Context, userID string) error
+}
+
+// TokenIssuer abstracts token pair creation for completing MFA login.
+type TokenIssuer interface {
+	IssueTokenPair(ctx context.Context, subject string, roles, scopes []string, clientType domain.ClientType) (*api.AuthResult, error)
+}
+
+// Config holds MFA-specific settings.
+type Config struct {
+	Issuer          string // TOTP issuer name shown in authenticator apps
+	Digits          int    // Number of digits (default 6)
+	Period          uint   // TOTP period in seconds (default 30)
+	BackupCodeCount int    // Number of backup codes to generate (default 10)
+}
+
+// DefaultConfig returns the default MFA configuration.
+func DefaultConfig() Config {
+	return Config{
+		Issuer:          "QuantFlow Studio",
+		Digits:          6,
+		Period:          30,
+		BackupCodeCount: 10,
+	}
+}
+
+// Service implements MFA business logic.
+type Service struct {
+	cfg    Config
+	repo   storage.MFARepository
+	tokens MFATokenStore
+	issuer TokenIssuer
+	logger *zap.Logger
+	audit  audit.EventLogger
+}
+
+// NewService creates a new MFA service.
+func NewService(
+	cfg Config,
+	repo storage.MFARepository,
+	tokens MFATokenStore,
+	issuer TokenIssuer,
+	logger *zap.Logger,
+	auditor audit.EventLogger,
+) *Service {
+	return &Service{
+		cfg:    cfg,
+		repo:   repo,
+		tokens: tokens,
+		issuer: issuer,
+		logger: logger,
+		audit:  auditor,
+	}
+}
+
+// InitiateEnrollment generates a new TOTP secret for the user.
+// The secret is stored unconfirmed until the user verifies a code.
+func (s *Service) InitiateEnrollment(ctx context.Context, userID, email string) (*api.MFAEnrollmentResult, error) {
+	otpDigits := otp.DigitsSix
+	if s.cfg.Digits == 8 {
+		otpDigits = otp.DigitsEight
+	}
+
+	key, err := totp.Generate(totp.GenerateOpts{
+		Issuer:      s.cfg.Issuer,
+		AccountName: email,
+		Period:      s.cfg.Period,
+		Digits:      otpDigits,
+		Algorithm:   otp.AlgorithmSHA1,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("generate totp key: %w", err)
+	}
+
+	secret := &domain.MFASecret{
+		ID:        uuid.New().String(),
+		UserID:    userID,
+		Type:      "totp",
+		Secret:    key.Secret(),
+		Confirmed: false,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+
+	if _, err := s.repo.SaveSecret(ctx, secret); err != nil {
+		if errors.Is(err, storage.ErrDuplicateMFA) {
+			return nil, fmt.Errorf("mfa already enrolled: %w", api.ErrConflict)
+		}
+		return nil, fmt.Errorf("save mfa secret: %w", err)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     "mfa_enrollment_initiated",
+		ActorID:  userID,
+		TargetID: userID,
+	})
+
+	return &api.MFAEnrollmentResult{
+		Secret: key.Secret(),
+		URI:    key.URL(),
+	}, nil
+}
+
+// ConfirmEnrollment validates a TOTP code against the unconfirmed secret,
+// confirms it, and generates backup codes.
+func (s *Service) ConfirmEnrollment(ctx context.Context, userID, code string) ([]string, error) {
+	secret, err := s.repo.GetSecret(ctx, userID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("no pending enrollment: %w", api.ErrNotFound)
+		}
+		return nil, fmt.Errorf("get mfa secret: %w", err)
+	}
+
+	if secret.Confirmed {
+		return nil, fmt.Errorf("mfa already confirmed: %w", api.ErrConflict)
+	}
+
+	if !s.validateTOTP(secret.Secret, code) {
+		return nil, fmt.Errorf("invalid totp code: %w", api.ErrUnauthorized)
+	}
+
+	if err := s.repo.ConfirmSecret(ctx, userID); err != nil {
+		return nil, fmt.Errorf("confirm mfa secret: %w", err)
+	}
+
+	// Generate and store backup codes.
+	plainCodes, hashedCodes, err := s.generateBackupCodes(userID)
+	if err != nil {
+		return nil, fmt.Errorf("generate backup codes: %w", err)
+	}
+
+	if err := s.repo.SaveBackupCodes(ctx, userID, hashedCodes); err != nil {
+		return nil, fmt.Errorf("save backup codes: %w", err)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     "mfa_enrollment_confirmed",
+		ActorID:  userID,
+		TargetID: userID,
+	})
+
+	return plainCodes, nil
+}
+
+// VerifyTOTP validates a TOTP code for a user with confirmed MFA.
+func (s *Service) VerifyTOTP(ctx context.Context, userID, code string) error {
+	secret, err := s.repo.GetSecret(ctx, userID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return fmt.Errorf("mfa not enrolled: %w", api.ErrNotFound)
+		}
+		return fmt.Errorf("get mfa secret: %w", err)
+	}
+
+	if !secret.Confirmed {
+		return fmt.Errorf("mfa not confirmed: %w", api.ErrNotFound)
+	}
+
+	if !s.validateTOTP(secret.Secret, code) {
+		if _, err := s.tokens.RecordFailedAttempt(ctx, userID); err != nil {
+			if errors.Is(err, storage.ErrMFAMaxAttempts) {
+				return fmt.Errorf("too many failed attempts: %w", api.ErrForbidden)
+			}
+			s.logger.Error("failed to record mfa attempt", zap.Error(err))
+		}
+		return fmt.Errorf("invalid totp code: %w", api.ErrUnauthorized)
+	}
+
+	if err := s.tokens.ClearFailedAttempts(ctx, userID); err != nil {
+		s.logger.Error("failed to clear mfa attempts", zap.String("user_id", userID), zap.Error(err))
+	}
+
+	return nil
+}
+
+// VerifyBackupCode validates and consumes a backup code for a user.
+func (s *Service) VerifyBackupCode(ctx context.Context, userID, code string) error {
+	codeHash := hashBackupCode(code)
+
+	if err := s.repo.ConsumeBackupCode(ctx, userID, codeHash); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			if _, err := s.tokens.RecordFailedAttempt(ctx, userID); err != nil {
+				if errors.Is(err, storage.ErrMFAMaxAttempts) {
+					return fmt.Errorf("too many failed attempts: %w", api.ErrForbidden)
+				}
+				s.logger.Error("failed to record mfa attempt", zap.Error(err))
+			}
+			return fmt.Errorf("invalid backup code: %w", api.ErrUnauthorized)
+		}
+		return fmt.Errorf("consume backup code: %w", err)
+	}
+
+	if err := s.tokens.ClearFailedAttempts(ctx, userID); err != nil {
+		s.logger.Error("failed to clear mfa attempts", zap.String("user_id", userID), zap.Error(err))
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     "mfa_backup_code_used",
+		ActorID:  userID,
+		TargetID: userID,
+	})
+
+	return nil
+}
+
+// CompleteMFALogin verifies the MFA token and TOTP/backup code, then issues tokens.
+func (s *Service) CompleteMFALogin(ctx context.Context, mfaToken, code, codeType string) (*api.AuthResult, error) {
+	userID, err := s.tokens.ConsumeMFAToken(ctx, mfaToken)
+	if err != nil {
+		if errors.Is(err, storage.ErrMFATokenNotFound) {
+			return nil, fmt.Errorf("invalid or expired mfa token: %w", api.ErrUnauthorized)
+		}
+		return nil, fmt.Errorf("consume mfa token: %w", err)
+	}
+
+	switch codeType {
+	case "totp", "":
+		if err := s.VerifyTOTP(ctx, userID, code); err != nil {
+			return nil, err
+		}
+	case "backup":
+		if err := s.VerifyBackupCode(ctx, userID, code); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unsupported code type %q: %w", codeType, api.ErrUnauthorized)
+	}
+
+	// Issue full token pair now that MFA is verified.
+	result, err := s.issuer.IssueTokenPair(ctx, userID, nil, nil, domain.ClientTypeUser)
+	if err != nil {
+		return nil, fmt.Errorf("issue tokens after mfa: %w", err)
+	}
+	result.UserID = userID
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     "mfa_login_success",
+		ActorID:  userID,
+		TargetID: userID,
+	})
+
+	return result, nil
+}
+
+// Disable removes MFA for a user (deletes secret and backup codes).
+func (s *Service) Disable(ctx context.Context, userID string) error {
+	if err := s.repo.DeleteSecret(ctx, userID); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return fmt.Errorf("mfa not enrolled: %w", api.ErrNotFound)
+		}
+		return fmt.Errorf("delete mfa secret: %w", err)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     "mfa_disabled",
+		ActorID:  userID,
+		TargetID: userID,
+	})
+
+	return nil
+}
+
+// GetStatus returns the MFA status for a user.
+func (s *Service) GetStatus(ctx context.Context, userID string) (*api.MFAStatusResponse, error) {
+	status, err := s.repo.GetMFAStatus(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get mfa status: %w", err)
+	}
+	return &api.MFAStatusResponse{
+		Enabled:    status.Enabled,
+		Type:       status.Type,
+		Confirmed:  status.Confirmed,
+		BackupLeft: status.BackupLeft,
+	}, nil
+}
+
+// GenerateMFAToken creates a short-lived token for the MFA challenge flow.
+func (s *Service) GenerateMFAToken(ctx context.Context, userID string) (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate mfa token: %w", err)
+	}
+	token := hex.EncodeToString(b)
+
+	if err := s.tokens.StoreMFAToken(ctx, token, userID); err != nil {
+		return "", fmt.Errorf("store mfa token: %w", err)
+	}
+
+	return token, nil
+}
+
+// IsMFAEnabled checks if the user has confirmed MFA enrollment.
+func (s *Service) IsMFAEnabled(ctx context.Context, userID string) (bool, error) {
+	status, err := s.repo.GetMFAStatus(ctx, userID)
+	if err != nil {
+		return false, fmt.Errorf("check mfa status: %w", err)
+	}
+	return status.Enabled && status.Confirmed, nil
+}
+
+// validateTOTP checks a TOTP code against the secret.
+func (s *Service) validateTOTP(secret, code string) bool {
+	valid, err := totp.ValidateCustom(code, secret, time.Now().UTC(), totp.ValidateOpts{
+		Period:    s.cfg.Period,
+		Digits:    otp.DigitsSix,
+		Algorithm: otp.AlgorithmSHA1,
+	})
+	if err != nil {
+		s.logger.Error("totp validation error", zap.Error(err))
+		return false
+	}
+	return valid
+}
+
+// generateBackupCodes creates the configured number of random backup codes.
+// Returns both plaintext codes (for the user) and hashed domain objects (for storage).
+func (s *Service) generateBackupCodes(userID string) ([]string, []domain.BackupCode, error) {
+	count := s.cfg.BackupCodeCount
+	if count <= 0 {
+		count = 10
+	}
+
+	plain := make([]string, 0, count)
+	hashed := make([]domain.BackupCode, 0, count)
+
+	for i := 0; i < count; i++ {
+		b := make([]byte, backupCodeBytes)
+		if _, err := rand.Read(b); err != nil {
+			return nil, nil, fmt.Errorf("generate backup code: %w", err)
+		}
+
+		code := formatBackupCode(hex.EncodeToString(b))
+		plain = append(plain, code)
+
+		hashed = append(hashed, domain.BackupCode{
+			ID:        uuid.New().String(),
+			UserID:    userID,
+			CodeHash:  hashBackupCode(code),
+			Used:      false,
+			CreatedAt: time.Now().UTC(),
+		})
+	}
+
+	return plain, hashed, nil
+}
+
+// formatBackupCode formats a hex string as xxxx-xxxx-xxxx-xxxx for readability.
+func formatBackupCode(hex string) string {
+	hex = strings.ReplaceAll(hex, "-", "")
+	var parts []string
+	for i := 0; i < len(hex); i += 4 {
+		end := i + 4
+		if end > len(hex) {
+			end = len(hex)
+		}
+		parts = append(parts, hex[i:end])
+	}
+	return strings.Join(parts, "-")
+}
+
+// hashBackupCode returns the SHA-256 hex digest of a backup code (normalized).
+func hashBackupCode(code string) string {
+	normalized := strings.ReplaceAll(strings.ToLower(strings.TrimSpace(code)), "-", "")
+	h := sha256.Sum256([]byte(normalized))
+	return hex.EncodeToString(h[:])
+}

--- a/internal/mfa/mfa_test.go
+++ b/internal/mfa/mfa_test.go
@@ -1,0 +1,611 @@
+package mfa
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/audit"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+type mockMFARepository struct {
+	saveSecretFn     func(ctx context.Context, secret *domain.MFASecret) (*domain.MFASecret, error)
+	getSecretFn      func(ctx context.Context, userID string) (*domain.MFASecret, error)
+	confirmSecretFn  func(ctx context.Context, userID string) error
+	deleteSecretFn   func(ctx context.Context, userID string) error
+	saveBackupFn     func(ctx context.Context, userID string, codes []domain.BackupCode) error
+	getBackupFn      func(ctx context.Context, userID string) ([]domain.BackupCode, error)
+	consumeBackupFn  func(ctx context.Context, userID, codeHash string) error
+	getMFAStatusFn   func(ctx context.Context, userID string) (*domain.MFAStatus, error)
+}
+
+func (m *mockMFARepository) SaveSecret(ctx context.Context, secret *domain.MFASecret) (*domain.MFASecret, error) {
+	if m.saveSecretFn != nil {
+		return m.saveSecretFn(ctx, secret)
+	}
+	return secret, nil
+}
+
+func (m *mockMFARepository) GetSecret(ctx context.Context, userID string) (*domain.MFASecret, error) {
+	if m.getSecretFn != nil {
+		return m.getSecretFn(ctx, userID)
+	}
+	return nil, storage.ErrNotFound
+}
+
+func (m *mockMFARepository) ConfirmSecret(ctx context.Context, userID string) error {
+	if m.confirmSecretFn != nil {
+		return m.confirmSecretFn(ctx, userID)
+	}
+	return nil
+}
+
+func (m *mockMFARepository) DeleteSecret(ctx context.Context, userID string) error {
+	if m.deleteSecretFn != nil {
+		return m.deleteSecretFn(ctx, userID)
+	}
+	return nil
+}
+
+func (m *mockMFARepository) SaveBackupCodes(ctx context.Context, userID string, codes []domain.BackupCode) error {
+	if m.saveBackupFn != nil {
+		return m.saveBackupFn(ctx, userID, codes)
+	}
+	return nil
+}
+
+func (m *mockMFARepository) GetBackupCodes(ctx context.Context, userID string) ([]domain.BackupCode, error) {
+	if m.getBackupFn != nil {
+		return m.getBackupFn(ctx, userID)
+	}
+	return nil, nil
+}
+
+func (m *mockMFARepository) ConsumeBackupCode(ctx context.Context, userID, codeHash string) error {
+	if m.consumeBackupFn != nil {
+		return m.consumeBackupFn(ctx, userID, codeHash)
+	}
+	return nil
+}
+
+func (m *mockMFARepository) GetMFAStatus(ctx context.Context, userID string) (*domain.MFAStatus, error) {
+	if m.getMFAStatusFn != nil {
+		return m.getMFAStatusFn(ctx, userID)
+	}
+	return &domain.MFAStatus{UserID: userID}, nil
+}
+
+type mockMFATokenStore struct {
+	storeFn          func(ctx context.Context, token, userID string) error
+	consumeFn        func(ctx context.Context, token string) (string, error)
+	recordFailedFn   func(ctx context.Context, userID string) (int, error)
+	clearFailedFn    func(ctx context.Context, userID string) error
+}
+
+func (m *mockMFATokenStore) StoreMFAToken(ctx context.Context, token, userID string) error {
+	if m.storeFn != nil {
+		return m.storeFn(ctx, token, userID)
+	}
+	return nil
+}
+
+func (m *mockMFATokenStore) ConsumeMFAToken(ctx context.Context, token string) (string, error) {
+	if m.consumeFn != nil {
+		return m.consumeFn(ctx, token)
+	}
+	return "user-1", nil
+}
+
+func (m *mockMFATokenStore) RecordFailedAttempt(ctx context.Context, userID string) (int, error) {
+	if m.recordFailedFn != nil {
+		return m.recordFailedFn(ctx, userID)
+	}
+	return 1, nil
+}
+
+func (m *mockMFATokenStore) ClearFailedAttempts(ctx context.Context, userID string) error {
+	if m.clearFailedFn != nil {
+		return m.clearFailedFn(ctx, userID)
+	}
+	return nil
+}
+
+type mockTokenIssuer struct {
+	issueTokenPairFn func(ctx context.Context, subject string, roles, scopes []string, ct domain.ClientType) (*api.AuthResult, error)
+}
+
+func (m *mockTokenIssuer) IssueTokenPair(ctx context.Context, subject string, roles, scopes []string, ct domain.ClientType) (*api.AuthResult, error) {
+	if m.issueTokenPairFn != nil {
+		return m.issueTokenPairFn(ctx, subject, roles, scopes, ct)
+	}
+	return &api.AuthResult{
+		AccessToken:  "qf_at_test-access",
+		RefreshToken: "qf_rt_test-refresh",
+		TokenType:    "Bearer",
+		ExpiresIn:    900,
+	}, nil
+}
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+func newTestService(repo *mockMFARepository, tokens *mockMFATokenStore, issuer *mockTokenIssuer) *Service {
+	logger, _ := zap.NewDevelopment()
+	return NewService(
+		DefaultConfig(),
+		repo,
+		tokens,
+		issuer,
+		logger,
+		audit.NopLogger{},
+	)
+}
+
+// ── Enrollment Tests ─────────────────────────────────────────────────────────
+
+func TestInitiateEnrollment_Success(t *testing.T) {
+	var savedSecret *domain.MFASecret
+	repo := &mockMFARepository{
+		saveSecretFn: func(_ context.Context, secret *domain.MFASecret) (*domain.MFASecret, error) {
+			savedSecret = secret
+			return secret, nil
+		},
+	}
+
+	svc := newTestService(repo, &mockMFATokenStore{}, &mockTokenIssuer{})
+
+	result, err := svc.InitiateEnrollment(context.Background(), "user-1", "alice@example.com")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.NotEmpty(t, result.Secret)
+	assert.Contains(t, result.URI, "otpauth://totp/")
+	assert.Contains(t, result.URI, "QuantFlow")
+
+	require.NotNil(t, savedSecret)
+	assert.Equal(t, "user-1", savedSecret.UserID)
+	assert.Equal(t, "totp", savedSecret.Type)
+	assert.False(t, savedSecret.Confirmed)
+}
+
+func TestInitiateEnrollment_DuplicateReturnsConflict(t *testing.T) {
+	repo := &mockMFARepository{
+		saveSecretFn: func(_ context.Context, _ *domain.MFASecret) (*domain.MFASecret, error) {
+			return nil, storage.ErrDuplicateMFA
+		},
+	}
+
+	svc := newTestService(repo, &mockMFATokenStore{}, &mockTokenIssuer{})
+	_, err := svc.InitiateEnrollment(context.Background(), "user-1", "alice@example.com")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrConflict)
+}
+
+// ── Confirm Enrollment Tests ─────────────────────────────────────────────────
+
+func TestConfirmEnrollment_Success(t *testing.T) {
+	// Generate a real TOTP secret for testing
+	key, err := totp.Generate(totp.GenerateOpts{
+		Issuer:      "Test",
+		AccountName: "alice@test.com",
+	})
+	require.NoError(t, err)
+
+	// Generate a valid code
+	code, err := totp.GenerateCode(key.Secret(), time.Now())
+	require.NoError(t, err)
+
+	var confirmed bool
+	var backupsSaved bool
+	repo := &mockMFARepository{
+		getSecretFn: func(_ context.Context, _ string) (*domain.MFASecret, error) {
+			return &domain.MFASecret{
+				ID:        "secret-1",
+				UserID:    "user-1",
+				Type:      "totp",
+				Secret:    key.Secret(),
+				Confirmed: false,
+			}, nil
+		},
+		confirmSecretFn: func(_ context.Context, _ string) error {
+			confirmed = true
+			return nil
+		},
+		saveBackupFn: func(_ context.Context, _ string, codes []domain.BackupCode) error {
+			backupsSaved = true
+			assert.Len(t, codes, 10, "expected 10 backup codes")
+			return nil
+		},
+	}
+
+	svc := newTestService(repo, &mockMFATokenStore{}, &mockTokenIssuer{})
+
+	backupCodes, err := svc.ConfirmEnrollment(context.Background(), "user-1", code)
+	require.NoError(t, err)
+	assert.Len(t, backupCodes, 10)
+	assert.True(t, confirmed)
+	assert.True(t, backupsSaved)
+}
+
+func TestConfirmEnrollment_InvalidCode(t *testing.T) {
+	repo := &mockMFARepository{
+		getSecretFn: func(_ context.Context, _ string) (*domain.MFASecret, error) {
+			return &domain.MFASecret{
+				ID:        "secret-1",
+				UserID:    "user-1",
+				Type:      "totp",
+				Secret:    "JBSWY3DPEHPK3PXP", // known test secret
+				Confirmed: false,
+			}, nil
+		},
+	}
+
+	svc := newTestService(repo, &mockMFATokenStore{}, &mockTokenIssuer{})
+	_, err := svc.ConfirmEnrollment(context.Background(), "user-1", "000000")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrUnauthorized)
+}
+
+func TestConfirmEnrollment_AlreadyConfirmed(t *testing.T) {
+	repo := &mockMFARepository{
+		getSecretFn: func(_ context.Context, _ string) (*domain.MFASecret, error) {
+			return &domain.MFASecret{
+				ID:        "secret-1",
+				UserID:    "user-1",
+				Type:      "totp",
+				Secret:    "JBSWY3DPEHPK3PXP",
+				Confirmed: true,
+			}, nil
+		},
+	}
+
+	svc := newTestService(repo, &mockMFATokenStore{}, &mockTokenIssuer{})
+	_, err := svc.ConfirmEnrollment(context.Background(), "user-1", "123456")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrConflict)
+}
+
+func TestConfirmEnrollment_NoPendingEnrollment(t *testing.T) {
+	repo := &mockMFARepository{} // default returns ErrNotFound
+
+	svc := newTestService(repo, &mockMFATokenStore{}, &mockTokenIssuer{})
+	_, err := svc.ConfirmEnrollment(context.Background(), "user-1", "123456")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrNotFound)
+}
+
+// ── TOTP Verification Tests ──────────────────────────────────────────────────
+
+func TestVerifyTOTP_Success(t *testing.T) {
+	key, err := totp.Generate(totp.GenerateOpts{
+		Issuer:      "Test",
+		AccountName: "alice@test.com",
+	})
+	require.NoError(t, err)
+
+	code, err := totp.GenerateCode(key.Secret(), time.Now())
+	require.NoError(t, err)
+
+	var cleared bool
+	repo := &mockMFARepository{
+		getSecretFn: func(_ context.Context, _ string) (*domain.MFASecret, error) {
+			return &domain.MFASecret{
+				Secret:    key.Secret(),
+				Confirmed: true,
+			}, nil
+		},
+	}
+	tokens := &mockMFATokenStore{
+		clearFailedFn: func(_ context.Context, _ string) error {
+			cleared = true
+			return nil
+		},
+	}
+
+	svc := newTestService(repo, tokens, &mockTokenIssuer{})
+	err = svc.VerifyTOTP(context.Background(), "user-1", code)
+	require.NoError(t, err)
+	assert.True(t, cleared, "expected failed attempts to be cleared")
+}
+
+func TestVerifyTOTP_InvalidCode(t *testing.T) {
+	var failedRecorded bool
+	repo := &mockMFARepository{
+		getSecretFn: func(_ context.Context, _ string) (*domain.MFASecret, error) {
+			return &domain.MFASecret{
+				Secret:    "JBSWY3DPEHPK3PXP",
+				Confirmed: true,
+			}, nil
+		},
+	}
+	tokens := &mockMFATokenStore{
+		recordFailedFn: func(_ context.Context, _ string) (int, error) {
+			failedRecorded = true
+			return 1, nil
+		},
+	}
+
+	svc := newTestService(repo, tokens, &mockTokenIssuer{})
+	err := svc.VerifyTOTP(context.Background(), "user-1", "000000")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrUnauthorized)
+	assert.True(t, failedRecorded)
+}
+
+func TestVerifyTOTP_MaxAttemptsExceeded(t *testing.T) {
+	repo := &mockMFARepository{
+		getSecretFn: func(_ context.Context, _ string) (*domain.MFASecret, error) {
+			return &domain.MFASecret{
+				Secret:    "JBSWY3DPEHPK3PXP",
+				Confirmed: true,
+			}, nil
+		},
+	}
+	tokens := &mockMFATokenStore{
+		recordFailedFn: func(_ context.Context, _ string) (int, error) {
+			return 5, storage.ErrMFAMaxAttempts
+		},
+	}
+
+	svc := newTestService(repo, tokens, &mockTokenIssuer{})
+	err := svc.VerifyTOTP(context.Background(), "user-1", "000000")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrForbidden)
+}
+
+// ── Backup Code Tests ────────────────────────────────────────────────────────
+
+func TestVerifyBackupCode_Success(t *testing.T) {
+	var consumed bool
+	repo := &mockMFARepository{
+		consumeBackupFn: func(_ context.Context, _, _ string) error {
+			consumed = true
+			return nil
+		},
+	}
+
+	svc := newTestService(repo, &mockMFATokenStore{}, &mockTokenIssuer{})
+	err := svc.VerifyBackupCode(context.Background(), "user-1", "abcd-1234-efgh-5678")
+	require.NoError(t, err)
+	assert.True(t, consumed)
+}
+
+func TestVerifyBackupCode_Invalid(t *testing.T) {
+	repo := &mockMFARepository{
+		consumeBackupFn: func(_ context.Context, _, _ string) error {
+			return storage.ErrNotFound
+		},
+	}
+
+	svc := newTestService(repo, &mockMFATokenStore{}, &mockTokenIssuer{})
+	err := svc.VerifyBackupCode(context.Background(), "user-1", "invalid-code")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrUnauthorized)
+}
+
+// ── Complete MFA Login Tests ─────────────────────────────────────────────────
+
+func TestCompleteMFALogin_Success(t *testing.T) {
+	key, err := totp.Generate(totp.GenerateOpts{
+		Issuer:      "Test",
+		AccountName: "alice@test.com",
+	})
+	require.NoError(t, err)
+
+	code, err := totp.GenerateCode(key.Secret(), time.Now())
+	require.NoError(t, err)
+
+	repo := &mockMFARepository{
+		getSecretFn: func(_ context.Context, _ string) (*domain.MFASecret, error) {
+			return &domain.MFASecret{
+				Secret:    key.Secret(),
+				Confirmed: true,
+			}, nil
+		},
+	}
+	tokenStore := &mockMFATokenStore{
+		consumeFn: func(_ context.Context, token string) (string, error) {
+			if token == "valid-mfa-token" {
+				return "user-1", nil
+			}
+			return "", storage.ErrMFATokenNotFound
+		},
+	}
+
+	svc := newTestService(repo, tokenStore, &mockTokenIssuer{})
+
+	result, err := svc.CompleteMFALogin(context.Background(), "valid-mfa-token", code, "totp")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "qf_at_test-access", result.AccessToken)
+	assert.Equal(t, "user-1", result.UserID)
+}
+
+func TestCompleteMFALogin_InvalidToken(t *testing.T) {
+	tokenStore := &mockMFATokenStore{
+		consumeFn: func(_ context.Context, _ string) (string, error) {
+			return "", storage.ErrMFATokenNotFound
+		},
+	}
+
+	svc := newTestService(&mockMFARepository{}, tokenStore, &mockTokenIssuer{})
+	_, err := svc.CompleteMFALogin(context.Background(), "bad-token", "123456", "totp")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrUnauthorized)
+}
+
+func TestCompleteMFALogin_BackupCode(t *testing.T) {
+	var consumed bool
+	repo := &mockMFARepository{
+		consumeBackupFn: func(_ context.Context, _, _ string) error {
+			consumed = true
+			return nil
+		},
+	}
+	tokenStore := &mockMFATokenStore{
+		consumeFn: func(_ context.Context, _ string) (string, error) {
+			return "user-1", nil
+		},
+	}
+
+	svc := newTestService(repo, tokenStore, &mockTokenIssuer{})
+	result, err := svc.CompleteMFALogin(context.Background(), "mfa-token", "abcd-1234-efgh-5678", "backup")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, consumed)
+	assert.Equal(t, "user-1", result.UserID)
+}
+
+// ── Disable Tests ────────────────────────────────────────────────────────────
+
+func TestDisable_Success(t *testing.T) {
+	var deleted bool
+	repo := &mockMFARepository{
+		deleteSecretFn: func(_ context.Context, _ string) error {
+			deleted = true
+			return nil
+		},
+	}
+
+	svc := newTestService(repo, &mockMFATokenStore{}, &mockTokenIssuer{})
+	err := svc.Disable(context.Background(), "user-1")
+	require.NoError(t, err)
+	assert.True(t, deleted)
+}
+
+func TestDisable_NotEnrolled(t *testing.T) {
+	repo := &mockMFARepository{
+		deleteSecretFn: func(_ context.Context, _ string) error {
+			return storage.ErrNotFound
+		},
+	}
+
+	svc := newTestService(repo, &mockMFATokenStore{}, &mockTokenIssuer{})
+	err := svc.Disable(context.Background(), "user-1")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrNotFound)
+}
+
+// ── Status Tests ─────────────────────────────────────────────────────────────
+
+func TestGetStatus_Success(t *testing.T) {
+	repo := &mockMFARepository{
+		getMFAStatusFn: func(_ context.Context, userID string) (*domain.MFAStatus, error) {
+			return &domain.MFAStatus{
+				UserID:     userID,
+				Enabled:    true,
+				Type:       "totp",
+				Confirmed:  true,
+				BackupLeft: 8,
+			}, nil
+		},
+	}
+
+	svc := newTestService(repo, &mockMFATokenStore{}, &mockTokenIssuer{})
+	status, err := svc.GetStatus(context.Background(), "user-1")
+	require.NoError(t, err)
+	assert.True(t, status.Enabled)
+	assert.Equal(t, "totp", status.Type)
+	assert.True(t, status.Confirmed)
+	assert.Equal(t, 8, status.BackupLeft)
+}
+
+// ── IsMFAEnabled Tests ───────────────────────────────────────────────────────
+
+func TestIsMFAEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   *domain.MFAStatus
+		expected bool
+	}{
+		{
+			name:     "enabled and confirmed",
+			status:   &domain.MFAStatus{Enabled: true, Confirmed: true},
+			expected: true,
+		},
+		{
+			name:     "enabled but not confirmed",
+			status:   &domain.MFAStatus{Enabled: true, Confirmed: false},
+			expected: false,
+		},
+		{
+			name:     "not enabled",
+			status:   &domain.MFAStatus{Enabled: false, Confirmed: false},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockMFARepository{
+				getMFAStatusFn: func(_ context.Context, _ string) (*domain.MFAStatus, error) {
+					return tt.status, nil
+				},
+			}
+			svc := newTestService(repo, &mockMFATokenStore{}, &mockTokenIssuer{})
+			enabled, err := svc.IsMFAEnabled(context.Background(), "user-1")
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, enabled)
+		})
+	}
+}
+
+// ── GenerateMFAToken Tests ───────────────────────────────────────────────────
+
+func TestGenerateMFAToken_Success(t *testing.T) {
+	var storedToken string
+	tokens := &mockMFATokenStore{
+		storeFn: func(_ context.Context, token, userID string) error {
+			storedToken = token
+			assert.Equal(t, "user-1", userID)
+			return nil
+		},
+	}
+
+	svc := newTestService(&mockMFARepository{}, tokens, &mockTokenIssuer{})
+	token, err := svc.GenerateMFAToken(context.Background(), "user-1")
+	require.NoError(t, err)
+	assert.NotEmpty(t, token)
+	assert.Len(t, token, 64) // 32 bytes = 64 hex chars
+	assert.Equal(t, storedToken, token)
+}
+
+func TestGenerateMFAToken_StoreError(t *testing.T) {
+	tokens := &mockMFATokenStore{
+		storeFn: func(_ context.Context, _, _ string) error {
+			return fmt.Errorf("redis down")
+		},
+	}
+
+	svc := newTestService(&mockMFARepository{}, tokens, &mockTokenIssuer{})
+	_, err := svc.GenerateMFAToken(context.Background(), "user-1")
+	require.Error(t, err)
+}
+
+// ── Backup Code Format Tests ─────────────────────────────────────────────────
+
+func TestFormatBackupCode(t *testing.T) {
+	result := formatBackupCode("abcdef1234567890")
+	assert.Equal(t, "abcd-ef12-3456-7890", result)
+}
+
+func TestHashBackupCode_Normalization(t *testing.T) {
+	// Same code in different formats should hash the same
+	hash1 := hashBackupCode("abcd-1234-efgh-5678")
+	hash2 := hashBackupCode("ABCD-1234-EFGH-5678")
+	hash3 := hashBackupCode("abcd1234efgh5678")
+	hash4 := hashBackupCode("  ABCD-1234-EFGH-5678  ")
+
+	assert.Equal(t, hash1, hash2, "case normalization")
+	assert.Equal(t, hash1, hash3, "dash normalization")
+	assert.Equal(t, hash1, hash4, "whitespace normalization")
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-235.

Closes #235

## Changes

Connect everything together. Touches `internal/api/` (new `mfa_handlers.go` with enrollment/confirm/verify/disable handlers; update `services.go` with `MFAService` interface; update `router.go` to register `POST /auth/mfa/setup`, `POST /auth/mfa/confirm`, `POST /auth/mfa/verify`, `POST /auth/mfa/disable` routes), `internal/auth/` (modify `Service.Login()` to check MFA status after password verification and return `mfa_required: true` + short-lived `mfa_token` instead of full token pair), `internal/config/` (add `MFAConfig` struct with issuer name, algorithm, digits, period, backup code count), `internal/admin/` (add `GET /admin/users/:id/mfa` status and `DELETE /admin/users/:id/mfa` reset endpoints), and `cmd/server/main.go` (wire `MFARepository`, `MFAService`, inject into auth service and handlers). Integration tests covering: full enrollment flow, login-with-MFA challenge flow, backup code recovery, admin MFA reset.