### PR TITLE
GH-246: Domain models, database migration, and storage layer

### DIFF
--- a/internal/domain/webauthn.go
+++ b/internal/domain/webauthn.go
@@ -1,0 +1,19 @@
+package domain
+
+import "time"
+
+// WebAuthnCredential represents a registered WebAuthn/FIDO2 credential for a user.
+type WebAuthnCredential struct {
+	ID              string     // unique internal identifier
+	UserID          string     // owner
+	CredentialID    []byte     // raw credential ID from the authenticator
+	PublicKey       []byte     // COSE-encoded public key
+	AAGUID          string     // authenticator attestation GUID (hex-encoded)
+	SignCount       uint32     // signature counter for clone detection
+	Transports      []string   // e.g. ["usb", "nfc", "ble", "internal"]
+	AttestationType string     // "none", "indirect", "direct", "enterprise"
+	FriendlyName    string     // user-assigned label (e.g. "YubiKey 5C")
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+	DeletedAt       *time.Time // soft-delete
+}

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -41,4 +41,10 @@ var (
 
 	// ErrMFAMaxAttempts indicates the user has exceeded maximum MFA verification attempts.
 	ErrMFAMaxAttempts = errors.New("mfa max attempts exceeded")
+
+	// ErrDuplicateWebAuthn indicates a credential with the same credential ID already exists.
+	ErrDuplicateWebAuthn = errors.New("duplicate webauthn credential")
+
+	// ErrWebAuthnChallengeNotFound indicates the WebAuthn challenge does not exist or has expired.
+	ErrWebAuthnChallengeNotFound = errors.New("webauthn challenge not found")
 )

--- a/internal/storage/postgres_webauthn_repository.go
+++ b/internal/storage/postgres_webauthn_repository.go
@@ -1,0 +1,163 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// PostgresWebAuthnRepository implements WebAuthnRepository using pgx against PostgreSQL.
+type PostgresWebAuthnRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresWebAuthnRepository creates a new PostgreSQL-backed WebAuthn credential repository.
+func NewPostgresWebAuthnRepository(pool *pgxpool.Pool) *PostgresWebAuthnRepository {
+	return &PostgresWebAuthnRepository{pool: pool}
+}
+
+// credentialColumns is the shared SELECT column list for WebAuthn credentials.
+const credentialColumns = `id, user_id, credential_id, public_key, aaguid, sign_count, transports, attestation_type, friendly_name, created_at, updated_at, deleted_at`
+
+// scanCredential scans a row into a WebAuthnCredential.
+func scanCredential(row pgx.Row) (*domain.WebAuthnCredential, error) {
+	c := &domain.WebAuthnCredential{}
+	err := row.Scan(
+		&c.ID, &c.UserID, &c.CredentialID, &c.PublicKey,
+		&c.AAGUID, &c.SignCount, &c.Transports, &c.AttestationType,
+		&c.FriendlyName, &c.CreatedAt, &c.UpdatedAt, &c.DeletedAt,
+	)
+	return c, err
+}
+
+// Create inserts a new WebAuthn credential.
+func (r *PostgresWebAuthnRepository) Create(ctx context.Context, cred *domain.WebAuthnCredential) (*domain.WebAuthnCredential, error) {
+	query := `
+		INSERT INTO webauthn_credentials (id, user_id, credential_id, public_key, aaguid, sign_count, transports, attestation_type, friendly_name, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		RETURNING ` + credentialColumns
+
+	out, err := scanCredential(r.pool.QueryRow(ctx, query,
+		cred.ID, cred.UserID, cred.CredentialID, cred.PublicKey,
+		cred.AAGUID, cred.SignCount, cred.Transports, cred.AttestationType,
+		cred.FriendlyName, cred.CreatedAt, cred.UpdatedAt,
+	))
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return nil, fmt.Errorf("credential already registered: %w", ErrDuplicateWebAuthn)
+		}
+		return nil, fmt.Errorf("insert webauthn credential: %w", err)
+	}
+
+	return out, nil
+}
+
+// GetByUser returns all active credentials for a user, ordered by creation time.
+func (r *PostgresWebAuthnRepository) GetByUser(ctx context.Context, userID string) ([]domain.WebAuthnCredential, error) {
+	query := `SELECT ` + credentialColumns + `
+		FROM webauthn_credentials
+		WHERE user_id = $1 AND deleted_at IS NULL
+		ORDER BY created_at`
+
+	rows, err := r.pool.Query(ctx, query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get webauthn credentials by user: %w", err)
+	}
+	defer rows.Close()
+
+	var creds []domain.WebAuthnCredential
+	for rows.Next() {
+		var c domain.WebAuthnCredential
+		if err := rows.Scan(
+			&c.ID, &c.UserID, &c.CredentialID, &c.PublicKey,
+			&c.AAGUID, &c.SignCount, &c.Transports, &c.AttestationType,
+			&c.FriendlyName, &c.CreatedAt, &c.UpdatedAt, &c.DeletedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan webauthn credential: %w", err)
+		}
+		creds = append(creds, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate webauthn credentials: %w", err)
+	}
+
+	return creds, nil
+}
+
+// GetByCredentialID retrieves an active credential by its raw credential ID.
+func (r *PostgresWebAuthnRepository) GetByCredentialID(ctx context.Context, credentialID []byte) (*domain.WebAuthnCredential, error) {
+	query := `SELECT ` + credentialColumns + `
+		FROM webauthn_credentials
+		WHERE credential_id = $1 AND deleted_at IS NULL`
+
+	out, err := scanCredential(r.pool.QueryRow(ctx, query, credentialID))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("credential: %w", ErrNotFound)
+		}
+		return nil, fmt.Errorf("get webauthn credential by credential_id: %w", err)
+	}
+
+	return out, nil
+}
+
+// UpdateSignCount sets the new sign count and bumps updated_at.
+func (r *PostgresWebAuthnRepository) UpdateSignCount(ctx context.Context, id string, newCount uint32) error {
+	now := time.Now().UTC()
+	query := `
+		UPDATE webauthn_credentials
+		SET sign_count = $1, updated_at = $2
+		WHERE id = $3 AND deleted_at IS NULL`
+
+	tag, err := r.pool.Exec(ctx, query, newCount, now, id)
+	if err != nil {
+		return fmt.Errorf("update webauthn sign count: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("credential %s: %w", id, ErrNotFound)
+	}
+
+	return nil
+}
+
+// Delete hard-deletes a credential row.
+func (r *PostgresWebAuthnRepository) Delete(ctx context.Context, id string) error {
+	query := `DELETE FROM webauthn_credentials WHERE id = $1`
+
+	tag, err := r.pool.Exec(ctx, query, id)
+	if err != nil {
+		return fmt.Errorf("delete webauthn credential: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("credential %s: %w", id, ErrNotFound)
+	}
+
+	return nil
+}
+
+// SoftDelete marks a credential as deleted by setting deleted_at.
+func (r *PostgresWebAuthnRepository) SoftDelete(ctx context.Context, id string) error {
+	now := time.Now().UTC()
+	query := `
+		UPDATE webauthn_credentials
+		SET deleted_at = $1, updated_at = $2
+		WHERE id = $3 AND deleted_at IS NULL`
+
+	tag, err := r.pool.Exec(ctx, query, now, now, id)
+	if err != nil {
+		return fmt.Errorf("soft-delete webauthn credential: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("credential %s: %w", id, ErrNotFound)
+	}
+
+	return nil
+}

--- a/internal/storage/redis_mfa_store.go
+++ b/internal/storage/redis_mfa_store.go
@@ -16,6 +16,9 @@ const (
 	// mfaFailedPrefix is the Redis key prefix for failed MFA attempt counters.
 	mfaFailedPrefix = "mfa:failed:"
 
+	// webauthnChallengePrefix is the Redis key prefix for WebAuthn challenge/session data.
+	webauthnChallengePrefix = "webauthn:challenge:"
+
 	// defaultMFATokenTTL is the lifetime of a temporary MFA token (5 minutes).
 	defaultMFATokenTTL = 5 * time.Minute
 
@@ -24,14 +27,19 @@ const (
 
 	// defaultMaxMFAAttempts is the maximum allowed failed MFA attempts before lockout.
 	defaultMaxMFAAttempts = 5
+
+	// defaultWebAuthnChallengeTTL is the lifetime of a WebAuthn challenge (60 seconds).
+	defaultWebAuthnChallengeTTL = 60 * time.Second
 )
 
-// RedisMFAStore manages temporary MFA tokens and failed-attempt tracking in Redis.
+// RedisMFAStore manages temporary MFA tokens, failed-attempt tracking,
+// and WebAuthn challenge/session data in Redis.
 type RedisMFAStore struct {
-	client       redis.Cmdable
-	tokenTTL     time.Duration
-	failedTTL    time.Duration
-	maxAttempts  int
+	client            redis.Cmdable
+	tokenTTL          time.Duration
+	failedTTL         time.Duration
+	maxAttempts       int
+	webauthnChallTTL  time.Duration
 }
 
 // RedisMFAStoreOption configures the RedisMFAStore.
@@ -52,13 +60,19 @@ func WithMaxMFAAttempts(n int) RedisMFAStoreOption {
 	return func(s *RedisMFAStore) { s.maxAttempts = n }
 }
 
+// WithWebAuthnChallengeTTL overrides the default WebAuthn challenge TTL.
+func WithWebAuthnChallengeTTL(d time.Duration) RedisMFAStoreOption {
+	return func(s *RedisMFAStore) { s.webauthnChallTTL = d }
+}
+
 // NewRedisMFAStore creates a new Redis-backed MFA token store.
 func NewRedisMFAStore(client redis.Cmdable, opts ...RedisMFAStoreOption) *RedisMFAStore {
 	s := &RedisMFAStore{
-		client:      client,
-		tokenTTL:    defaultMFATokenTTL,
-		failedTTL:   defaultMFAFailedTTL,
-		maxAttempts: defaultMaxMFAAttempts,
+		client:           client,
+		tokenTTL:         defaultMFATokenTTL,
+		failedTTL:        defaultMFAFailedTTL,
+		maxAttempts:      defaultMaxMFAAttempts,
+		webauthnChallTTL: defaultWebAuthnChallengeTTL,
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -143,6 +157,61 @@ func (s *RedisMFAStore) ClearFailedAttempts(ctx context.Context, userID string) 
 	key := mfaFailedPrefix + userID
 	if err := s.client.Del(ctx, key).Err(); err != nil {
 		return fmt.Errorf("clear mfa failed attempts: %w", err)
+	}
+	return nil
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// WebAuthn challenge / session data
+// ────────────────────────────────────────────────────────────────────────────
+
+// StoreWebAuthnChallenge saves WebAuthn challenge/session data keyed by session ID.
+// The data expires after the configured WebAuthn challenge TTL (default 60s).
+func (s *RedisMFAStore) StoreWebAuthnChallenge(ctx context.Context, sessionID string, data []byte) error {
+	key := webauthnChallengePrefix + sessionID
+	ok, err := s.client.SetNX(ctx, key, data, s.webauthnChallTTL).Result()
+	if err != nil {
+		return fmt.Errorf("store webauthn challenge: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("session %s: webauthn challenge already exists", sessionID)
+	}
+	return nil
+}
+
+// GetWebAuthnChallenge retrieves WebAuthn challenge/session data without consuming it.
+// Returns ErrWebAuthnChallengeNotFound if the session has expired or does not exist.
+func (s *RedisMFAStore) GetWebAuthnChallenge(ctx context.Context, sessionID string) ([]byte, error) {
+	key := webauthnChallengePrefix + sessionID
+	data, err := s.client.Get(ctx, key).Bytes()
+	if err != nil {
+		if err == redis.Nil {
+			return nil, ErrWebAuthnChallengeNotFound
+		}
+		return nil, fmt.Errorf("get webauthn challenge: %w", err)
+	}
+	return data, nil
+}
+
+// ConsumeWebAuthnChallenge retrieves and deletes the challenge data atomically.
+// Returns ErrWebAuthnChallengeNotFound if the session has expired or does not exist.
+func (s *RedisMFAStore) ConsumeWebAuthnChallenge(ctx context.Context, sessionID string) ([]byte, error) {
+	key := webauthnChallengePrefix + sessionID
+	data, err := s.client.GetDel(ctx, key).Bytes()
+	if err != nil {
+		if err == redis.Nil {
+			return nil, ErrWebAuthnChallengeNotFound
+		}
+		return nil, fmt.Errorf("consume webauthn challenge: %w", err)
+	}
+	return data, nil
+}
+
+// DeleteWebAuthnChallenge removes a WebAuthn challenge/session entry.
+func (s *RedisMFAStore) DeleteWebAuthnChallenge(ctx context.Context, sessionID string) error {
+	key := webauthnChallengePrefix + sessionID
+	if err := s.client.Del(ctx, key).Err(); err != nil {
+		return fmt.Errorf("delete webauthn challenge: %w", err)
 	}
 	return nil
 }

--- a/internal/storage/redis_mfa_store_test.go
+++ b/internal/storage/redis_mfa_store_test.go
@@ -174,3 +174,116 @@ func TestRedisMFAStore_FailedAttempts_Expire(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, count)
 }
+
+// ────────────────────────────────────────────────────────────────────────────
+// WebAuthn challenge / session data tests
+// ────────────────────────────────────────────────────────────────────────────
+
+func TestRedisMFAStore_StoreWebAuthnChallenge(t *testing.T) {
+	_, client := newTestRedis(t)
+	store := storage.NewRedisMFAStore(client)
+	ctx := context.Background()
+
+	data := []byte(`{"challenge":"abc123","user_id":"user-1"}`)
+	err := store.StoreWebAuthnChallenge(ctx, "session-001", data)
+	require.NoError(t, err)
+}
+
+func TestRedisMFAStore_StoreWebAuthnChallenge_DuplicateRejected(t *testing.T) {
+	_, client := newTestRedis(t)
+	store := storage.NewRedisMFAStore(client)
+	ctx := context.Background()
+
+	data := []byte(`{"challenge":"abc"}`)
+	err := store.StoreWebAuthnChallenge(ctx, "session-dup", data)
+	require.NoError(t, err)
+
+	err = store.StoreWebAuthnChallenge(ctx, "session-dup", []byte(`{"challenge":"xyz"}`))
+	require.Error(t, err)
+}
+
+func TestRedisMFAStore_GetWebAuthnChallenge(t *testing.T) {
+	_, client := newTestRedis(t)
+	store := storage.NewRedisMFAStore(client)
+	ctx := context.Background()
+
+	data := []byte(`{"challenge":"get-test","user_id":"user-2"}`)
+	err := store.StoreWebAuthnChallenge(ctx, "session-get", data)
+	require.NoError(t, err)
+
+	got, err := store.GetWebAuthnChallenge(ctx, "session-get")
+	require.NoError(t, err)
+	assert.Equal(t, data, got)
+}
+
+func TestRedisMFAStore_GetWebAuthnChallenge_NotFound(t *testing.T) {
+	_, client := newTestRedis(t)
+	store := storage.NewRedisMFAStore(client)
+	ctx := context.Background()
+
+	_, err := store.GetWebAuthnChallenge(ctx, "nonexistent-session")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrWebAuthnChallengeNotFound)
+}
+
+func TestRedisMFAStore_ConsumeWebAuthnChallenge(t *testing.T) {
+	_, client := newTestRedis(t)
+	store := storage.NewRedisMFAStore(client)
+	ctx := context.Background()
+
+	data := []byte(`{"challenge":"consume-test"}`)
+	err := store.StoreWebAuthnChallenge(ctx, "session-consume", data)
+	require.NoError(t, err)
+
+	got, err := store.ConsumeWebAuthnChallenge(ctx, "session-consume")
+	require.NoError(t, err)
+	assert.Equal(t, data, got)
+
+	// Second consume should fail (single-use).
+	_, err = store.ConsumeWebAuthnChallenge(ctx, "session-consume")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrWebAuthnChallengeNotFound)
+}
+
+func TestRedisMFAStore_ConsumeWebAuthnChallenge_NotFound(t *testing.T) {
+	_, client := newTestRedis(t)
+	store := storage.NewRedisMFAStore(client)
+	ctx := context.Background()
+
+	_, err := store.ConsumeWebAuthnChallenge(ctx, "nonexistent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrWebAuthnChallengeNotFound)
+}
+
+func TestRedisMFAStore_WebAuthnChallenge_Expired(t *testing.T) {
+	mr, client := newTestRedis(t)
+	store := storage.NewRedisMFAStore(client, storage.WithWebAuthnChallengeTTL(1*time.Second))
+	ctx := context.Background()
+
+	data := []byte(`{"challenge":"expire-test"}`)
+	err := store.StoreWebAuthnChallenge(ctx, "session-expire", data)
+	require.NoError(t, err)
+
+	mr.FastForward(2 * time.Second)
+
+	_, err = store.GetWebAuthnChallenge(ctx, "session-expire")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrWebAuthnChallengeNotFound)
+}
+
+func TestRedisMFAStore_DeleteWebAuthnChallenge(t *testing.T) {
+	_, client := newTestRedis(t)
+	store := storage.NewRedisMFAStore(client)
+	ctx := context.Background()
+
+	data := []byte(`{"challenge":"delete-test"}`)
+	err := store.StoreWebAuthnChallenge(ctx, "session-del", data)
+	require.NoError(t, err)
+
+	err = store.DeleteWebAuthnChallenge(ctx, "session-del")
+	require.NoError(t, err)
+
+	_, err = store.GetWebAuthnChallenge(ctx, "session-del")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrWebAuthnChallengeNotFound)
+}

--- a/internal/storage/repository_integration_test.go
+++ b/internal/storage/repository_integration_test.go
@@ -118,11 +118,29 @@ func createTables(t *testing.T, pool *pgxpool.Pool) {
 			used_at    TIMESTAMPTZ,
 			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		);
+
+		CREATE TABLE IF NOT EXISTS webauthn_credentials (
+			id               TEXT        PRIMARY KEY,
+			user_id          TEXT        NOT NULL REFERENCES users (id),
+			credential_id    BYTEA       NOT NULL,
+			public_key       BYTEA       NOT NULL,
+			aaguid           TEXT        NOT NULL DEFAULT '',
+			sign_count       INTEGER     NOT NULL DEFAULT 0,
+			transports       TEXT[]      NOT NULL DEFAULT '{}',
+			attestation_type TEXT        NOT NULL DEFAULT 'none',
+			friendly_name    TEXT        NOT NULL DEFAULT '',
+			created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			deleted_at       TIMESTAMPTZ
+		);
+
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_webauthn_credentials_credential_id_active
+			ON webauthn_credentials (credential_id) WHERE deleted_at IS NULL;
 	`)
 	require.NoError(t, err)
 
 	// Clean tables before each test file run.
-	_, err = pool.Exec(ctx, `TRUNCATE users, refresh_tokens, clients, mfa_secrets, mfa_backup_codes`)
+	_, err = pool.Exec(ctx, `TRUNCATE users, refresh_tokens, clients, mfa_secrets, mfa_backup_codes, webauthn_credentials`)
 	require.NoError(t, err)
 }
 

--- a/internal/storage/webauthn_repository.go
+++ b/internal/storage/webauthn_repository.go
@@ -1,0 +1,32 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// WebAuthnRepository defines persistence operations for WebAuthn credentials.
+type WebAuthnRepository interface {
+	// Create stores a new WebAuthn credential.
+	Create(ctx context.Context, cred *domain.WebAuthnCredential) (*domain.WebAuthnCredential, error)
+
+	// GetByUser returns all active (non-deleted) credentials for a user.
+	GetByUser(ctx context.Context, userID string) ([]domain.WebAuthnCredential, error)
+
+	// GetByCredentialID retrieves a single active credential by its raw credential ID.
+	// Returns ErrNotFound if no matching active credential exists.
+	GetByCredentialID(ctx context.Context, credentialID []byte) (*domain.WebAuthnCredential, error)
+
+	// UpdateSignCount atomically updates the signature counter for clone detection.
+	// Returns ErrNotFound if the credential does not exist or is deleted.
+	UpdateSignCount(ctx context.Context, id string, newCount uint32) error
+
+	// Delete hard-deletes a credential by internal ID.
+	// Returns ErrNotFound if the credential does not exist.
+	Delete(ctx context.Context, id string) error
+
+	// SoftDelete marks a credential as deleted without removing the row.
+	// Returns ErrNotFound if the credential is already deleted or does not exist.
+	SoftDelete(ctx context.Context, id string) error
+}

--- a/internal/storage/webauthn_repository_integration_test.go
+++ b/internal/storage/webauthn_repository_integration_test.go
@@ -1,0 +1,332 @@
+package storage_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+// ────────────────────────────────────────────────────────────────────────────
+// WebAuthnRepository integration tests
+// ────────────────────────────────────────────────────────────────────────────
+
+func newTestWebAuthnCredential(userID string) *domain.WebAuthnCredential {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	return &domain.WebAuthnCredential{
+		ID:              uuid.New().String(),
+		UserID:          userID,
+		CredentialID:    []byte("cred-" + uuid.New().String()[:8]),
+		PublicKey:       []byte("pk-" + uuid.New().String()[:8]),
+		AAGUID:          "00000000-0000-0000-0000-000000000000",
+		SignCount:       0,
+		Transports:      []string{"usb", "internal"},
+		AttestationType: "none",
+		FriendlyName:    "Test Key",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+}
+
+func TestPostgresWebAuthnRepository_Create(t *testing.T) {
+	pool := testPool(t)
+	userRepo := storage.NewPostgresUserRepository(pool)
+	repo := storage.NewPostgresWebAuthnRepository(pool)
+	ctx := context.Background()
+
+	user := newTestUser()
+	_, err := userRepo.Create(ctx, user)
+	require.NoError(t, err)
+
+	cred := newTestWebAuthnCredential(user.ID)
+	created, err := repo.Create(ctx, cred)
+	require.NoError(t, err)
+
+	assert.Equal(t, cred.ID, created.ID)
+	assert.Equal(t, cred.UserID, created.UserID)
+	assert.Equal(t, cred.CredentialID, created.CredentialID)
+	assert.Equal(t, cred.PublicKey, created.PublicKey)
+	assert.Equal(t, cred.AAGUID, created.AAGUID)
+	assert.Equal(t, uint32(0), created.SignCount)
+	assert.Equal(t, []string{"usb", "internal"}, created.Transports)
+	assert.Equal(t, "none", created.AttestationType)
+	assert.Equal(t, "Test Key", created.FriendlyName)
+	assert.Nil(t, created.DeletedAt)
+}
+
+func TestPostgresWebAuthnRepository_Create_DuplicateCredentialID(t *testing.T) {
+	pool := testPool(t)
+	userRepo := storage.NewPostgresUserRepository(pool)
+	repo := storage.NewPostgresWebAuthnRepository(pool)
+	ctx := context.Background()
+
+	user := newTestUser()
+	_, err := userRepo.Create(ctx, user)
+	require.NoError(t, err)
+
+	cred1 := newTestWebAuthnCredential(user.ID)
+	_, err = repo.Create(ctx, cred1)
+	require.NoError(t, err)
+
+	cred2 := newTestWebAuthnCredential(user.ID)
+	cred2.CredentialID = cred1.CredentialID // same credential ID
+	_, err = repo.Create(ctx, cred2)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrDuplicateWebAuthn)
+}
+
+func TestPostgresWebAuthnRepository_GetByUser(t *testing.T) {
+	pool := testPool(t)
+	userRepo := storage.NewPostgresUserRepository(pool)
+	repo := storage.NewPostgresWebAuthnRepository(pool)
+	ctx := context.Background()
+
+	user := newTestUser()
+	_, err := userRepo.Create(ctx, user)
+	require.NoError(t, err)
+
+	// Register two credentials.
+	cred1 := newTestWebAuthnCredential(user.ID)
+	cred1.FriendlyName = "Key A"
+	_, err = repo.Create(ctx, cred1)
+	require.NoError(t, err)
+
+	cred2 := newTestWebAuthnCredential(user.ID)
+	cred2.FriendlyName = "Key B"
+	_, err = repo.Create(ctx, cred2)
+	require.NoError(t, err)
+
+	creds, err := repo.GetByUser(ctx, user.ID)
+	require.NoError(t, err)
+	assert.Len(t, creds, 2)
+}
+
+func TestPostgresWebAuthnRepository_GetByUser_Empty(t *testing.T) {
+	pool := testPool(t)
+	userRepo := storage.NewPostgresUserRepository(pool)
+	repo := storage.NewPostgresWebAuthnRepository(pool)
+	ctx := context.Background()
+
+	user := newTestUser()
+	_, err := userRepo.Create(ctx, user)
+	require.NoError(t, err)
+
+	creds, err := repo.GetByUser(ctx, user.ID)
+	require.NoError(t, err)
+	assert.Empty(t, creds)
+}
+
+func TestPostgresWebAuthnRepository_GetByCredentialID(t *testing.T) {
+	pool := testPool(t)
+	userRepo := storage.NewPostgresUserRepository(pool)
+	repo := storage.NewPostgresWebAuthnRepository(pool)
+	ctx := context.Background()
+
+	user := newTestUser()
+	_, err := userRepo.Create(ctx, user)
+	require.NoError(t, err)
+
+	cred := newTestWebAuthnCredential(user.ID)
+	_, err = repo.Create(ctx, cred)
+	require.NoError(t, err)
+
+	got, err := repo.GetByCredentialID(ctx, cred.CredentialID)
+	require.NoError(t, err)
+	assert.Equal(t, cred.ID, got.ID)
+	assert.Equal(t, cred.PublicKey, got.PublicKey)
+}
+
+func TestPostgresWebAuthnRepository_GetByCredentialID_NotFound(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresWebAuthnRepository(pool)
+	ctx := context.Background()
+
+	_, err := repo.GetByCredentialID(ctx, []byte("nonexistent"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresWebAuthnRepository_UpdateSignCount(t *testing.T) {
+	pool := testPool(t)
+	userRepo := storage.NewPostgresUserRepository(pool)
+	repo := storage.NewPostgresWebAuthnRepository(pool)
+	ctx := context.Background()
+
+	user := newTestUser()
+	_, err := userRepo.Create(ctx, user)
+	require.NoError(t, err)
+
+	cred := newTestWebAuthnCredential(user.ID)
+	_, err = repo.Create(ctx, cred)
+	require.NoError(t, err)
+
+	err = repo.UpdateSignCount(ctx, cred.ID, 42)
+	require.NoError(t, err)
+
+	got, err := repo.GetByCredentialID(ctx, cred.CredentialID)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(42), got.SignCount)
+}
+
+func TestPostgresWebAuthnRepository_UpdateSignCount_NotFound(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresWebAuthnRepository(pool)
+	ctx := context.Background()
+
+	err := repo.UpdateSignCount(ctx, "nonexistent-id", 1)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresWebAuthnRepository_Delete(t *testing.T) {
+	pool := testPool(t)
+	userRepo := storage.NewPostgresUserRepository(pool)
+	repo := storage.NewPostgresWebAuthnRepository(pool)
+	ctx := context.Background()
+
+	user := newTestUser()
+	_, err := userRepo.Create(ctx, user)
+	require.NoError(t, err)
+
+	cred := newTestWebAuthnCredential(user.ID)
+	_, err = repo.Create(ctx, cred)
+	require.NoError(t, err)
+
+	err = repo.Delete(ctx, cred.ID)
+	require.NoError(t, err)
+
+	// Should not be found after hard delete.
+	_, err = repo.GetByCredentialID(ctx, cred.CredentialID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresWebAuthnRepository_Delete_NotFound(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresWebAuthnRepository(pool)
+	ctx := context.Background()
+
+	err := repo.Delete(ctx, "nonexistent-id")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresWebAuthnRepository_SoftDelete(t *testing.T) {
+	pool := testPool(t)
+	userRepo := storage.NewPostgresUserRepository(pool)
+	repo := storage.NewPostgresWebAuthnRepository(pool)
+	ctx := context.Background()
+
+	user := newTestUser()
+	_, err := userRepo.Create(ctx, user)
+	require.NoError(t, err)
+
+	cred := newTestWebAuthnCredential(user.ID)
+	_, err = repo.Create(ctx, cred)
+	require.NoError(t, err)
+
+	err = repo.SoftDelete(ctx, cred.ID)
+	require.NoError(t, err)
+
+	// Should not appear in GetByUser results.
+	creds, err := repo.GetByUser(ctx, user.ID)
+	require.NoError(t, err)
+	assert.Empty(t, creds)
+
+	// Should not be found by credential ID.
+	_, err = repo.GetByCredentialID(ctx, cred.CredentialID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresWebAuthnRepository_SoftDelete_NotFound(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresWebAuthnRepository(pool)
+	ctx := context.Background()
+
+	err := repo.SoftDelete(ctx, "nonexistent-id")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresWebAuthnRepository_SoftDelete_AllowsReregistration(t *testing.T) {
+	pool := testPool(t)
+	userRepo := storage.NewPostgresUserRepository(pool)
+	repo := storage.NewPostgresWebAuthnRepository(pool)
+	ctx := context.Background()
+
+	user := newTestUser()
+	_, err := userRepo.Create(ctx, user)
+	require.NoError(t, err)
+
+	cred := newTestWebAuthnCredential(user.ID)
+	_, err = repo.Create(ctx, cred)
+	require.NoError(t, err)
+
+	err = repo.SoftDelete(ctx, cred.ID)
+	require.NoError(t, err)
+
+	// Re-register with the same credential ID should succeed (unique index is partial).
+	cred2 := newTestWebAuthnCredential(user.ID)
+	cred2.CredentialID = cred.CredentialID
+	created, err := repo.Create(ctx, cred2)
+	require.NoError(t, err)
+	assert.Equal(t, cred2.ID, created.ID)
+}
+
+func TestPostgresWebAuthnRepository_SoftDelete_AlreadyDeleted(t *testing.T) {
+	pool := testPool(t)
+	userRepo := storage.NewPostgresUserRepository(pool)
+	repo := storage.NewPostgresWebAuthnRepository(pool)
+	ctx := context.Background()
+
+	user := newTestUser()
+	_, err := userRepo.Create(ctx, user)
+	require.NoError(t, err)
+
+	cred := newTestWebAuthnCredential(user.ID)
+	_, err = repo.Create(ctx, cred)
+	require.NoError(t, err)
+
+	err = repo.SoftDelete(ctx, cred.ID)
+	require.NoError(t, err)
+
+	// Second soft-delete should return not found.
+	err = repo.SoftDelete(ctx, cred.ID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresWebAuthnRepository_GetByUser_ExcludesSoftDeleted(t *testing.T) {
+	pool := testPool(t)
+	userRepo := storage.NewPostgresUserRepository(pool)
+	repo := storage.NewPostgresWebAuthnRepository(pool)
+	ctx := context.Background()
+
+	user := newTestUser()
+	_, err := userRepo.Create(ctx, user)
+	require.NoError(t, err)
+
+	cred1 := newTestWebAuthnCredential(user.ID)
+	_, err = repo.Create(ctx, cred1)
+	require.NoError(t, err)
+
+	cred2 := newTestWebAuthnCredential(user.ID)
+	_, err = repo.Create(ctx, cred2)
+	require.NoError(t, err)
+
+	// Soft-delete one credential.
+	err = repo.SoftDelete(ctx, cred1.ID)
+	require.NoError(t, err)
+
+	creds, err := repo.GetByUser(ctx, user.ID)
+	require.NoError(t, err)
+	assert.Len(t, creds, 1)
+	assert.Equal(t, cred2.ID, creds[0].ID)
+}

--- a/migrations/000008_create_webauthn_credentials_table.down.sql
+++ b/migrations/000008_create_webauthn_credentials_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS webauthn_credentials;

--- a/migrations/000008_create_webauthn_credentials_table.up.sql
+++ b/migrations/000008_create_webauthn_credentials_table.up.sql
@@ -1,0 +1,23 @@
+-- WebAuthn credentials: stores FIDO2/WebAuthn public-key credentials per user.
+CREATE TABLE IF NOT EXISTS webauthn_credentials (
+    id               TEXT        PRIMARY KEY,
+    user_id          TEXT        NOT NULL REFERENCES users (id),
+    credential_id    BYTEA       NOT NULL,
+    public_key       BYTEA       NOT NULL,
+    aaguid           TEXT        NOT NULL DEFAULT '',
+    sign_count       INTEGER     NOT NULL DEFAULT 0,
+    transports       TEXT[]      NOT NULL DEFAULT '{}',
+    attestation_type TEXT        NOT NULL DEFAULT 'none',
+    friendly_name    TEXT        NOT NULL DEFAULT '',
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at       TIMESTAMPTZ
+);
+
+-- Fast lookup by credential ID for authentication (unique among active credentials).
+CREATE UNIQUE INDEX idx_webauthn_credentials_credential_id_active
+    ON webauthn_credentials (credential_id) WHERE deleted_at IS NULL;
+
+-- List all credentials for a user.
+CREATE INDEX idx_webauthn_credentials_user_id
+    ON webauthn_credentials (user_id);


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-246.

Closes #246

## Changes

Define WebAuthn credential domain models in `internal/domain/` (credential ID, public key, AAGUID, sign count, transports, attestation type, user-friendly name, timestamps). Create the `webauthn_credentials` table migration in `migrations/`. Implement the repository interface and PostgreSQL implementation in `internal/storage/` (CRUD for credentials: create, get-by-user, get-by-credential-id, update sign count, delete, soft-delete). Extend the Redis MFA store in `internal/storage/` for WebAuthn challenge/session data storage with 60s TTL (`webauthn:challenge:{sessionID}` keys). Include storage-layer tests (repository + Redis store).