### PR TITLE
GH-240: `internal/mfa/`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
+	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
@@ -47,6 +48,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/pquerna/otp v1.5.0 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/alicebob/miniredis/v2 v2.37.0 h1:RheObYW32G1aiJIj81XVt78ZHJpHonHLHW7O
 github.com/alicebob/miniredis/v2 v2.37.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
@@ -125,6 +127,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
+github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
 github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=

--- a/internal/mfa/service.go
+++ b/internal/mfa/service.go
@@ -1,0 +1,364 @@
+// Package mfa provides multi-factor authentication: TOTP enrollment,
+// verification, and backup code management.
+package mfa
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pquerna/otp"
+	"github.com/pquerna/otp/totp"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/audit"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+const (
+	// totpIssuer is the issuer name displayed in authenticator apps.
+	totpIssuer = "QuantFlow Studio"
+
+	// totpSecretSize is the TOTP secret length in bytes (160 bits per RFC 4226).
+	totpSecretSize = 20
+
+	// totpDigits is the number of OTP digits.
+	totpDigits = 6
+
+	// totpPeriod is the time step in seconds.
+	totpPeriod = 30
+
+	// backupCodeCount is the number of backup codes generated per enrollment.
+	backupCodeCount = 10
+
+	// backupCodeLength is the character length of each plaintext backup code.
+	backupCodeLength = 8
+
+	// backupCodeAlphabet contains the allowed characters for backup codes.
+	backupCodeAlphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
+)
+
+// Sentinel errors returned by the MFA service.
+var (
+	ErrMFAAlreadyEnrolled = errors.New("mfa already enrolled")
+	ErrMFANotEnrolled     = errors.New("mfa not enrolled")
+	ErrMFANotConfirmed    = errors.New("mfa not confirmed")
+	ErrInvalidTOTP        = errors.New("invalid totp code")
+	ErrInvalidBackupCode  = errors.New("invalid backup code")
+	ErrMaxAttempts        = errors.New("max verification attempts exceeded")
+)
+
+// MFARepo is the subset of storage.MFARepository used by Service.
+type MFARepo interface {
+	SaveSecret(ctx context.Context, secret *domain.MFASecret) (*domain.MFASecret, error)
+	GetSecret(ctx context.Context, userID string) (*domain.MFASecret, error)
+	ConfirmSecret(ctx context.Context, userID string) error
+	DeleteSecret(ctx context.Context, userID string) error
+	SaveBackupCodes(ctx context.Context, userID string, codes []domain.BackupCode) error
+	GetBackupCodes(ctx context.Context, userID string) ([]domain.BackupCode, error)
+	ConsumeBackupCode(ctx context.Context, userID, codeHash string) error
+	GetMFAStatus(ctx context.Context, userID string) (*domain.MFAStatus, error)
+}
+
+// RateLimiter is the subset of storage.RedisMFAStore used by Service for
+// failed-attempt tracking.
+type RateLimiter interface {
+	RecordFailedAttempt(ctx context.Context, userID string) (int, error)
+	ClearFailedAttempts(ctx context.Context, userID string) error
+}
+
+// EnrollmentResult contains the data returned when a user enrolls in TOTP MFA.
+type EnrollmentResult struct {
+	Secret      string   // base32-encoded TOTP secret
+	QRCodeURI   string   // otpauth:// URI for QR code generation
+	BackupCodes []string // plaintext backup codes (shown once)
+}
+
+// Service implements the core MFA business logic.
+type Service struct {
+	repo    MFARepo
+	limiter RateLimiter
+	logger  *zap.Logger
+	audit   audit.EventLogger
+}
+
+// NewService creates a new MFA service.
+func NewService(
+	repo MFARepo,
+	limiter RateLimiter,
+	logger *zap.Logger,
+	auditor audit.EventLogger,
+) *Service {
+	return &Service{
+		repo:    repo,
+		limiter: limiter,
+		logger:  logger,
+		audit:   auditor,
+	}
+}
+
+// EnrollTOTP generates a new TOTP secret and backup codes for the user.
+// The enrollment is not active until ConfirmEnrollment is called with a valid code.
+func (s *Service) EnrollTOTP(ctx context.Context, userID string) (*EnrollmentResult, error) {
+	// Check if user already has an active (non-deleted) MFA secret.
+	existing, err := s.repo.GetSecret(ctx, userID)
+	if err != nil && !errors.Is(err, storage.ErrNotFound) {
+		return nil, fmt.Errorf("check existing mfa: %w", err)
+	}
+	if existing != nil {
+		return nil, ErrMFAAlreadyEnrolled
+	}
+
+	// Generate TOTP key using pquerna/otp.
+	key, err := totp.Generate(totp.GenerateOpts{
+		Issuer:      totpIssuer,
+		AccountName: userID,
+		SecretSize:  totpSecretSize,
+		Digits:      otp.DigitsSix,
+		Algorithm:   otp.AlgorithmSHA1,
+		Period:      totpPeriod,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("generate totp key: %w", err)
+	}
+
+	// Generate backup codes.
+	plaintextCodes, hashedCodes, err := generateBackupCodes(userID, backupCodeCount)
+	if err != nil {
+		return nil, fmt.Errorf("generate backup codes: %w", err)
+	}
+
+	// Persist the secret (unconfirmed).
+	now := time.Now().UTC()
+	secret := &domain.MFASecret{
+		ID:        uuid.New().String(),
+		UserID:    userID,
+		Type:      "totp",
+		Secret:    key.Secret(),
+		Confirmed: false,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	if _, err := s.repo.SaveSecret(ctx, secret); err != nil {
+		return nil, fmt.Errorf("save mfa secret: %w", err)
+	}
+
+	// Persist hashed backup codes.
+	if err := s.repo.SaveBackupCodes(ctx, userID, hashedCodes); err != nil {
+		return nil, fmt.Errorf("save backup codes: %w", err)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     "mfa_enroll_start",
+		ActorID:  userID,
+		TargetID: userID,
+	})
+
+	return &EnrollmentResult{
+		Secret:      key.Secret(),
+		QRCodeURI:   key.URL(),
+		BackupCodes: plaintextCodes,
+	}, nil
+}
+
+// ConfirmEnrollment activates MFA after the user provides a valid TOTP code,
+// proving they have configured their authenticator app.
+func (s *Service) ConfirmEnrollment(ctx context.Context, userID, code string) error {
+	secret, err := s.repo.GetSecret(ctx, userID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return ErrMFANotEnrolled
+		}
+		return fmt.Errorf("get mfa secret: %w", err)
+	}
+
+	if secret.Confirmed {
+		return ErrMFAAlreadyEnrolled
+	}
+
+	if !validateTOTP(secret.Secret, code) {
+		return ErrInvalidTOTP
+	}
+
+	if err := s.repo.ConfirmSecret(ctx, userID); err != nil {
+		return fmt.Errorf("confirm mfa secret: %w", err)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     "mfa_enroll_confirm",
+		ActorID:  userID,
+		TargetID: userID,
+	})
+
+	return nil
+}
+
+// VerifyTOTP validates a TOTP code during login. It enforces rate limiting
+// via the RateLimiter and clears failed attempts on success.
+func (s *Service) VerifyTOTP(ctx context.Context, userID, code string) error {
+	secret, err := s.repo.GetSecret(ctx, userID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return ErrMFANotEnrolled
+		}
+		return fmt.Errorf("get mfa secret: %w", err)
+	}
+
+	if !secret.Confirmed {
+		return ErrMFANotConfirmed
+	}
+
+	if !validateTOTP(secret.Secret, code) {
+		if _, rateLimitErr := s.limiter.RecordFailedAttempt(ctx, userID); rateLimitErr != nil {
+			if errors.Is(rateLimitErr, storage.ErrMFAMaxAttempts) {
+				return ErrMaxAttempts
+			}
+			s.logger.Error("failed to record mfa attempt", zap.Error(rateLimitErr))
+		}
+		return ErrInvalidTOTP
+	}
+
+	// Clear failed attempts on success.
+	if err := s.limiter.ClearFailedAttempts(ctx, userID); err != nil {
+		s.logger.Error("failed to clear mfa attempts", zap.Error(err))
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     "mfa_verify_success",
+		ActorID:  userID,
+		TargetID: userID,
+	})
+
+	return nil
+}
+
+// VerifyBackupCode validates and consumes a single-use backup code.
+// Rate limiting applies the same as TOTP verification.
+func (s *Service) VerifyBackupCode(ctx context.Context, userID, code string) error {
+	secret, err := s.repo.GetSecret(ctx, userID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return ErrMFANotEnrolled
+		}
+		return fmt.Errorf("get mfa secret: %w", err)
+	}
+
+	if !secret.Confirmed {
+		return ErrMFANotConfirmed
+	}
+
+	codeHash := hashBackupCode(strings.ToLower(strings.TrimSpace(code)))
+
+	if err := s.repo.ConsumeBackupCode(ctx, userID, codeHash); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			if _, rateLimitErr := s.limiter.RecordFailedAttempt(ctx, userID); rateLimitErr != nil {
+				if errors.Is(rateLimitErr, storage.ErrMFAMaxAttempts) {
+					return ErrMaxAttempts
+				}
+				s.logger.Error("failed to record mfa attempt", zap.Error(rateLimitErr))
+			}
+			return ErrInvalidBackupCode
+		}
+		return fmt.Errorf("consume backup code: %w", err)
+	}
+
+	// Clear failed attempts on success.
+	if err := s.limiter.ClearFailedAttempts(ctx, userID); err != nil {
+		s.logger.Error("failed to clear mfa attempts", zap.Error(err))
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     "mfa_backup_code_used",
+		ActorID:  userID,
+		TargetID: userID,
+	})
+
+	return nil
+}
+
+// GetStatus returns the MFA enrollment status for a user.
+func (s *Service) GetStatus(ctx context.Context, userID string) (*domain.MFAStatus, error) {
+	status, err := s.repo.GetMFAStatus(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get mfa status: %w", err)
+	}
+	return status, nil
+}
+
+// DisableMFA soft-deletes the user's MFA secret (deactivates MFA).
+func (s *Service) DisableMFA(ctx context.Context, userID string) error {
+	if err := s.repo.DeleteSecret(ctx, userID); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return ErrMFANotEnrolled
+		}
+		return fmt.Errorf("delete mfa secret: %w", err)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     "mfa_disabled",
+		ActorID:  userID,
+		TargetID: userID,
+	})
+
+	return nil
+}
+
+// validateTOTP checks a TOTP code against the stored secret.
+func validateTOTP(secret, code string) bool {
+	valid, _ := totp.ValidateCustom(code, secret, time.Now().UTC(), totp.ValidateOpts{
+		Digits:    otp.DigitsSix,
+		Algorithm: otp.AlgorithmSHA1,
+		Period:    totpPeriod,
+		Skew:     1, // allow ±1 time step (±30s drift)
+	})
+	return valid
+}
+
+// hashBackupCode returns the SHA-256 hex digest of a backup code.
+func hashBackupCode(code string) string {
+	h := sha256.Sum256([]byte(code))
+	return hex.EncodeToString(h[:])
+}
+
+// generateBackupCodes creates n random backup codes and their SHA-256 hashes.
+func generateBackupCodes(userID string, n int) (plaintext []string, hashed []domain.BackupCode, err error) {
+	plaintext = make([]string, n)
+	hashed = make([]domain.BackupCode, n)
+	now := time.Now().UTC()
+
+	for i := 0; i < n; i++ {
+		code, err := randomCode(backupCodeLength)
+		if err != nil {
+			return nil, nil, fmt.Errorf("generate backup code %d: %w", i, err)
+		}
+		plaintext[i] = code
+		hashed[i] = domain.BackupCode{
+			ID:        uuid.New().String(),
+			UserID:    userID,
+			CodeHash:  hashBackupCode(code),
+			Used:      false,
+			CreatedAt: now,
+		}
+	}
+	return plaintext, hashed, nil
+}
+
+// randomCode generates a cryptographically random alphanumeric string of length n.
+func randomCode(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("crypto/rand: %w", err)
+	}
+	for i := range b {
+		b[i] = backupCodeAlphabet[int(b[i])%len(backupCodeAlphabet)]
+	}
+	return string(b), nil
+}

--- a/internal/mfa/service_test.go
+++ b/internal/mfa/service_test.go
@@ -1,0 +1,719 @@
+package mfa
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/audit"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+// --- Mocks ---
+
+type mockMFARepo struct {
+	secret      *domain.MFASecret
+	backupCodes []domain.BackupCode
+	confirmed   bool
+	deleted     bool
+
+	saveSecretErr      error
+	getSecretErr       error
+	confirmSecretErr   error
+	deleteSecretErr    error
+	saveBackupErr      error
+	getBackupErr       error
+	consumeBackupErr   error
+	getMFAStatusErr    error
+	consumeBackupHash  string // last hash passed to ConsumeBackupCode
+}
+
+func (m *mockMFARepo) SaveSecret(_ context.Context, secret *domain.MFASecret) (*domain.MFASecret, error) {
+	if m.saveSecretErr != nil {
+		return nil, m.saveSecretErr
+	}
+	m.secret = secret
+	return secret, nil
+}
+
+func (m *mockMFARepo) GetSecret(_ context.Context, _ string) (*domain.MFASecret, error) {
+	// If a secret has been saved, return it regardless of initial getSecretErr.
+	if m.secret != nil {
+		return m.secret, nil
+	}
+	if m.getSecretErr != nil {
+		return nil, m.getSecretErr
+	}
+	return nil, storage.ErrNotFound
+}
+
+func (m *mockMFARepo) ConfirmSecret(_ context.Context, _ string) error {
+	if m.confirmSecretErr != nil {
+		return m.confirmSecretErr
+	}
+	if m.secret != nil {
+		m.secret.Confirmed = true
+		now := time.Now().UTC()
+		m.secret.ConfirmedAt = &now
+	}
+	m.confirmed = true
+	return nil
+}
+
+func (m *mockMFARepo) DeleteSecret(_ context.Context, _ string) error {
+	if m.deleteSecretErr != nil {
+		return m.deleteSecretErr
+	}
+	if m.secret == nil {
+		return storage.ErrNotFound
+	}
+	m.deleted = true
+	m.secret = nil
+	return nil
+}
+
+func (m *mockMFARepo) SaveBackupCodes(_ context.Context, _ string, codes []domain.BackupCode) error {
+	if m.saveBackupErr != nil {
+		return m.saveBackupErr
+	}
+	m.backupCodes = codes
+	return nil
+}
+
+func (m *mockMFARepo) GetBackupCodes(_ context.Context, _ string) ([]domain.BackupCode, error) {
+	if m.getBackupErr != nil {
+		return nil, m.getBackupErr
+	}
+	return m.backupCodes, nil
+}
+
+func (m *mockMFARepo) ConsumeBackupCode(_ context.Context, _ string, codeHash string) error {
+	if m.consumeBackupErr != nil {
+		return m.consumeBackupErr
+	}
+	m.consumeBackupHash = codeHash
+	for i, c := range m.backupCodes {
+		if c.CodeHash == codeHash && !c.Used {
+			m.backupCodes[i].Used = true
+			now := time.Now().UTC()
+			m.backupCodes[i].UsedAt = &now
+			return nil
+		}
+	}
+	return storage.ErrNotFound
+}
+
+func (m *mockMFARepo) GetMFAStatus(_ context.Context, _ string) (*domain.MFAStatus, error) {
+	if m.getMFAStatusErr != nil {
+		return nil, m.getMFAStatusErr
+	}
+	status := &domain.MFAStatus{
+		UserID: "test-user",
+	}
+	if m.secret != nil {
+		status.Enabled = m.secret.Confirmed
+		status.Type = m.secret.Type
+		status.Confirmed = m.secret.Confirmed
+	}
+	unused := 0
+	for _, c := range m.backupCodes {
+		if !c.Used {
+			unused++
+		}
+	}
+	status.BackupLeft = unused
+	return status, nil
+}
+
+type mockRateLimiter struct {
+	attempts    int
+	maxAttempts int
+	clearErr    error
+	recordErr   error
+}
+
+func newMockRateLimiter(max int) *mockRateLimiter {
+	return &mockRateLimiter{maxAttempts: max}
+}
+
+func (m *mockRateLimiter) RecordFailedAttempt(_ context.Context, _ string) (int, error) {
+	if m.recordErr != nil {
+		return 0, m.recordErr
+	}
+	m.attempts++
+	if m.attempts >= m.maxAttempts {
+		return m.attempts, storage.ErrMFAMaxAttempts
+	}
+	return m.attempts, nil
+}
+
+func (m *mockRateLimiter) ClearFailedAttempts(_ context.Context, _ string) error {
+	if m.clearErr != nil {
+		return m.clearErr
+	}
+	m.attempts = 0
+	return nil
+}
+
+// --- Helpers ---
+
+func newTestService(repo *mockMFARepo, limiter *mockRateLimiter) *Service {
+	return NewService(repo, limiter, zap.NewNop(), audit.NopLogger{})
+}
+
+func enrollTestUser(t *testing.T, svc *Service, repo *mockMFARepo) *EnrollmentResult {
+	t.Helper()
+	result, err := svc.EnrollTOTP(context.Background(), "test-user")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	return result
+}
+
+func generateValidCode(t *testing.T, secret string) string {
+	t.Helper()
+	code, err := totp.GenerateCode(secret, time.Now().UTC())
+	require.NoError(t, err)
+	return code
+}
+
+// --- Tests ---
+
+func TestEnrollTOTP(t *testing.T) {
+	t.Run("successful enrollment", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		svc := newTestService(repo, newMockRateLimiter(5))
+
+		result, err := svc.EnrollTOTP(context.Background(), "test-user")
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.NotEmpty(t, result.Secret)
+		assert.Contains(t, result.QRCodeURI, "otpauth://totp/")
+		assert.Contains(t, result.QRCodeURI, "QuantFlow")
+		assert.Len(t, result.BackupCodes, backupCodeCount)
+
+		// Verify backup codes are 8-char lowercase alphanumeric.
+		for _, code := range result.BackupCodes {
+			assert.Len(t, code, backupCodeLength)
+			for _, c := range code {
+				assert.Contains(t, backupCodeAlphabet, string(c))
+			}
+		}
+
+		// Verify secret was saved unconfirmed.
+		assert.NotNil(t, repo.secret)
+		assert.False(t, repo.secret.Confirmed)
+		assert.Equal(t, "totp", repo.secret.Type)
+
+		// Verify backup codes were persisted (hashed).
+		assert.Len(t, repo.backupCodes, backupCodeCount)
+		for i, bc := range repo.backupCodes {
+			expectedHash := hashBackupCode(result.BackupCodes[i])
+			assert.Equal(t, expectedHash, bc.CodeHash)
+			assert.False(t, bc.Used)
+		}
+	})
+
+	t.Run("already enrolled", func(t *testing.T) {
+		repo := &mockMFARepo{
+			secret: &domain.MFASecret{
+				ID:        "existing",
+				UserID:    "test-user",
+				Type:      "totp",
+				Confirmed: true,
+			},
+		}
+		svc := newTestService(repo, newMockRateLimiter(5))
+
+		result, err := svc.EnrollTOTP(context.Background(), "test-user")
+
+		assert.ErrorIs(t, err, ErrMFAAlreadyEnrolled)
+		assert.Nil(t, result)
+	})
+
+	t.Run("repo error on check", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: errors.New("db down")}
+		svc := newTestService(repo, newMockRateLimiter(5))
+
+		result, err := svc.EnrollTOTP(context.Background(), "test-user")
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "check existing mfa")
+		assert.Nil(t, result)
+	})
+
+	t.Run("save secret error", func(t *testing.T) {
+		repo := &mockMFARepo{
+			getSecretErr:  storage.ErrNotFound,
+			saveSecretErr: errors.New("db write failed"),
+		}
+		svc := newTestService(repo, newMockRateLimiter(5))
+
+		result, err := svc.EnrollTOTP(context.Background(), "test-user")
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "save mfa secret")
+		assert.Nil(t, result)
+	})
+
+	t.Run("save backup codes error", func(t *testing.T) {
+		repo := &mockMFARepo{
+			getSecretErr:  storage.ErrNotFound,
+			saveBackupErr: errors.New("db write failed"),
+		}
+		svc := newTestService(repo, newMockRateLimiter(5))
+
+		result, err := svc.EnrollTOTP(context.Background(), "test-user")
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "save backup codes")
+		assert.Nil(t, result)
+	})
+}
+
+func TestConfirmEnrollment(t *testing.T) {
+	t.Run("successful confirmation", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		svc := newTestService(repo, newMockRateLimiter(5))
+
+		result := enrollTestUser(t, svc, repo)
+
+		code := generateValidCode(t, result.Secret)
+		err := svc.ConfirmEnrollment(context.Background(), "test-user", code)
+
+		require.NoError(t, err)
+		assert.True(t, repo.confirmed)
+		assert.True(t, repo.secret.Confirmed)
+	})
+
+	t.Run("invalid code", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		svc := newTestService(repo, newMockRateLimiter(5))
+		enrollTestUser(t, svc, repo)
+
+		err := svc.ConfirmEnrollment(context.Background(), "test-user", "000000")
+
+		assert.ErrorIs(t, err, ErrInvalidTOTP)
+	})
+
+	t.Run("no enrollment", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		svc := newTestService(repo, newMockRateLimiter(5))
+
+		err := svc.ConfirmEnrollment(context.Background(), "test-user", "123456")
+
+		assert.ErrorIs(t, err, ErrMFANotEnrolled)
+	})
+
+	t.Run("already confirmed", func(t *testing.T) {
+		repo := &mockMFARepo{
+			secret: &domain.MFASecret{
+				UserID:    "test-user",
+				Secret:    "JBSWY3DPEHPK3PXP",
+				Confirmed: true,
+			},
+		}
+		svc := newTestService(repo, newMockRateLimiter(5))
+
+		err := svc.ConfirmEnrollment(context.Background(), "test-user", "123456")
+
+		assert.ErrorIs(t, err, ErrMFAAlreadyEnrolled)
+	})
+
+	t.Run("confirm secret repo error", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		svc := newTestService(repo, newMockRateLimiter(5))
+
+		result := enrollTestUser(t, svc, repo)
+		repo.confirmSecretErr = errors.New("db error")
+
+		code := generateValidCode(t, result.Secret)
+		err := svc.ConfirmEnrollment(context.Background(), "test-user", code)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "confirm mfa secret")
+	})
+}
+
+func TestVerifyTOTP(t *testing.T) {
+	t.Run("successful verification", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		limiter := newMockRateLimiter(5)
+		svc := newTestService(repo, limiter)
+
+		result := enrollTestUser(t, svc, repo)
+
+		// Confirm enrollment first.
+		code := generateValidCode(t, result.Secret)
+		require.NoError(t, svc.ConfirmEnrollment(context.Background(), "test-user", code))
+
+		// Verify TOTP.
+		code2 := generateValidCode(t, result.Secret)
+		err := svc.VerifyTOTP(context.Background(), "test-user", code2)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid code increments failed attempts", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		limiter := newMockRateLimiter(5)
+		svc := newTestService(repo, limiter)
+
+		result := enrollTestUser(t, svc, repo)
+		code := generateValidCode(t, result.Secret)
+		require.NoError(t, svc.ConfirmEnrollment(context.Background(), "test-user", code))
+
+		err := svc.VerifyTOTP(context.Background(), "test-user", "000000")
+
+		assert.ErrorIs(t, err, ErrInvalidTOTP)
+		assert.Equal(t, 1, limiter.attempts)
+	})
+
+	t.Run("max attempts exceeded", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		limiter := newMockRateLimiter(3)
+		svc := newTestService(repo, limiter)
+
+		result := enrollTestUser(t, svc, repo)
+		code := generateValidCode(t, result.Secret)
+		require.NoError(t, svc.ConfirmEnrollment(context.Background(), "test-user", code))
+
+		// Exhaust attempts.
+		for i := 0; i < 2; i++ {
+			err := svc.VerifyTOTP(context.Background(), "test-user", "000000")
+			assert.ErrorIs(t, err, ErrInvalidTOTP)
+		}
+
+		// Third attempt triggers rate limit.
+		err := svc.VerifyTOTP(context.Background(), "test-user", "000000")
+		assert.ErrorIs(t, err, ErrMaxAttempts)
+	})
+
+	t.Run("not enrolled", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		svc := newTestService(repo, newMockRateLimiter(5))
+
+		err := svc.VerifyTOTP(context.Background(), "test-user", "123456")
+
+		assert.ErrorIs(t, err, ErrMFANotEnrolled)
+	})
+
+	t.Run("not confirmed", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		svc := newTestService(repo, newMockRateLimiter(5))
+		enrollTestUser(t, svc, repo)
+
+		err := svc.VerifyTOTP(context.Background(), "test-user", "123456")
+
+		assert.ErrorIs(t, err, ErrMFANotConfirmed)
+	})
+
+	t.Run("successful verification clears failed attempts", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		limiter := newMockRateLimiter(5)
+		svc := newTestService(repo, limiter)
+
+		result := enrollTestUser(t, svc, repo)
+		code := generateValidCode(t, result.Secret)
+		require.NoError(t, svc.ConfirmEnrollment(context.Background(), "test-user", code))
+
+		// Fail once.
+		_ = svc.VerifyTOTP(context.Background(), "test-user", "000000")
+		assert.Equal(t, 1, limiter.attempts)
+
+		// Succeed — attempts should be cleared.
+		code2 := generateValidCode(t, result.Secret)
+		err := svc.VerifyTOTP(context.Background(), "test-user", code2)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, limiter.attempts)
+	})
+}
+
+func TestVerifyBackupCode(t *testing.T) {
+	t.Run("successful verification and consumption", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		limiter := newMockRateLimiter(5)
+		svc := newTestService(repo, limiter)
+
+		result := enrollTestUser(t, svc, repo)
+		code := generateValidCode(t, result.Secret)
+		require.NoError(t, svc.ConfirmEnrollment(context.Background(), "test-user", code))
+
+		// Use first backup code.
+		err := svc.VerifyBackupCode(context.Background(), "test-user", result.BackupCodes[0])
+
+		assert.NoError(t, err)
+		// Verify the code was consumed (marked as used).
+		assert.True(t, repo.backupCodes[0].Used)
+	})
+
+	t.Run("single-use enforcement", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		limiter := newMockRateLimiter(5)
+		svc := newTestService(repo, limiter)
+
+		result := enrollTestUser(t, svc, repo)
+		code := generateValidCode(t, result.Secret)
+		require.NoError(t, svc.ConfirmEnrollment(context.Background(), "test-user", code))
+
+		// Use backup code once.
+		backupCode := result.BackupCodes[0]
+		err := svc.VerifyBackupCode(context.Background(), "test-user", backupCode)
+		require.NoError(t, err)
+
+		// Try to use same code again — should fail.
+		err = svc.VerifyBackupCode(context.Background(), "test-user", backupCode)
+		assert.ErrorIs(t, err, ErrInvalidBackupCode)
+	})
+
+	t.Run("invalid backup code", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		limiter := newMockRateLimiter(5)
+		svc := newTestService(repo, limiter)
+
+		result := enrollTestUser(t, svc, repo)
+		code := generateValidCode(t, result.Secret)
+		require.NoError(t, svc.ConfirmEnrollment(context.Background(), "test-user", code))
+
+		err := svc.VerifyBackupCode(context.Background(), "test-user", "invalidcode")
+
+		assert.ErrorIs(t, err, ErrInvalidBackupCode)
+		assert.Equal(t, 1, limiter.attempts)
+	})
+
+	t.Run("max attempts via backup code", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		limiter := newMockRateLimiter(3)
+		svc := newTestService(repo, limiter)
+
+		result := enrollTestUser(t, svc, repo)
+		code := generateValidCode(t, result.Secret)
+		require.NoError(t, svc.ConfirmEnrollment(context.Background(), "test-user", code))
+
+		// Exhaust attempts with invalid codes.
+		for i := 0; i < 2; i++ {
+			_ = svc.VerifyBackupCode(context.Background(), "test-user", "badcode")
+		}
+
+		err := svc.VerifyBackupCode(context.Background(), "test-user", "badcode")
+		assert.ErrorIs(t, err, ErrMaxAttempts)
+	})
+
+	t.Run("not enrolled", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		svc := newTestService(repo, newMockRateLimiter(5))
+
+		err := svc.VerifyBackupCode(context.Background(), "test-user", "somecode")
+
+		assert.ErrorIs(t, err, ErrMFANotEnrolled)
+	})
+
+	t.Run("not confirmed", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		svc := newTestService(repo, newMockRateLimiter(5))
+		enrollTestUser(t, svc, repo)
+
+		err := svc.VerifyBackupCode(context.Background(), "test-user", "somecode")
+
+		assert.ErrorIs(t, err, ErrMFANotConfirmed)
+	})
+
+	t.Run("case insensitive and trimmed", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		limiter := newMockRateLimiter(5)
+		svc := newTestService(repo, limiter)
+
+		result := enrollTestUser(t, svc, repo)
+		code := generateValidCode(t, result.Secret)
+		require.NoError(t, svc.ConfirmEnrollment(context.Background(), "test-user", code))
+
+		// Backup codes are lowercase, try with uppercase + spaces.
+		backupCode := result.BackupCodes[0]
+		err := svc.VerifyBackupCode(context.Background(), "test-user", "  "+strings.ToUpper(backupCode)+"  ")
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("successful verification clears failed attempts", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		limiter := newMockRateLimiter(5)
+		svc := newTestService(repo, limiter)
+
+		result := enrollTestUser(t, svc, repo)
+		code := generateValidCode(t, result.Secret)
+		require.NoError(t, svc.ConfirmEnrollment(context.Background(), "test-user", code))
+
+		// Fail once.
+		_ = svc.VerifyBackupCode(context.Background(), "test-user", "badcode")
+		assert.Equal(t, 1, limiter.attempts)
+
+		// Succeed.
+		err := svc.VerifyBackupCode(context.Background(), "test-user", result.BackupCodes[0])
+		assert.NoError(t, err)
+		assert.Equal(t, 0, limiter.attempts)
+	})
+}
+
+func TestDisableMFA(t *testing.T) {
+	t.Run("successful disable", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		svc := newTestService(repo, newMockRateLimiter(5))
+		enrollTestUser(t, svc, repo)
+
+		err := svc.DisableMFA(context.Background(), "test-user")
+
+		assert.NoError(t, err)
+		assert.True(t, repo.deleted)
+	})
+
+	t.Run("not enrolled", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		svc := newTestService(repo, newMockRateLimiter(5))
+
+		err := svc.DisableMFA(context.Background(), "test-user")
+
+		assert.ErrorIs(t, err, ErrMFANotEnrolled)
+	})
+
+	t.Run("repo error", func(t *testing.T) {
+		repo := &mockMFARepo{
+			secret:          &domain.MFASecret{UserID: "test-user"},
+			deleteSecretErr: errors.New("db error"),
+		}
+		svc := newTestService(repo, newMockRateLimiter(5))
+
+		err := svc.DisableMFA(context.Background(), "test-user")
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "delete mfa secret")
+	})
+}
+
+func TestGetStatus(t *testing.T) {
+	t.Run("no enrollment", func(t *testing.T) {
+		repo := &mockMFARepo{}
+		svc := newTestService(repo, newMockRateLimiter(5))
+
+		status, err := svc.GetStatus(context.Background(), "test-user")
+
+		require.NoError(t, err)
+		assert.False(t, status.Enabled)
+		assert.Empty(t, status.Type)
+	})
+
+	t.Run("enrolled and confirmed", func(t *testing.T) {
+		repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+		svc := newTestService(repo, newMockRateLimiter(5))
+
+		result := enrollTestUser(t, svc, repo)
+		code := generateValidCode(t, result.Secret)
+		require.NoError(t, svc.ConfirmEnrollment(context.Background(), "test-user", code))
+
+		status, err := svc.GetStatus(context.Background(), "test-user")
+
+		require.NoError(t, err)
+		assert.True(t, status.Enabled)
+		assert.Equal(t, "totp", status.Type)
+		assert.Equal(t, backupCodeCount, status.BackupLeft)
+	})
+
+	t.Run("repo error", func(t *testing.T) {
+		repo := &mockMFARepo{getMFAStatusErr: errors.New("db error")}
+		svc := newTestService(repo, newMockRateLimiter(5))
+
+		status, err := svc.GetStatus(context.Background(), "test-user")
+
+		assert.Error(t, err)
+		assert.Nil(t, status)
+	})
+}
+
+func TestHashBackupCode(t *testing.T) {
+	code := "abcd1234"
+	expected := sha256.Sum256([]byte(code))
+	expectedHex := hex.EncodeToString(expected[:])
+
+	assert.Equal(t, expectedHex, hashBackupCode(code))
+}
+
+func TestGenerateBackupCodes(t *testing.T) {
+	plaintext, hashed, err := generateBackupCodes("user-123", 10)
+
+	require.NoError(t, err)
+	assert.Len(t, plaintext, 10)
+	assert.Len(t, hashed, 10)
+
+	// All codes should be unique.
+	seen := make(map[string]bool)
+	for _, code := range plaintext {
+		assert.Len(t, code, backupCodeLength)
+		assert.False(t, seen[code], "duplicate backup code: %s", code)
+		seen[code] = true
+	}
+
+	// Hashes should match.
+	for i, code := range plaintext {
+		expectedHash := hashBackupCode(code)
+		assert.Equal(t, expectedHash, hashed[i].CodeHash)
+		assert.Equal(t, "user-123", hashed[i].UserID)
+		assert.False(t, hashed[i].Used)
+		assert.NotEmpty(t, hashed[i].ID)
+	}
+}
+
+func TestRandomCode(t *testing.T) {
+	code, err := randomCode(8)
+	require.NoError(t, err)
+	assert.Len(t, code, 8)
+
+	for _, c := range code {
+		assert.Contains(t, backupCodeAlphabet, string(c))
+	}
+
+	// Two codes should (almost certainly) be different.
+	code2, err := randomCode(8)
+	require.NoError(t, err)
+	assert.NotEqual(t, code, code2)
+}
+
+func TestTOTPRoundTrip(t *testing.T) {
+	// Full enrollment → confirm → verify flow.
+	repo := &mockMFARepo{getSecretErr: storage.ErrNotFound}
+	limiter := newMockRateLimiter(5)
+	svc := newTestService(repo, limiter)
+
+	// Enroll.
+	result, err := svc.EnrollTOTP(context.Background(), "test-user")
+	require.NoError(t, err)
+
+	// Confirm with valid TOTP code.
+	code := generateValidCode(t, result.Secret)
+	require.NoError(t, svc.ConfirmEnrollment(context.Background(), "test-user", code))
+
+	// Verify with valid TOTP code.
+	code2 := generateValidCode(t, result.Secret)
+	require.NoError(t, svc.VerifyTOTP(context.Background(), "test-user", code2))
+
+	// Verify backup code works.
+	require.NoError(t, svc.VerifyBackupCode(context.Background(), "test-user", result.BackupCodes[0]))
+
+	// Same backup code fails on second use.
+	err = svc.VerifyBackupCode(context.Background(), "test-user", result.BackupCodes[0])
+	assert.ErrorIs(t, err, ErrInvalidBackupCode)
+
+	// Different backup code still works.
+	require.NoError(t, svc.VerifyBackupCode(context.Background(), "test-user", result.BackupCodes[1]))
+
+	// Disable MFA.
+	require.NoError(t, svc.DisableMFA(context.Background(), "test-user"))
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-240.

Closes #240

## Changes

TOTP service and backup codes — Build the core MFA business logic in the `internal/mfa/` package (currently a stub). Implement `EnrollTOTP(ctx, userID)` generating a 160-bit secret via `pquerna/otp`, returning QR code URI + 10 plaintext backup codes. Implement `ConfirmEnrollment(ctx, userID, code)` to activate MFA after first valid TOTP. Implement `VerifyTOTP(ctx, userID, code)` for login-time validation (SHA-1, 30s period, 6 digits). Implement backup code generation (8-char alphanumeric, SHA-256 hashed before storage) and `VerifyBackupCode(ctx, userID, code)` with single-use consumption. Wire to the existing `MFARepository` and `RedisMFAStore` interfaces. Include comprehensive unit tests (table-driven, >90% coverage): enrollment flow, TOTP round-trip, backup code single-use enforcement, rate limiting via Redis failed attempts.