### PR TITLE
GH-241: `internal/api/` + `internal/domain/`

### DIFF
--- a/internal/api/admin_mfa_handlers.go
+++ b/internal/api/admin_mfa_handlers.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// AdminMFAHandlers groups HTTP handlers for admin MFA management endpoints.
+type AdminMFAHandlers struct {
+	mfa AdminMFAService
+}
+
+// NewAdminMFAHandlers creates a new AdminMFAHandlers with the given AdminMFAService.
+func NewAdminMFAHandlers(mfa AdminMFAService) *AdminMFAHandlers {
+	return &AdminMFAHandlers{mfa: mfa}
+}
+
+// GetStatus handles GET /admin/users/:id/mfa.
+// Returns the MFA enrollment status for a specific user.
+func (h *AdminMFAHandlers) GetStatus(c *gin.Context) {
+	userID := c.Param("id")
+
+	status, err := h.mfa.GetMFAStatus(c.Request.Context(), userID)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, status)
+}
+
+// Reset handles DELETE /admin/users/:id/mfa.
+// Resets (disables) MFA for a specific user.
+func (h *AdminMFAHandlers) Reset(c *gin.Context) {
+	userID := c.Param("id")
+
+	if err := h.mfa.ResetMFA(c.Request.Context(), userID); err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "MFA reset"})
+}

--- a/internal/api/admin_mfa_handlers_test.go
+++ b/internal/api/admin_mfa_handlers_test.go
@@ -1,0 +1,141 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/health"
+)
+
+// --- Mock AdminMFAService ---
+
+type mockAdminMFAService struct {
+	getMFAStatusFn func(ctx context.Context, userID string) (*api.AdminMFAStatus, error)
+	resetMFAFn     func(ctx context.Context, userID string) error
+}
+
+func (m *mockAdminMFAService) GetMFAStatus(ctx context.Context, userID string) (*api.AdminMFAStatus, error) {
+	if m.getMFAStatusFn != nil {
+		return m.getMFAStatusFn(ctx, userID)
+	}
+	return &api.AdminMFAStatus{
+		UserID:     userID,
+		Enabled:    true,
+		Type:       "totp",
+		Confirmed:  true,
+		BackupLeft: 8,
+	}, nil
+}
+
+func (m *mockAdminMFAService) ResetMFA(ctx context.Context, userID string) error {
+	if m.resetMFAFn != nil {
+		return m.resetMFAFn(ctx, userID)
+	}
+	return nil
+}
+
+// --- Helper ---
+
+func newAdminMFARouter(mfaSvc api.AdminMFAService) *gin.Engine {
+	svc := &api.AdminServices{MFA: mfaSvc}
+	return api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+}
+
+// --- GetStatus tests ---
+
+func TestAdminMFAGetStatus_Success(t *testing.T) {
+	r := newAdminMFARouter(&mockAdminMFAService{})
+	w := doRequest(r, http.MethodGet, "/admin/users/user-42/mfa", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminMFAStatus
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "user-42", resp.UserID)
+	assert.True(t, resp.Enabled)
+	assert.Equal(t, "totp", resp.Type)
+	assert.True(t, resp.Confirmed)
+	assert.Equal(t, 8, resp.BackupLeft)
+}
+
+func TestAdminMFAGetStatus_NotFound(t *testing.T) {
+	svc := &mockAdminMFAService{
+		getMFAStatusFn: func(_ context.Context, _ string) (*api.AdminMFAStatus, error) {
+			return nil, fmt.Errorf("user not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminMFARouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/users/nonexistent/mfa", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestAdminMFAGetStatus_ServiceError(t *testing.T) {
+	svc := &mockAdminMFAService{
+		getMFAStatusFn: func(_ context.Context, _ string) (*api.AdminMFAStatus, error) {
+			return nil, fmt.Errorf("db failure: %w", api.ErrInternalError)
+		},
+	}
+	r := newAdminMFARouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/users/user-42/mfa", nil)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- Reset tests ---
+
+func TestAdminMFAReset_Success(t *testing.T) {
+	r := newAdminMFARouter(&mockAdminMFAService{})
+	w := doRequest(r, http.MethodDelete, "/admin/users/user-42/mfa", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "MFA reset", resp["message"])
+}
+
+func TestAdminMFAReset_NotFound(t *testing.T) {
+	svc := &mockAdminMFAService{
+		resetMFAFn: func(_ context.Context, _ string) error {
+			return fmt.Errorf("user not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminMFARouter(svc)
+	w := doRequest(r, http.MethodDelete, "/admin/users/nonexistent/mfa", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestAdminMFAReset_ServiceError(t *testing.T) {
+	svc := &mockAdminMFAService{
+		resetMFAFn: func(_ context.Context, _ string) error {
+			return fmt.Errorf("internal failure: %w", api.ErrInternalError)
+		},
+	}
+	r := newAdminMFARouter(svc)
+	w := doRequest(r, http.MethodDelete, "/admin/users/user-42/mfa", nil)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- Routes not registered when service is nil ---
+
+func TestAdminMFARoutes_NotRegisteredWhenNil(t *testing.T) {
+	svc := &api.AdminServices{} // MFA is nil
+	r := api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+
+	w := doRequest(r, http.MethodGet, "/admin/users/user-42/mfa", nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	w = doRequest(r, http.MethodDelete, "/admin/users/user-42/mfa", nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/internal/api/admin_router.go
+++ b/internal/api/admin_router.go
@@ -89,6 +89,13 @@ func NewAdminRouter(svc *AdminServices, deps *AdminDeps) *gin.Engine {
 		}
 	}
 
+	// MFA management (nested under /admin/users/:id).
+	if svc.MFA != nil {
+		mfaH := NewAdminMFAHandlers(svc.MFA)
+		admin.GET("/users/:id/mfa", mfaH.GetStatus)
+		admin.DELETE("/users/:id/mfa", mfaH.Reset)
+	}
+
 	// Token introspection.
 	if svc.Tokens != nil {
 		tokenH := NewAdminTokenHandlers(svc.Tokens)

--- a/internal/api/admin_services.go
+++ b/internal/api/admin_services.go
@@ -196,10 +196,26 @@ type AdminAPIKeyService interface {
 	RotateAPIKey(ctx context.Context, keyID string) (*AdminAPIKeyWithSecret, error)
 }
 
+// AdminMFAStatus represents the MFA status for a user in admin API responses.
+type AdminMFAStatus struct {
+	UserID     string `json:"user_id"`
+	Enabled    bool   `json:"enabled"`
+	Type       string `json:"type,omitempty"`
+	Confirmed  bool   `json:"confirmed"`
+	BackupLeft int    `json:"backup_codes_remaining"`
+}
+
+// AdminMFAService defines admin operations for MFA management.
+type AdminMFAService interface {
+	GetMFAStatus(ctx context.Context, userID string) (*AdminMFAStatus, error)
+	ResetMFA(ctx context.Context, userID string) error
+}
+
 // AdminServices aggregates all admin service interfaces required by admin API handlers.
 type AdminServices struct {
 	Users   AdminUserService
 	Clients AdminClientService
 	Tokens  AdminTokenService
 	APIKeys AdminAPIKeyService
+	MFA     AdminMFAService
 }

--- a/internal/api/mfa_handlers.go
+++ b/internal/api/mfa_handlers.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// MFAHandlers groups HTTP handlers for MFA endpoints.
+type MFAHandlers struct {
+	mfa MFAService
+}
+
+// NewMFAHandlers creates a new MFAHandlers with the given MFAService.
+func NewMFAHandlers(mfa MFAService) *MFAHandlers {
+	return &MFAHandlers{mfa: mfa}
+}
+
+// Enroll handles POST /auth/mfa/enroll.
+// Protected — requires authenticated user.
+// Returns the TOTP secret URI (for QR code) and backup codes.
+func (h *MFAHandlers) Enroll(c *gin.Context) {
+	userID := c.GetString("user_id")
+	if userID == "" {
+		domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized, "missing user identity")
+		return
+	}
+
+	result, err := h.mfa.Enroll(c.Request.Context(), userID)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// Confirm handles POST /auth/mfa/confirm.
+// Protected — requires authenticated user.
+// Activates a pending MFA enrollment by verifying a TOTP code.
+func (h *MFAHandlers) Confirm(c *gin.Context) {
+	userID := c.GetString("user_id")
+	if userID == "" {
+		domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized, "missing user identity")
+		return
+	}
+
+	req := c.MustGet("validated_request").(*domain.MFAConfirmRequest)
+
+	if err := h.mfa.Confirm(c.Request.Context(), userID, req.Code); err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "MFA enabled"})
+}
+
+// Verify handles POST /auth/mfa/verify.
+// Public — consumes an mfa_token (issued during login) plus a TOTP or backup code,
+// and returns a full token pair on success.
+func (h *MFAHandlers) Verify(c *gin.Context) {
+	req := c.MustGet("validated_request").(*domain.MFAVerifyRequest)
+
+	result, err := h.mfa.Verify(c.Request.Context(), req.MFAToken, req.Code)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}

--- a/internal/api/mfa_handlers_test.go
+++ b/internal/api/mfa_handlers_test.go
@@ -1,0 +1,289 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/health"
+)
+
+// --- Mock MFAService ---
+
+type mockMFAService struct {
+	enrollFn  func(ctx context.Context, userID string) (*api.MFAEnrollResult, error)
+	confirmFn func(ctx context.Context, userID, code string) error
+	verifyFn  func(ctx context.Context, mfaToken, code string) (*api.AuthResult, error)
+}
+
+func (m *mockMFAService) Enroll(ctx context.Context, userID string) (*api.MFAEnrollResult, error) {
+	if m.enrollFn != nil {
+		return m.enrollFn(ctx, userID)
+	}
+	return &api.MFAEnrollResult{
+		Secret:      "JBSWY3DPEHPK3PXP",
+		QRCodeURI:   "otpauth://totp/QuantFlow:user@example.com?secret=JBSWY3DPEHPK3PXP&issuer=QuantFlow",
+		BackupCodes: []string{"abc123", "def456", "ghi789"},
+	}, nil
+}
+
+func (m *mockMFAService) Confirm(ctx context.Context, userID, code string) error {
+	if m.confirmFn != nil {
+		return m.confirmFn(ctx, userID, code)
+	}
+	return nil
+}
+
+func (m *mockMFAService) Verify(ctx context.Context, mfaToken, code string) (*api.AuthResult, error) {
+	if m.verifyFn != nil {
+		return m.verifyFn(ctx, mfaToken, code)
+	}
+	return &api.AuthResult{
+		AccessToken:  "qf_at_mfa_verified",
+		RefreshToken: "qf_rt_mfa_verified",
+		TokenType:    "Bearer",
+		ExpiresIn:    3600,
+	}, nil
+}
+
+// --- Helper ---
+
+func newMFATestRouter(mfaSvc api.MFAService) *gin.Engine {
+	svc := &api.Services{
+		Auth:  &mockAuthService{},
+		Token: &mockTokenService{},
+		MFA:   mfaSvc,
+	}
+	authMW := func(c *gin.Context) {
+		userID := c.GetHeader("X-User-ID")
+		if userID == "" {
+			domain.RespondWithError(c, http.StatusUnauthorized, domain.CodeUnauthorized, "missing authentication")
+			return
+		}
+		c.Set("user_id", userID)
+		c.Next()
+	}
+	mw := &api.MiddlewareStack{Auth: authMW}
+	return api.NewPublicRouter(svc, mw, health.NewService())
+}
+
+// --- Enroll tests ---
+
+func TestMFAEnroll_Success(t *testing.T) {
+	r := newMFATestRouter(&mockMFAService{})
+	w := doRequest(r, http.MethodPost, "/auth/mfa/enroll", nil, "X-User-ID", "user-42")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.MFAEnrollResult
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.Secret)
+	assert.NotEmpty(t, resp.QRCodeURI)
+	assert.Len(t, resp.BackupCodes, 3)
+}
+
+func TestMFAEnroll_Unauthorized(t *testing.T) {
+	r := newMFATestRouter(&mockMFAService{})
+	w := doRequest(r, http.MethodPost, "/auth/mfa/enroll", nil)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestMFAEnroll_AlreadyEnrolled(t *testing.T) {
+	svc := &mockMFAService{
+		enrollFn: func(_ context.Context, _ string) (*api.MFAEnrollResult, error) {
+			return nil, fmt.Errorf("already enrolled: %w", api.ErrConflict)
+		},
+	}
+	r := newMFATestRouter(svc)
+	w := doRequest(r, http.MethodPost, "/auth/mfa/enroll", nil, "X-User-ID", "user-42")
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+func TestMFAEnroll_ServiceError(t *testing.T) {
+	svc := &mockMFAService{
+		enrollFn: func(_ context.Context, _ string) (*api.MFAEnrollResult, error) {
+			return nil, fmt.Errorf("internal failure: %w", api.ErrInternalError)
+		},
+	}
+	r := newMFATestRouter(svc)
+	w := doRequest(r, http.MethodPost, "/auth/mfa/enroll", nil, "X-User-ID", "user-42")
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- Confirm tests ---
+
+func TestMFAConfirm_Success(t *testing.T) {
+	r := newMFATestRouter(&mockMFAService{})
+	body := map[string]string{"code": "123456"}
+	w := doRequest(r, http.MethodPost, "/auth/mfa/confirm", body, "X-User-ID", "user-42")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "MFA enabled", resp["message"])
+}
+
+func TestMFAConfirm_Unauthorized(t *testing.T) {
+	r := newMFATestRouter(&mockMFAService{})
+	body := map[string]string{"code": "123456"}
+	w := doRequest(r, http.MethodPost, "/auth/mfa/confirm", body)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestMFAConfirm_MissingCode(t *testing.T) {
+	r := newMFATestRouter(&mockMFAService{})
+	body := map[string]string{}
+	w := doRequest(r, http.MethodPost, "/auth/mfa/confirm", body, "X-User-ID", "user-42")
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestMFAConfirm_InvalidCodeLength(t *testing.T) {
+	r := newMFATestRouter(&mockMFAService{})
+	body := map[string]string{"code": "12345"} // 5 chars, need exactly 6
+	w := doRequest(r, http.MethodPost, "/auth/mfa/confirm", body, "X-User-ID", "user-42")
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestMFAConfirm_ServiceError(t *testing.T) {
+	svc := &mockMFAService{
+		confirmFn: func(_ context.Context, _, _ string) error {
+			return fmt.Errorf("invalid code: %w", api.ErrUnauthorized)
+		},
+	}
+	r := newMFATestRouter(svc)
+	body := map[string]string{"code": "000000"}
+	w := doRequest(r, http.MethodPost, "/auth/mfa/confirm", body, "X-User-ID", "user-42")
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestMFAConfirm_InvalidJSON(t *testing.T) {
+	r := newMFATestRouter(&mockMFAService{})
+	w := doRequest(r, http.MethodPost, "/auth/mfa/confirm", nil, "X-User-ID", "user-42")
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// --- Verify tests ---
+
+func TestMFAVerify_Success(t *testing.T) {
+	r := newMFATestRouter(&mockMFAService{})
+	body := map[string]string{
+		"mfa_token": "mfa-token-123",
+		"code":      "123456",
+	}
+	w := doRequest(r, http.MethodPost, "/auth/mfa/verify", body)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AuthResult
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "qf_at_mfa_verified", resp.AccessToken)
+	assert.Equal(t, "qf_rt_mfa_verified", resp.RefreshToken)
+	assert.Equal(t, "Bearer", resp.TokenType)
+}
+
+func TestMFAVerify_WithBackupCode(t *testing.T) {
+	r := newMFATestRouter(&mockMFAService{})
+	body := map[string]string{
+		"mfa_token": "mfa-token-123",
+		"code":      "abc123def456", // 12-char backup code
+	}
+	w := doRequest(r, http.MethodPost, "/auth/mfa/verify", body)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestMFAVerify_MissingToken(t *testing.T) {
+	r := newMFATestRouter(&mockMFAService{})
+	body := map[string]string{"code": "123456"}
+	w := doRequest(r, http.MethodPost, "/auth/mfa/verify", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestMFAVerify_MissingCode(t *testing.T) {
+	r := newMFATestRouter(&mockMFAService{})
+	body := map[string]string{"mfa_token": "mfa-token-123"}
+	w := doRequest(r, http.MethodPost, "/auth/mfa/verify", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestMFAVerify_InvalidCode(t *testing.T) {
+	svc := &mockMFAService{
+		verifyFn: func(_ context.Context, _, _ string) (*api.AuthResult, error) {
+			return nil, fmt.Errorf("invalid OTP: %w", api.ErrUnauthorized)
+		},
+	}
+	r := newMFATestRouter(svc)
+	body := map[string]string{
+		"mfa_token": "mfa-token-123",
+		"code":      "000000",
+	}
+	w := doRequest(r, http.MethodPost, "/auth/mfa/verify", body)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestMFAVerify_ExpiredToken(t *testing.T) {
+	svc := &mockMFAService{
+		verifyFn: func(_ context.Context, _, _ string) (*api.AuthResult, error) {
+			return nil, fmt.Errorf("token expired: %w", api.ErrUnauthorized)
+		},
+	}
+	r := newMFATestRouter(svc)
+	body := map[string]string{
+		"mfa_token": "expired-token",
+		"code":      "123456",
+	}
+	w := doRequest(r, http.MethodPost, "/auth/mfa/verify", body)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestMFAVerify_InvalidJSON(t *testing.T) {
+	r := newMFATestRouter(&mockMFAService{})
+	w := doRequest(r, http.MethodPost, "/auth/mfa/verify", nil)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// --- MFA routes not registered when service is nil ---
+
+func TestMFARoutes_NotRegisteredWhenNil(t *testing.T) {
+	svc := &api.Services{
+		Auth:  &mockAuthService{},
+		Token: &mockTokenService{},
+		// MFA is nil
+	}
+	mw := &api.MiddlewareStack{Auth: func(c *gin.Context) {
+		c.Set("user_id", "test")
+		c.Next()
+	}}
+	r := api.NewPublicRouter(svc, mw, health.NewService())
+
+	w := doRequest(r, http.MethodPost, "/auth/mfa/enroll", nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	w = doRequest(r, http.MethodPost, "/auth/mfa/confirm", map[string]string{"code": "123456"})
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	w = doRequest(r, http.MethodPost, "/auth/mfa/verify", map[string]string{"mfa_token": "t", "code": "123456"})
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -49,6 +49,11 @@ func NewPublicRouter(svc *Services, mw *MiddlewareStack, healthSvc *health.Servi
 		sessionH = NewSessionHandlers(svc.Session)
 	}
 
+	var mfaH *MFAHandlers
+	if svc.MFA != nil {
+		mfaH = NewMFAHandlers(svc.MFA)
+	}
+
 	// Health probes (no middleware beyond global).
 	hh := newHealthHandlers(healthSvc)
 	r.GET("/health", hh.health)
@@ -69,6 +74,10 @@ func NewPublicRouter(svc *Services, mw *MiddlewareStack, healthSvc *health.Servi
 		pw := auth.Group("/password")
 		pw.POST("/reset", validateReq(v, &domain.PasswordResetRequest{}), authH.ResetPassword)
 		pw.POST("/reset/confirm", validateReq(v, &domain.PasswordResetConfirmRequest{}), authH.ConfirmPasswordReset)
+
+		if mfaH != nil {
+			auth.POST("/mfa/verify", validateReq(v, &domain.MFAVerifyRequest{}), mfaH.Verify)
+		}
 	}
 
 	// Protected auth routes (require API key or auth middleware).
@@ -93,6 +102,11 @@ func NewPublicRouter(svc *Services, mw *MiddlewareStack, healthSvc *health.Servi
 		protected.DELETE("/sessions", sessionH.DeleteAll)
 	}
 
+	if mfaH != nil {
+		protected.POST("/mfa/enroll", mfaH.Enroll)
+		protected.POST("/mfa/confirm", validateReq(v, &domain.MFAConfirmRequest{}), mfaH.Confirm)
+	}
+
 	return r
 }
 
@@ -114,6 +128,10 @@ func validateReq(v *validator.Validate, zero interface{}) gin.HandlerFunc {
 		return domain.ValidateRequest(v, func() interface{} { return &domain.PasswordResetConfirmRequest{} })
 	case *domain.PasswordChangeRequest:
 		return domain.ValidateRequest(v, func() interface{} { return &domain.PasswordChangeRequest{} })
+	case *domain.MFAConfirmRequest:
+		return domain.ValidateRequest(v, func() interface{} { return &domain.MFAConfirmRequest{} })
+	case *domain.MFAVerifyRequest:
+		return domain.ValidateRequest(v, func() interface{} { return &domain.MFAVerifyRequest{} })
 	default:
 		panic("unsupported request type for validation middleware")
 	}

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -88,12 +88,27 @@ type SessionService interface {
 	DeleteAllSessions(ctx context.Context, userID string) error
 }
 
+// MFAEnrollResult contains the data returned after initiating MFA enrollment.
+type MFAEnrollResult struct {
+	Secret      string   `json:"secret"`
+	QRCodeURI   string   `json:"qr_code_uri"`
+	BackupCodes []string `json:"backup_codes"`
+}
+
+// MFAService defines the operations for multi-factor authentication.
+type MFAService interface {
+	Enroll(ctx context.Context, userID string) (*MFAEnrollResult, error)
+	Confirm(ctx context.Context, userID, code string) error
+	Verify(ctx context.Context, mfaToken, code string) (*AuthResult, error)
+}
+
 // Services aggregates all service interfaces required by the API handlers.
 type Services struct {
 	Auth    AuthService
 	Token   TokenService
 	Session SessionService
 	DPoP    DPoPService
+	MFA     MFAService
 }
 
 // MiddlewareStack holds middleware handler functions used by the router.

--- a/internal/domain/sentinel_errors.go
+++ b/internal/domain/sentinel_errors.go
@@ -26,4 +26,12 @@ var (
 	// Authorization errors.
 	ErrInsufficientScope = errors.New("insufficient scope")
 	ErrInsufficientRole  = errors.New("insufficient role")
+
+	// MFA errors.
+	ErrMFANotEnrolled     = errors.New("MFA not enrolled")
+	ErrMFAAlreadyEnrolled = errors.New("MFA already enrolled")
+	ErrMFANotConfirmed    = errors.New("MFA enrollment not confirmed")
+	ErrInvalidOTP         = errors.New("invalid one-time password")
+	ErrInvalidBackupCode  = errors.New("invalid backup code")
+	ErrMFARequired        = errors.New("MFA verification required")
 )

--- a/internal/domain/validation.go
+++ b/internal/domain/validation.go
@@ -84,6 +84,21 @@ type VerifyEmailRequest struct {
 	Token string `json:"token" validate:"required"`
 }
 
+// MFAEnrollRequest is the validated request body for initiating MFA enrollment.
+// No body fields required — the user is identified from the auth context.
+type MFAEnrollRequest struct{}
+
+// MFAConfirmRequest is the validated request body for confirming MFA enrollment.
+type MFAConfirmRequest struct {
+	Code string `json:"code" validate:"required,len=6"`
+}
+
+// MFAVerifyRequest is the validated request body for MFA verification during login.
+type MFAVerifyRequest struct {
+	MFAToken string `json:"mfa_token" validate:"required"`
+	Code     string `json:"code"      validate:"required,min=6,max=12"`
+}
+
 // --- Validator setup ---
 
 // NewValidator creates a validator.Validate instance with custom NIST password validation registered.
@@ -174,6 +189,8 @@ func validationMessage(fe validator.FieldError) string {
 		return fmt.Sprintf("%s is required for this grant type", strings.ToLower(fe.Field()))
 	case "client_type":
 		return "must be one of: service, agent"
+	case "len":
+		return fmt.Sprintf("must be exactly %s characters", fe.Param())
 	case "valid_scope":
 		return "invalid scope"
 	default:


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-241.

Closes #241

## Changes

MFA HTTP handlers, routes, and request types — Add MFA request/response types to `internal/domain/validation.go` (enroll request, confirm request with TOTP code, verify request with mfa_token + code, admin MFA status/reset). Define an `MFAService` interface in `internal/api/services.go` and add it to the `Services` struct. Create `internal/api/mfa_handlers.go` with handlers: `POST /auth/mfa/enroll` (protected, returns QR URI + backup codes), `POST /auth/mfa/confirm` (protected, activates enrollment), `POST /auth/mfa/verify` (public, consumes mfa_token + TOTP/backup code → returns full TokenPair), `GET /admin/users/:id/mfa` (admin, returns MFA status), `DELETE /admin/users/:id/mfa` (admin, resets MFA). Register routes in `internal/api/router.go`. Include handler unit tests.