### PR TITLE
GH-252: OAuth provider framework and implementations (`internal/oauth/`)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.8.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
 	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
@@ -59,6 +60,7 @@ require (
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/arch v0.22.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
+	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,6 @@
+cloud.google.com/go v0.121.6 h1:waZiuajrI28iAf40cWgycWNgaXPO06dupuS+sgibK6c=
+cloud.google.com/go/compute/metadata v0.8.0 h1:HxMRIbao8w17ZX6wBnjhcDkW6lTFpgcaobyVfZWqRLA=
+cloud.google.com/go/compute/metadata v0.8.0/go.mod h1:sYOGTp851OV9bOFJ9CH7elVvyzopvWQFNNghtDQ/Biw=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
@@ -187,6 +190,8 @@ golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtC
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.51.0 h1:94R/GTO7mt3/4wIKpcR5gkGmRLOuE/2hNGeWq/GBIFo=
 golang.org/x/net v0.51.0/go.mod h1:aamm+2QF5ogm02fjy5Bb7CQ0WMt1/WVM7FtyaTLlA9Y=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,24 @@ type Config struct {
 	Email        EmailConfig
 	DPoP         DPoPConfig
 	MFA          MFAConfig
+	OAuth        OAuthConfig
+}
+
+// OAuthProviderConfig holds credentials and toggle for a single OAuth provider.
+type OAuthProviderConfig struct {
+	Enabled      bool
+	ClientID     string
+	ClientSecret string
+}
+
+// OAuthConfig holds social login / OAuth provider settings.
+type OAuthConfig struct {
+	Google          OAuthProviderConfig
+	GitHub          OAuthProviderConfig
+	Apple           OAuthProviderConfig
+	StateHMACSecret string        // OAUTH_STATE_HMAC_SECRET: HMAC key for signing state tokens
+	StateTTL        time.Duration // OAUTH_STATE_TTL: lifetime of OAuth state parameters
+	RedirectBaseURL string        // OAUTH_REDIRECT_BASE_URL: base URL for OAuth callback endpoints
 }
 
 // MFAConfig holds multi-factor authentication settings.
@@ -232,6 +250,10 @@ func Load() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	oauthCfg, err := loadOAuth(l)
+	if err != nil {
+		return nil, err
+	}
 
 	if len(l.missing) > 0 {
 		return nil, fmt.Errorf("missing required environment variables: %s", strings.Join(l.missing, ", "))
@@ -254,6 +276,7 @@ func Load() (*Config, error) {
 		Email:        email,
 		DPoP:         dpop,
 		MFA:          mfaCfg,
+		OAuth:        oauthCfg,
 	}, nil
 }
 
@@ -547,6 +570,48 @@ func loadMFA(l *loader) (MFAConfig, error) {
 		Digits:          digits,
 		Period:          period,
 		BackupCodeCount: backupCount,
+	}, nil
+}
+
+func loadOAuth(l *loader) (OAuthConfig, error) {
+	googleEnabled, err := l.optBool("OAUTH_GOOGLE_ENABLED", false)
+	if err != nil {
+		return OAuthConfig{}, err
+	}
+	githubEnabled, err := l.optBool("OAUTH_GITHUB_ENABLED", false)
+	if err != nil {
+		return OAuthConfig{}, err
+	}
+	appleEnabled, err := l.optBool("OAUTH_APPLE_ENABLED", false)
+	if err != nil {
+		return OAuthConfig{}, err
+	}
+
+	stateTTLStr := l.optStr("OAUTH_STATE_TTL", "10m")
+	stateTTL, err := parseDuration(stateTTLStr)
+	if err != nil {
+		return OAuthConfig{}, fmt.Errorf("OAUTH_STATE_TTL: %w", err)
+	}
+
+	return OAuthConfig{
+		Google: OAuthProviderConfig{
+			Enabled:      googleEnabled,
+			ClientID:     l.optStr("OAUTH_GOOGLE_CLIENT_ID", ""),
+			ClientSecret: l.optStr("OAUTH_GOOGLE_CLIENT_SECRET", ""),
+		},
+		GitHub: OAuthProviderConfig{
+			Enabled:      githubEnabled,
+			ClientID:     l.optStr("OAUTH_GITHUB_CLIENT_ID", ""),
+			ClientSecret: l.optStr("OAUTH_GITHUB_CLIENT_SECRET", ""),
+		},
+		Apple: OAuthProviderConfig{
+			Enabled:      appleEnabled,
+			ClientID:     l.optStr("OAUTH_APPLE_CLIENT_ID", ""),
+			ClientSecret: l.optStr("OAUTH_APPLE_CLIENT_SECRET", ""),
+		},
+		StateHMACSecret: l.optStr("OAUTH_STATE_HMAC_SECRET", ""),
+		StateTTL:        stateTTL,
+		RedirectBaseURL: l.optStr("OAUTH_REDIRECT_BASE_URL", ""),
 	}, nil
 }
 

--- a/internal/domain/social.go
+++ b/internal/domain/social.go
@@ -1,0 +1,40 @@
+package domain
+
+import "time"
+
+// OAuthProvider identifies a supported social login provider.
+type OAuthProvider string
+
+const (
+	OAuthProviderGoogle OAuthProvider = "google"
+	OAuthProviderGitHub OAuthProvider = "github"
+	OAuthProviderApple  OAuthProvider = "apple"
+)
+
+// ValidOAuthProviders is the set of all recognized provider identifiers.
+var ValidOAuthProviders = map[OAuthProvider]bool{
+	OAuthProviderGoogle: true,
+	OAuthProviderGitHub: true,
+	OAuthProviderApple:  true,
+}
+
+// SocialAccount links a user to an external OAuth provider account.
+type SocialAccount struct {
+	ID             string
+	UserID         string
+	Provider       OAuthProvider
+	ProviderUserID string
+	Email          string
+	Name           string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+// OAuthUserInfo holds the profile data returned by a social provider
+// after a successful token exchange.
+type OAuthUserInfo struct {
+	ProviderUserID string
+	Email          string
+	Name           string
+	EmailVerified  bool
+}

--- a/internal/oauth/apple.go
+++ b/internal/oauth/apple.go
@@ -1,0 +1,259 @@
+package oauth
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/oauth2"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// AppleProvider implements the Provider interface for Sign in with Apple.
+// Apple uses a JWT-based client secret and returns user info via an ID token
+// rather than a userinfo endpoint.
+type AppleProvider struct {
+	cfg        *oauth2.Config
+	teamID     string
+	keyID      string
+	privateKey interface{} // *ecdsa.PrivateKey for ES256 signing
+	httpClient *http.Client
+	nowFunc    func() time.Time
+}
+
+// AppleConfig holds Apple-specific configuration beyond standard OAuth2 fields.
+type AppleConfig struct {
+	ClientID    string // Apple Services ID (e.g., "com.example.app")
+	TeamID      string // Apple Developer Team ID
+	KeyID       string // Key ID for the private key
+	PrivateKey  interface{}
+	RedirectURL string
+}
+
+// appleAuthURL and appleTokenURL are Apple's OAuth endpoints.
+var (
+	appleAuthURL  = "https://appleid.apple.com/auth/authorize"
+	appleTokenURL = "https://appleid.apple.com/auth/token"
+	appleKeysURL  = "https://appleid.apple.com/auth/keys"
+)
+
+// NewAppleProvider creates an Apple Sign In provider.
+func NewAppleProvider(cfg AppleConfig) *AppleProvider {
+	return &AppleProvider{
+		cfg: &oauth2.Config{
+			ClientID: cfg.ClientID,
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  appleAuthURL,
+				TokenURL: appleTokenURL,
+			},
+			RedirectURL: cfg.RedirectURL,
+			Scopes:      []string{"name", "email"},
+		},
+		teamID:     cfg.TeamID,
+		keyID:      cfg.KeyID,
+		privateKey: cfg.PrivateKey,
+		nowFunc:    time.Now,
+	}
+}
+
+func (a *AppleProvider) Name() domain.OAuthProvider {
+	return domain.OAuthProviderApple
+}
+
+func (a *AppleProvider) AuthCodeURL(state, codeVerifier string) string {
+	challenge := CodeChallenge(codeVerifier)
+	return a.cfg.AuthCodeURL(state,
+		oauth2.SetAuthURLParam("response_mode", "form_post"),
+		oauth2.SetAuthURLParam("code_challenge", challenge),
+		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
+	)
+}
+
+func (a *AppleProvider) ExchangeCode(ctx context.Context, code, codeVerifier string) (*domain.OAuthUserInfo, error) {
+	// Generate the ephemeral client_secret JWT.
+	clientSecret, err := a.generateClientSecret()
+	if err != nil {
+		return nil, fmt.Errorf("apple generate client secret: %w", err)
+	}
+
+	// Override client secret for this exchange.
+	cfg := *a.cfg
+	cfg.ClientSecret = clientSecret
+
+	tok, err := cfg.Exchange(ctx, code,
+		oauth2.SetAuthURLParam("code_verifier", codeVerifier),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("apple token exchange: %w", err)
+	}
+
+	// Apple returns user info in the id_token, not via a separate endpoint.
+	idTokenRaw, ok := tok.Extra("id_token").(string)
+	if !ok || idTokenRaw == "" {
+		return nil, errors.New("apple: no id_token in token response")
+	}
+
+	info, err := a.parseIDToken(ctx, idTokenRaw)
+	if err != nil {
+		return nil, fmt.Errorf("apple parse id_token: %w", err)
+	}
+
+	return info, nil
+}
+
+// generateClientSecret creates a short-lived ES256 JWT used as the client_secret
+// when calling Apple's token endpoint.
+func (a *AppleProvider) generateClientSecret() (string, error) {
+	now := a.nowFunc()
+	claims := jwt.RegisteredClaims{
+		Issuer:    a.teamID,
+		Subject:   a.cfg.ClientID,
+		Audience:  jwt.ClaimStrings{"https://appleid.apple.com"},
+		IssuedAt:  jwt.NewNumericDate(now),
+		ExpiresAt: jwt.NewNumericDate(now.Add(5 * time.Minute)),
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	token.Header["kid"] = a.keyID
+
+	signed, err := token.SignedString(a.privateKey)
+	if err != nil {
+		return "", fmt.Errorf("sign client secret: %w", err)
+	}
+	return signed, nil
+}
+
+// parseIDToken validates and extracts user info from Apple's id_token.
+// It fetches Apple's public keys and verifies the JWT signature.
+func (a *AppleProvider) parseIDToken(ctx context.Context, rawToken string) (*domain.OAuthUserInfo, error) {
+	keys, err := a.fetchApplePublicKeys(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := jwt.Parse(rawToken, func(t *jwt.Token) (interface{}, error) {
+		kid, ok := t.Header["kid"].(string)
+		if !ok {
+			return nil, errors.New("missing kid in id_token header")
+		}
+		key, exists := keys[kid]
+		if !exists {
+			return nil, fmt.Errorf("unknown kid %q in id_token", kid)
+		}
+		return key, nil
+	},
+		jwt.WithValidMethods([]string{"RS256"}),
+		jwt.WithIssuer("https://appleid.apple.com"),
+		jwt.WithAudience(a.cfg.ClientID),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("validate id_token: %w", err)
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, errors.New("invalid id_token claims")
+	}
+
+	sub, _ := claims["sub"].(string)
+	email, _ := claims["email"].(string)
+	emailVerified, _ := claims["email_verified"].(bool)
+	// If email_verified comes as a string "true", handle it.
+	if !emailVerified {
+		if ev, ok := claims["email_verified"].(string); ok && ev == "true" {
+			emailVerified = true
+		}
+	}
+
+	return &domain.OAuthUserInfo{
+		ProviderUserID: sub,
+		Email:          email,
+		Name:           "", // Apple only provides name on first authorization; handled at service level.
+		EmailVerified:  emailVerified,
+	}, nil
+}
+
+// appleJWKSet represents the response from Apple's keys endpoint.
+type appleJWKSet struct {
+	Keys []appleJWK `json:"keys"`
+}
+
+type appleJWK struct {
+	Kty string `json:"kty"`
+	Kid string `json:"kid"`
+	Use string `json:"use"`
+	Alg string `json:"alg"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+// fetchApplePublicKeys retrieves Apple's JWKS and returns a map of kid → *rsa.PublicKey.
+func (a *AppleProvider) fetchApplePublicKeys(ctx context.Context) (map[string]*rsa.PublicKey, error) {
+	client := a.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, appleKeysURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create apple keys request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch apple keys: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("apple keys returned %d: %s", resp.StatusCode, body)
+	}
+
+	var jwks appleJWKSet
+	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+		return nil, fmt.Errorf("decode apple keys: %w", err)
+	}
+
+	keys := make(map[string]*rsa.PublicKey, len(jwks.Keys))
+	for _, k := range jwks.Keys {
+		if k.Kty != "RSA" || k.Use != "sig" {
+			continue
+		}
+		pub, err := jwkToRSAPublicKey(k)
+		if err != nil {
+			continue
+		}
+		keys[k.Kid] = pub
+	}
+
+	return keys, nil
+}
+
+// jwkToRSAPublicKey converts a JWK to an *rsa.PublicKey.
+func jwkToRSAPublicKey(k appleJWK) (*rsa.PublicKey, error) {
+	nBytes, err := jwt.NewParser().DecodeSegment(k.N)
+	if err != nil {
+		return nil, fmt.Errorf("decode n: %w", err)
+	}
+	eBytes, err := jwt.NewParser().DecodeSegment(k.E)
+	if err != nil {
+		return nil, fmt.Errorf("decode e: %w", err)
+	}
+
+	n := new(big.Int).SetBytes(nBytes)
+	e := new(big.Int).SetBytes(eBytes)
+
+	return &rsa.PublicKey{
+		N: n,
+		E: int(e.Int64()),
+	}, nil
+}

--- a/internal/oauth/apple_test.go
+++ b/internal/oauth/apple_test.go
@@ -1,0 +1,196 @@
+package oauth
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+func TestAppleProvider_Name(t *testing.T) {
+	p := NewAppleProvider(AppleConfig{ClientID: "com.example.app"})
+	assert.Equal(t, domain.OAuthProviderApple, p.Name())
+}
+
+func TestAppleProvider_AuthCodeURL(t *testing.T) {
+	p := NewAppleProvider(AppleConfig{
+		ClientID:    "com.example.app",
+		RedirectURL: "https://example.com/callback",
+	})
+
+	url := p.AuthCodeURL("test-state", "test-verifier")
+	assert.Contains(t, url, "state=test-state")
+	assert.Contains(t, url, "response_mode=form_post")
+	assert.Contains(t, url, "code_challenge=")
+	assert.Contains(t, url, "code_challenge_method=S256")
+}
+
+func TestAppleProvider_GenerateClientSecret(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	p := NewAppleProvider(AppleConfig{
+		ClientID: "com.example.app",
+		TeamID:   "TEAM123",
+		KeyID:    "KEY456",
+	})
+	p.privateKey = key
+	now := time.Now()
+	p.nowFunc = func() time.Time { return now }
+
+	secret, err := p.generateClientSecret()
+	require.NoError(t, err)
+	assert.NotEmpty(t, secret)
+
+	// Parse and validate the generated JWT.
+	token, err := jwt.Parse(secret, func(t *jwt.Token) (interface{}, error) {
+		return &key.PublicKey, nil
+	})
+	require.NoError(t, err)
+	assert.True(t, token.Valid)
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	require.True(t, ok)
+
+	assert.Equal(t, "TEAM123", claims["iss"])
+	assert.Equal(t, "com.example.app", claims["sub"])
+	assert.Equal(t, "KEY456", token.Header["kid"])
+}
+
+func TestAppleProvider_ExchangeCode_Success(t *testing.T) {
+	// Generate RSA key pair for signing the mock id_token.
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	kid := "test-kid-1"
+
+	// Create a mock id_token.
+	idTokenClaims := jwt.MapClaims{
+		"iss":            "https://appleid.apple.com",
+		"aud":            "com.example.app",
+		"sub":            "apple-user-001",
+		"email":          "user@icloud.com",
+		"email_verified": true,
+		"iat":            time.Now().Unix(),
+		"exp":            time.Now().Add(time.Hour).Unix(),
+	}
+	idToken := jwt.NewWithClaims(jwt.SigningMethodRS256, idTokenClaims)
+	idToken.Header["kid"] = kid
+	idTokenStr, err := idToken.SignedString(rsaKey)
+	require.NoError(t, err)
+
+	// Mock Apple keys endpoint.
+	keysServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		nBytes := rsaKey.PublicKey.N.Bytes()
+		eBytes := big.NewInt(int64(rsaKey.PublicKey.E)).Bytes()
+		jwks := map[string]interface{}{
+			"keys": []map[string]interface{}{
+				{
+					"kty": "RSA",
+					"kid": kid,
+					"use": "sig",
+					"alg": "RS256",
+					"n":   base64.RawURLEncoding.EncodeToString(nBytes),
+					"e":   base64.RawURLEncoding.EncodeToString(eBytes),
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(jwks)
+	}))
+	defer keysServer.Close()
+
+	// Mock token endpoint.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]interface{}{
+			"access_token": "test-token",
+			"token_type":   "Bearer",
+			"id_token":     idTokenStr,
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer tokenServer.Close()
+
+	// Override Apple URLs.
+	origKeysURL := appleKeysURL
+	appleKeysURL = keysServer.URL
+	defer func() { appleKeysURL = origKeysURL }()
+
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	p := NewAppleProvider(AppleConfig{
+		ClientID:    "com.example.app",
+		TeamID:      "TEAM123",
+		KeyID:       "KEY456",
+		PrivateKey:  ecKey,
+		RedirectURL: "https://example.com/callback",
+	})
+	p.cfg.Endpoint.TokenURL = tokenServer.URL
+	p.httpClient = &http.Client{}
+
+	info, err := p.ExchangeCode(t.Context(), "auth-code", "verifier")
+	require.NoError(t, err)
+	assert.Equal(t, "apple-user-001", info.ProviderUserID)
+	assert.Equal(t, "user@icloud.com", info.Email)
+	assert.True(t, info.EmailVerified)
+}
+
+func TestAppleProvider_ExchangeCode_TokenError(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	}))
+	defer tokenServer.Close()
+
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	p := NewAppleProvider(AppleConfig{
+		ClientID:   "com.example.app",
+		TeamID:     "TEAM123",
+		KeyID:      "KEY456",
+		PrivateKey: ecKey,
+	})
+	p.cfg.Endpoint.TokenURL = tokenServer.URL
+
+	_, err = p.ExchangeCode(t.Context(), "bad-code", "verifier")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "apple token exchange")
+}
+
+func TestJwkToRSAPublicKey(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	nBytes := key.PublicKey.N.Bytes()
+	eBytes := big.NewInt(int64(key.PublicKey.E)).Bytes()
+
+	jwk := appleJWK{
+		Kty: "RSA",
+		Kid: "test",
+		Use: "sig",
+		Alg: "RS256",
+		N:   base64.RawURLEncoding.EncodeToString(nBytes),
+		E:   base64.RawURLEncoding.EncodeToString(eBytes),
+	}
+
+	pub, err := jwkToRSAPublicKey(jwk)
+	require.NoError(t, err)
+	assert.Equal(t, key.PublicKey.N, pub.N)
+	assert.Equal(t, key.PublicKey.E, pub.E)
+}

--- a/internal/oauth/github.go
+++ b/internal/oauth/github.go
@@ -1,0 +1,177 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	"golang.org/x/oauth2"
+	oauthgithub "golang.org/x/oauth2/github"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// GitHubProvider implements the Provider interface for GitHub OAuth2.
+type GitHubProvider struct {
+	cfg        *oauth2.Config
+	httpClient *http.Client // injectable for testing; nil uses http.DefaultClient
+}
+
+// NewGitHubProvider creates a GitHub OAuth provider.
+func NewGitHubProvider(clientID, clientSecret, redirectURL string) *GitHubProvider {
+	return &GitHubProvider{
+		cfg: &oauth2.Config{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			RedirectURL:  redirectURL,
+			Scopes:       []string{"user:email"},
+			Endpoint:     oauthgithub.Endpoint,
+		},
+	}
+}
+
+func (g *GitHubProvider) Name() domain.OAuthProvider {
+	return domain.OAuthProviderGitHub
+}
+
+func (g *GitHubProvider) AuthCodeURL(state, codeVerifier string) string {
+	// GitHub doesn't support PKCE but we keep the interface consistent.
+	// The code_verifier is still used on the exchange side.
+	return g.cfg.AuthCodeURL(state)
+}
+
+// githubUserURL and githubEmailsURL are the GitHub API endpoints. Package-level vars for test injection.
+var (
+	githubUserURL   = "https://api.github.com/user"
+	githubEmailsURL = "https://api.github.com/user/emails"
+)
+
+func (g *GitHubProvider) ExchangeCode(ctx context.Context, code, _ string) (*domain.OAuthUserInfo, error) {
+	tok, err := g.cfg.Exchange(ctx, code)
+	if err != nil {
+		return nil, fmt.Errorf("github token exchange: %w", err)
+	}
+
+	client := g.httpClient
+	if client == nil {
+		client = g.cfg.Client(ctx, tok)
+	}
+
+	// Fetch user profile.
+	userResp, err := client.Get(githubUserURL)
+	if err != nil {
+		return nil, fmt.Errorf("github user request: %w", err)
+	}
+	defer userResp.Body.Close()
+
+	if userResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(userResp.Body)
+		return nil, fmt.Errorf("github user returned %d: %s", userResp.StatusCode, body)
+	}
+
+	var user struct {
+		ID    int    `json:"id"`
+		Name  string `json:"name"`
+		Login string `json:"login"`
+		Email string `json:"email"`
+	}
+	if err := json.NewDecoder(userResp.Body).Decode(&user); err != nil {
+		return nil, fmt.Errorf("github user decode: %w", err)
+	}
+
+	name := user.Name
+	if name == "" {
+		name = user.Login
+	}
+
+	email := user.Email
+	emailVerified := false
+
+	// If the profile email is empty, fetch from the emails endpoint.
+	if email == "" {
+		email, emailVerified, err = g.fetchPrimaryEmail(client)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Verify the profile email via the emails endpoint.
+		emailVerified, _ = g.checkEmailVerified(client, email)
+	}
+
+	return &domain.OAuthUserInfo{
+		ProviderUserID: strconv.Itoa(user.ID),
+		Email:          email,
+		Name:           name,
+		EmailVerified:  emailVerified,
+	}, nil
+}
+
+// fetchPrimaryEmail retrieves the user's primary verified email from GitHub.
+func (g *GitHubProvider) fetchPrimaryEmail(client *http.Client) (string, bool, error) {
+	resp, err := client.Get(githubEmailsURL)
+	if err != nil {
+		return "", false, fmt.Errorf("github emails request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", false, fmt.Errorf("github emails returned %d: %s", resp.StatusCode, body)
+	}
+
+	var emails []struct {
+		Email    string `json:"email"`
+		Primary  bool   `json:"primary"`
+		Verified bool   `json:"verified"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&emails); err != nil {
+		return "", false, fmt.Errorf("github emails decode: %w", err)
+	}
+
+	for _, e := range emails {
+		if e.Primary && e.Verified {
+			return e.Email, true, nil
+		}
+	}
+	for _, e := range emails {
+		if e.Primary {
+			return e.Email, e.Verified, nil
+		}
+	}
+	if len(emails) > 0 {
+		return emails[0].Email, emails[0].Verified, nil
+	}
+
+	return "", false, fmt.Errorf("github: no email addresses found")
+}
+
+// checkEmailVerified checks if a specific email is verified via the emails endpoint.
+func (g *GitHubProvider) checkEmailVerified(client *http.Client, targetEmail string) (bool, error) {
+	resp, err := client.Get(githubEmailsURL)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return false, nil
+	}
+
+	var emails []struct {
+		Email    string `json:"email"`
+		Verified bool   `json:"verified"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&emails); err != nil {
+		return false, nil
+	}
+
+	for _, e := range emails {
+		if e.Email == targetEmail {
+			return e.Verified, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/oauth/github_test.go
+++ b/internal/oauth/github_test.go
@@ -1,0 +1,148 @@
+package oauth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+func TestGitHubProvider_Name(t *testing.T) {
+	p := NewGitHubProvider("id", "secret", "https://example.com/callback")
+	assert.Equal(t, domain.OAuthProviderGitHub, p.Name())
+}
+
+func TestGitHubProvider_AuthCodeURL(t *testing.T) {
+	p := NewGitHubProvider("client-id", "secret", "https://example.com/callback")
+	url := p.AuthCodeURL("test-state", "test-verifier")
+	assert.Contains(t, url, "state=test-state")
+	assert.Contains(t, url, "client_id=client-id")
+}
+
+func TestGitHubProvider_ExchangeCode_WithProfileEmail(t *testing.T) {
+	// Mock user endpoint.
+	userServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/user" {
+			w.Header().Set("Content-Type", "application/json")
+			resp := map[string]interface{}{
+				"id":    42,
+				"name":  "GitHub User",
+				"login": "ghuser",
+				"email": "ghuser@example.com",
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		if r.URL.Path == "/user/emails" {
+			w.Header().Set("Content-Type", "application/json")
+			emails := []map[string]interface{}{
+				{"email": "ghuser@example.com", "primary": true, "verified": true},
+			}
+			_ = json.NewEncoder(w).Encode(emails)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer userServer.Close()
+
+	// Override GitHub API URLs.
+	origUserURL := githubUserURL
+	origEmailsURL := githubEmailsURL
+	githubUserURL = userServer.URL + "/user"
+	githubEmailsURL = userServer.URL + "/user/emails"
+	defer func() {
+		githubUserURL = origUserURL
+		githubEmailsURL = origEmailsURL
+	}()
+
+	// Mock token endpoint.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","scope":"user:email"}`))
+	}))
+	defer tokenServer.Close()
+
+	p := NewGitHubProvider("client-id", "secret", "https://example.com/callback")
+	p.cfg.Endpoint.TokenURL = tokenServer.URL
+	p.httpClient = &http.Client{}
+
+	info, err := p.ExchangeCode(t.Context(), "auth-code", "verifier")
+	require.NoError(t, err)
+	assert.Equal(t, "42", info.ProviderUserID)
+	assert.Equal(t, "ghuser@example.com", info.Email)
+	assert.Equal(t, "GitHub User", info.Name)
+	assert.True(t, info.EmailVerified)
+}
+
+func TestGitHubProvider_ExchangeCode_FallbackToEmailsEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/user" {
+			w.Header().Set("Content-Type", "application/json")
+			resp := map[string]interface{}{
+				"id":    99,
+				"name":  "",
+				"login": "noemail",
+				"email": nil,
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		if r.URL.Path == "/user/emails" {
+			w.Header().Set("Content-Type", "application/json")
+			emails := []map[string]interface{}{
+				{"email": "secondary@example.com", "primary": false, "verified": true},
+				{"email": "primary@example.com", "primary": true, "verified": true},
+			}
+			_ = json.NewEncoder(w).Encode(emails)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	origUserURL := githubUserURL
+	origEmailsURL := githubEmailsURL
+	githubUserURL = server.URL + "/user"
+	githubEmailsURL = server.URL + "/user/emails"
+	defer func() {
+		githubUserURL = origUserURL
+		githubEmailsURL = origEmailsURL
+	}()
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer"}`))
+	}))
+	defer tokenServer.Close()
+
+	p := NewGitHubProvider("client-id", "secret", "https://example.com/callback")
+	p.cfg.Endpoint.TokenURL = tokenServer.URL
+	p.httpClient = &http.Client{}
+
+	info, err := p.ExchangeCode(t.Context(), "auth-code", "verifier")
+	require.NoError(t, err)
+	assert.Equal(t, "99", info.ProviderUserID)
+	assert.Equal(t, "primary@example.com", info.Email)
+	assert.Equal(t, "noemail", info.Name) // Falls back to login
+	assert.True(t, info.EmailVerified)
+}
+
+func TestGitHubProvider_ExchangeCode_TokenError(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"bad_verification_code"}`))
+	}))
+	defer tokenServer.Close()
+
+	p := NewGitHubProvider("client-id", "secret", "https://example.com/callback")
+	p.cfg.Endpoint.TokenURL = tokenServer.URL
+
+	_, err := p.ExchangeCode(t.Context(), "bad-code", "verifier")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "github token exchange")
+}

--- a/internal/oauth/google.go
+++ b/internal/oauth/google.go
@@ -1,0 +1,90 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// GoogleProvider implements the Provider interface for Google OAuth2.
+type GoogleProvider struct {
+	cfg        *oauth2.Config
+	httpClient *http.Client // injectable for testing; nil uses http.DefaultClient
+}
+
+// NewGoogleProvider creates a Google OAuth provider.
+func NewGoogleProvider(clientID, clientSecret, redirectURL string) *GoogleProvider {
+	return &GoogleProvider{
+		cfg: &oauth2.Config{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			RedirectURL:  redirectURL,
+			Scopes:       []string{"openid", "email", "profile"},
+			Endpoint:     google.Endpoint,
+		},
+	}
+}
+
+func (g *GoogleProvider) Name() domain.OAuthProvider {
+	return domain.OAuthProviderGoogle
+}
+
+func (g *GoogleProvider) AuthCodeURL(state, codeVerifier string) string {
+	challenge := CodeChallenge(codeVerifier)
+	return g.cfg.AuthCodeURL(state,
+		oauth2.SetAuthURLParam("code_challenge", challenge),
+		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
+	)
+}
+
+// googleUserInfoURL is the Google userinfo endpoint. Package-level var for test injection.
+var googleUserInfoURL = "https://www.googleapis.com/oauth2/v2/userinfo"
+
+func (g *GoogleProvider) ExchangeCode(ctx context.Context, code, codeVerifier string) (*domain.OAuthUserInfo, error) {
+	tok, err := g.cfg.Exchange(ctx, code,
+		oauth2.SetAuthURLParam("code_verifier", codeVerifier),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("google token exchange: %w", err)
+	}
+
+	client := g.httpClient
+	if client == nil {
+		client = g.cfg.Client(ctx, tok)
+	}
+
+	resp, err := client.Get(googleUserInfoURL)
+	if err != nil {
+		return nil, fmt.Errorf("google userinfo request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("google userinfo returned %d: %s", resp.StatusCode, body)
+	}
+
+	var info struct {
+		ID            string `json:"id"`
+		Email         string `json:"email"`
+		Name          string `json:"name"`
+		VerifiedEmail bool   `json:"verified_email"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return nil, fmt.Errorf("google userinfo decode: %w", err)
+	}
+
+	return &domain.OAuthUserInfo{
+		ProviderUserID: info.ID,
+		Email:          info.Email,
+		Name:           info.Name,
+		EmailVerified:  info.VerifiedEmail,
+	}, nil
+}

--- a/internal/oauth/google_test.go
+++ b/internal/oauth/google_test.go
@@ -1,0 +1,81 @@
+package oauth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+func TestGoogleProvider_Name(t *testing.T) {
+	p := NewGoogleProvider("id", "secret", "https://example.com/callback")
+	assert.Equal(t, domain.OAuthProviderGoogle, p.Name())
+}
+
+func TestGoogleProvider_AuthCodeURL(t *testing.T) {
+	p := NewGoogleProvider("client-id", "secret", "https://example.com/callback")
+
+	url := p.AuthCodeURL("test-state", "test-verifier")
+	assert.Contains(t, url, "state=test-state")
+	assert.Contains(t, url, "code_challenge=")
+	assert.Contains(t, url, "code_challenge_method=S256")
+	assert.Contains(t, url, "client_id=client-id")
+}
+
+func TestGoogleProvider_ExchangeCode_UserInfoParsing(t *testing.T) {
+	// Mock userinfo endpoint.
+	userInfoServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]interface{}{
+			"id":             "google-user-123",
+			"email":          "user@gmail.com",
+			"name":           "Google User",
+			"verified_email": true,
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer userInfoServer.Close()
+
+	// Override the userinfo URL for testing.
+	origURL := googleUserInfoURL
+	googleUserInfoURL = userInfoServer.URL
+	defer func() { googleUserInfoURL = origURL }()
+
+	// Mock token endpoint.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer tokenServer.Close()
+
+	p := NewGoogleProvider("client-id", "secret", "https://example.com/callback")
+	p.cfg.Endpoint.TokenURL = tokenServer.URL
+	// Use a plain HTTP client that won't inject OAuth tokens (we handle it via the mock).
+	p.httpClient = &http.Client{}
+
+	info, err := p.ExchangeCode(t.Context(), "auth-code", "verifier")
+	assert.NoError(t, err)
+	assert.Equal(t, "google-user-123", info.ProviderUserID)
+	assert.Equal(t, "user@gmail.com", info.Email)
+	assert.Equal(t, "Google User", info.Name)
+	assert.True(t, info.EmailVerified)
+}
+
+func TestGoogleProvider_ExchangeCode_TokenError(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	}))
+	defer tokenServer.Close()
+
+	p := NewGoogleProvider("client-id", "secret", "https://example.com/callback")
+	p.cfg.Endpoint.TokenURL = tokenServer.URL
+
+	_, err := p.ExchangeCode(t.Context(), "bad-code", "verifier")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "google token exchange")
+}

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -1,2 +1,0 @@
-// Package oauth provides social login and OIDC provider support (Phase 2).
-package oauth

--- a/internal/oauth/pkce.go
+++ b/internal/oauth/pkce.go
@@ -1,0 +1,32 @@
+package oauth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+)
+
+// PKCE implements RFC 7636 Proof Key for Code Exchange (S256 method).
+
+const (
+	// codeVerifierBytes is the number of random bytes for the verifier (32 bytes → 43 base64url chars).
+	// RFC 7636 requires 43-128 characters; 32 bytes yields 43 characters.
+	codeVerifierBytes = 32
+)
+
+// GenerateCodeVerifier creates a cryptographically random code_verifier
+// per RFC 7636 Section 4.1.
+func GenerateCodeVerifier() (string, error) {
+	buf := make([]byte, codeVerifierBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// CodeChallenge computes the S256 code_challenge from a code_verifier
+// per RFC 7636 Section 4.2: BASE64URL(SHA256(code_verifier)).
+func CodeChallenge(verifier string) string {
+	h := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(h[:])
+}

--- a/internal/oauth/pkce_test.go
+++ b/internal/oauth/pkce_test.go
@@ -1,0 +1,74 @@
+package oauth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateCodeVerifier(t *testing.T) {
+	t.Run("produces valid base64url string", func(t *testing.T) {
+		v, err := GenerateCodeVerifier()
+		require.NoError(t, err)
+
+		// 32 bytes → 43 base64url chars (no padding).
+		assert.Len(t, v, 43)
+
+		// Must decode without error.
+		decoded, err := base64.RawURLEncoding.DecodeString(v)
+		require.NoError(t, err)
+		assert.Len(t, decoded, codeVerifierBytes)
+	})
+
+	t.Run("produces unique values", func(t *testing.T) {
+		v1, err := GenerateCodeVerifier()
+		require.NoError(t, err)
+
+		v2, err := GenerateCodeVerifier()
+		require.NoError(t, err)
+
+		assert.NotEqual(t, v1, v2)
+	})
+}
+
+func TestCodeChallenge(t *testing.T) {
+	t.Run("S256 transform matches RFC 7636 Appendix B", func(t *testing.T) {
+		// RFC 7636 Appendix B example (adapted for base64url without padding).
+		verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+		challenge := CodeChallenge(verifier)
+
+		// Manually compute expected: BASE64URL(SHA256(verifier))
+		h := sha256.Sum256([]byte(verifier))
+		expected := base64.RawURLEncoding.EncodeToString(h[:])
+
+		assert.Equal(t, expected, challenge)
+	})
+
+	t.Run("different verifiers produce different challenges", func(t *testing.T) {
+		c1 := CodeChallenge("verifier-one")
+		c2 := CodeChallenge("verifier-two")
+		assert.NotEqual(t, c1, c2)
+	})
+
+	t.Run("same verifier is deterministic", func(t *testing.T) {
+		c1 := CodeChallenge("stable-verifier")
+		c2 := CodeChallenge("stable-verifier")
+		assert.Equal(t, c1, c2)
+	})
+}
+
+func TestCodeVerifierChallengeRoundTrip(t *testing.T) {
+	// Generate a verifier, compute its challenge, then verify the relationship.
+	verifier, err := GenerateCodeVerifier()
+	require.NoError(t, err)
+
+	challenge := CodeChallenge(verifier)
+
+	// Re-compute from the verifier to verify the S256 relationship.
+	h := sha256.Sum256([]byte(verifier))
+	expected := base64.RawURLEncoding.EncodeToString(h[:])
+	assert.Equal(t, expected, challenge)
+}

--- a/internal/oauth/provider.go
+++ b/internal/oauth/provider.go
@@ -1,0 +1,96 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// Provider is the interface that each OAuth/social-login provider must implement.
+type Provider interface {
+	// Name returns the provider identifier (e.g. "google", "github", "apple").
+	Name() domain.OAuthProvider
+
+	// AuthCodeURL returns the URL to redirect the user to for authorization.
+	// state is the CSRF token; codeVerifier is the PKCE verifier whose challenge
+	// will be included in the authorization request.
+	AuthCodeURL(state, codeVerifier string) string
+
+	// ExchangeCode exchanges an authorization code for user info.
+	// codeVerifier is the PKCE verifier that was used when generating the auth URL.
+	ExchangeCode(ctx context.Context, code, codeVerifier string) (*domain.OAuthUserInfo, error)
+}
+
+// Registry holds the set of registered OAuth providers and controls which are enabled.
+type Registry struct {
+	mu        sync.RWMutex
+	providers map[domain.OAuthProvider]Provider
+	enabled   map[domain.OAuthProvider]bool
+}
+
+// NewRegistry creates an empty provider registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		providers: make(map[domain.OAuthProvider]Provider),
+		enabled:   make(map[domain.OAuthProvider]bool),
+	}
+}
+
+// Register adds a provider to the registry. If enabled is true, the provider
+// is immediately available for use.
+func (r *Registry) Register(p Provider, enabled bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	name := p.Name()
+	r.providers[name] = p
+	r.enabled[name] = enabled
+}
+
+// ErrProviderNotFound is returned when a requested provider is not registered.
+var ErrProviderNotFound = errors.New("oauth provider not found")
+
+// ErrProviderDisabled is returned when a registered provider is not enabled.
+var ErrProviderDisabled = errors.New("oauth provider disabled")
+
+// Get returns the provider for the given name, or an error if not found or disabled.
+func (r *Registry) Get(name domain.OAuthProvider) (Provider, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	p, ok := r.providers[name]
+	if !ok {
+		return nil, ErrProviderNotFound
+	}
+	if !r.enabled[name] {
+		return nil, ErrProviderDisabled
+	}
+	return p, nil
+}
+
+// SetEnabled enables or disables a provider by name.
+func (r *Registry) SetEnabled(name domain.OAuthProvider, enabled bool) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.providers[name]; !ok {
+		return ErrProviderNotFound
+	}
+	r.enabled[name] = enabled
+	return nil
+}
+
+// ListEnabled returns the names of all currently enabled providers.
+func (r *Registry) ListEnabled() []domain.OAuthProvider {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var out []domain.OAuthProvider
+	for name, on := range r.enabled {
+		if on {
+			out = append(out, name)
+		}
+	}
+	return out
+}

--- a/internal/oauth/registry_test.go
+++ b/internal/oauth/registry_test.go
@@ -1,0 +1,95 @@
+package oauth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// stubProvider implements Provider for testing.
+type stubProvider struct {
+	name domain.OAuthProvider
+}
+
+func (s *stubProvider) Name() domain.OAuthProvider { return s.name }
+func (s *stubProvider) AuthCodeURL(state, codeVerifier string) string {
+	return "https://example.com/auth?state=" + state
+}
+func (s *stubProvider) ExchangeCode(_ context.Context, _, _ string) (*domain.OAuthUserInfo, error) {
+	return &domain.OAuthUserInfo{
+		ProviderUserID: "stub-id",
+		Email:          "stub@example.com",
+		Name:           "Stub User",
+		EmailVerified:  true,
+	}, nil
+}
+
+func TestRegistry_RegisterAndGet(t *testing.T) {
+	r := NewRegistry()
+
+	google := &stubProvider{name: domain.OAuthProviderGoogle}
+	github := &stubProvider{name: domain.OAuthProviderGitHub}
+
+	t.Run("register and retrieve enabled provider", func(t *testing.T) {
+		r.Register(google, true)
+		p, err := r.Get(domain.OAuthProviderGoogle)
+		require.NoError(t, err)
+		assert.Equal(t, domain.OAuthProviderGoogle, p.Name())
+	})
+
+	t.Run("register disabled provider returns ErrProviderDisabled", func(t *testing.T) {
+		r.Register(github, false)
+		_, err := r.Get(domain.OAuthProviderGitHub)
+		assert.ErrorIs(t, err, ErrProviderDisabled)
+	})
+
+	t.Run("unregistered provider returns ErrProviderNotFound", func(t *testing.T) {
+		_, err := r.Get(domain.OAuthProviderApple)
+		assert.ErrorIs(t, err, ErrProviderNotFound)
+	})
+}
+
+func TestRegistry_SetEnabled(t *testing.T) {
+	r := NewRegistry()
+	p := &stubProvider{name: domain.OAuthProviderGoogle}
+	r.Register(p, false)
+
+	t.Run("enable a disabled provider", func(t *testing.T) {
+		err := r.SetEnabled(domain.OAuthProviderGoogle, true)
+		require.NoError(t, err)
+
+		got, err := r.Get(domain.OAuthProviderGoogle)
+		require.NoError(t, err)
+		assert.Equal(t, domain.OAuthProviderGoogle, got.Name())
+	})
+
+	t.Run("disable an enabled provider", func(t *testing.T) {
+		err := r.SetEnabled(domain.OAuthProviderGoogle, false)
+		require.NoError(t, err)
+
+		_, err = r.Get(domain.OAuthProviderGoogle)
+		assert.ErrorIs(t, err, ErrProviderDisabled)
+	})
+
+	t.Run("set enabled on unregistered provider returns error", func(t *testing.T) {
+		err := r.SetEnabled(domain.OAuthProviderApple, true)
+		assert.ErrorIs(t, err, ErrProviderNotFound)
+	})
+}
+
+func TestRegistry_ListEnabled(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&stubProvider{name: domain.OAuthProviderGoogle}, true)
+	r.Register(&stubProvider{name: domain.OAuthProviderGitHub}, false)
+	r.Register(&stubProvider{name: domain.OAuthProviderApple}, true)
+
+	enabled := r.ListEnabled()
+	assert.Len(t, enabled, 2)
+	assert.Contains(t, enabled, domain.OAuthProviderGoogle)
+	assert.Contains(t, enabled, domain.OAuthProviderApple)
+	assert.NotContains(t, enabled, domain.OAuthProviderGitHub)
+}

--- a/internal/oauth/service.go
+++ b/internal/oauth/service.go
@@ -1,0 +1,242 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/audit"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+// Audit event types for social login operations.
+const (
+	EventSocialLoginSuccess = "social_login_success"
+	EventSocialLoginFailure = "social_login_failure"
+	EventSocialAccountLink  = "social_account_link"
+)
+
+// UserRepository abstracts user persistence needed by the OAuth service.
+type UserRepository interface {
+	FindByEmail(ctx context.Context, email string) (*domain.User, error)
+	Create(ctx context.Context, user *domain.User) (*domain.User, error)
+}
+
+// Config holds OAuth service-level settings.
+type Config struct {
+	StateHMACSecret string
+	StateTTL        time.Duration
+}
+
+// DefaultConfig returns a default OAuth service configuration.
+func DefaultConfig() Config {
+	return Config{
+		StateTTL: 10 * time.Minute,
+	}
+}
+
+// Service orchestrates the OAuth authorization flow, including PKCE,
+// state management, provider delegation, and account linking.
+type Service struct {
+	registry *Registry
+	state    *StateManager
+	users    UserRepository
+	socials  storage.SocialAccountRepository
+	logger   *zap.Logger
+	audit    audit.EventLogger
+}
+
+// NewService creates a new OAuth service.
+func NewService(
+	registry *Registry,
+	state *StateManager,
+	users UserRepository,
+	socials storage.SocialAccountRepository,
+	logger *zap.Logger,
+	auditor audit.EventLogger,
+) *Service {
+	return &Service{
+		registry: registry,
+		state:    state,
+		users:    users,
+		socials:  socials,
+		logger:   logger,
+		audit:    auditor,
+	}
+}
+
+// BeginAuthResult contains the data needed to redirect the user to the provider.
+type BeginAuthResult struct {
+	AuthURL      string
+	CodeVerifier string
+}
+
+// BeginAuth starts the OAuth flow for the given provider.
+// It generates PKCE parameters and a signed state token, then returns
+// the authorization URL the user should be redirected to.
+func (s *Service) BeginAuth(ctx context.Context, providerName domain.OAuthProvider) (*BeginAuthResult, error) {
+	provider, err := s.registry.Get(providerName)
+	if err != nil {
+		return nil, fmt.Errorf("begin auth: %w", err)
+	}
+
+	codeVerifier, err := GenerateCodeVerifier()
+	if err != nil {
+		return nil, fmt.Errorf("begin auth: generate code verifier: %w", err)
+	}
+
+	state, err := s.state.Generate(ctx, string(providerName))
+	if err != nil {
+		return nil, fmt.Errorf("begin auth: generate state: %w", err)
+	}
+
+	authURL := provider.AuthCodeURL(state, codeVerifier)
+
+	return &BeginAuthResult{
+		AuthURL:      authURL,
+		CodeVerifier: codeVerifier,
+	}, nil
+}
+
+// CompleteAuthResult contains the user info from a completed OAuth flow.
+type CompleteAuthResult struct {
+	User          *domain.User
+	SocialAccount *domain.SocialAccount
+	IsNewUser     bool
+}
+
+// CompleteAuth finishes the OAuth flow: validates state, exchanges the code
+// for user info, then finds or creates a user and links the social account.
+func (s *Service) CompleteAuth(ctx context.Context, stateToken, code, codeVerifier string) (*CompleteAuthResult, error) {
+	// Validate and consume the state token.
+	providerName, err := s.state.Validate(ctx, stateToken)
+	if err != nil {
+		s.audit.LogEvent(ctx, audit.Event{
+			Type:     EventSocialLoginFailure,
+			Metadata: map[string]string{"reason": "invalid_state", "error": err.Error()},
+		})
+		return nil, fmt.Errorf("complete auth: validate state: %w", err)
+	}
+
+	provider, err := s.registry.Get(domain.OAuthProvider(providerName))
+	if err != nil {
+		return nil, fmt.Errorf("complete auth: %w", err)
+	}
+
+	// Exchange the authorization code for user info.
+	userInfo, err := provider.ExchangeCode(ctx, code, codeVerifier)
+	if err != nil {
+		s.audit.LogEvent(ctx, audit.Event{
+			Type:     EventSocialLoginFailure,
+			Metadata: map[string]string{"provider": providerName, "reason": "code_exchange_failed"},
+		})
+		return nil, fmt.Errorf("complete auth: exchange code: %w", err)
+	}
+
+	if userInfo.Email == "" {
+		return nil, fmt.Errorf("complete auth: provider returned no email")
+	}
+
+	// Account linking: find or create.
+	result, err := s.findOrCreateUser(ctx, domain.OAuthProvider(providerName), userInfo)
+	if err != nil {
+		return nil, fmt.Errorf("complete auth: %w", err)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     EventSocialLoginSuccess,
+		ActorID:  result.User.ID,
+		Metadata: map[string]string{"provider": providerName, "new_user": fmt.Sprintf("%t", result.IsNewUser)},
+	})
+
+	return result, nil
+}
+
+// findOrCreateUser looks up a user by the social account's provider+ID, falls
+// back to email matching, and creates a new user if neither is found.
+func (s *Service) findOrCreateUser(ctx context.Context, provider domain.OAuthProvider, info *domain.OAuthUserInfo) (*CompleteAuthResult, error) {
+	// 1. Check if the social account already exists.
+	existing, err := s.socials.FindByProviderUser(ctx, provider, info.ProviderUserID)
+	if err == nil {
+		// Social account exists — look up the linked user.
+		user, userErr := s.users.FindByEmail(ctx, existing.Email)
+		if userErr != nil {
+			return nil, fmt.Errorf("find linked user: %w", userErr)
+		}
+		return &CompleteAuthResult{
+			User:          user,
+			SocialAccount: existing,
+			IsNewUser:     false,
+		}, nil
+	}
+	if !errors.Is(err, storage.ErrNotFound) {
+		return nil, fmt.Errorf("lookup social account: %w", err)
+	}
+
+	// 2. Check if a user with this email already exists (link new social account).
+	user, err := s.users.FindByEmail(ctx, info.Email)
+	if err != nil && !errors.Is(err, storage.ErrNotFound) {
+		return nil, fmt.Errorf("find user by email: %w", err)
+	}
+
+	isNewUser := false
+	if errors.Is(err, storage.ErrNotFound) {
+		// 3. Create a new user.
+		now := time.Now().UTC()
+		newUser := &domain.User{
+			ID:            uuid.New().String(),
+			Email:         info.Email,
+			Name:          info.Name,
+			Roles:         []string{"user"},
+			EmailVerified: info.EmailVerified,
+			CreatedAt:     now,
+			UpdatedAt:     now,
+		}
+		user, err = s.users.Create(ctx, newUser)
+		if err != nil {
+			return nil, fmt.Errorf("create user: %w", err)
+		}
+		isNewUser = true
+	}
+
+	// 4. Link the social account.
+	now := time.Now().UTC()
+	account := &domain.SocialAccount{
+		ID:             uuid.New().String(),
+		UserID:         user.ID,
+		Provider:       provider,
+		ProviderUserID: info.ProviderUserID,
+		Email:          info.Email,
+		Name:           info.Name,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	linked, err := s.socials.Link(ctx, account)
+	if err != nil {
+		return nil, fmt.Errorf("link social account: %w", err)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     EventSocialAccountLink,
+		ActorID:  user.ID,
+		TargetID: linked.ID,
+		Metadata: map[string]string{"provider": string(provider)},
+	})
+
+	return &CompleteAuthResult{
+		User:          user,
+		SocialAccount: linked,
+		IsNewUser:     isNewUser,
+	}, nil
+}
+
+// GetRegistry returns the underlying provider registry for inspection.
+func (s *Service) GetRegistry() *Registry {
+	return s.registry
+}

--- a/internal/oauth/service_test.go
+++ b/internal/oauth/service_test.go
@@ -1,0 +1,304 @@
+package oauth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/audit"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+type mockUserRepo struct {
+	findByEmailFn func(ctx context.Context, email string) (*domain.User, error)
+	createFn      func(ctx context.Context, user *domain.User) (*domain.User, error)
+}
+
+func (m *mockUserRepo) FindByEmail(ctx context.Context, email string) (*domain.User, error) {
+	if m.findByEmailFn != nil {
+		return m.findByEmailFn(ctx, email)
+	}
+	return nil, storage.ErrNotFound
+}
+
+func (m *mockUserRepo) Create(ctx context.Context, user *domain.User) (*domain.User, error) {
+	if m.createFn != nil {
+		return m.createFn(ctx, user)
+	}
+	return user, nil
+}
+
+type mockSocialRepo struct {
+	findByProviderUserFn func(ctx context.Context, provider domain.OAuthProvider, providerUserID string) (*domain.SocialAccount, error)
+	findByUserIDFn       func(ctx context.Context, userID string) ([]domain.SocialAccount, error)
+	linkFn               func(ctx context.Context, account *domain.SocialAccount) (*domain.SocialAccount, error)
+}
+
+func (m *mockSocialRepo) FindByProviderUser(ctx context.Context, provider domain.OAuthProvider, providerUserID string) (*domain.SocialAccount, error) {
+	if m.findByProviderUserFn != nil {
+		return m.findByProviderUserFn(ctx, provider, providerUserID)
+	}
+	return nil, storage.ErrNotFound
+}
+
+func (m *mockSocialRepo) FindByUserID(ctx context.Context, userID string) ([]domain.SocialAccount, error) {
+	if m.findByUserIDFn != nil {
+		return m.findByUserIDFn(ctx, userID)
+	}
+	return nil, nil
+}
+
+func (m *mockSocialRepo) Link(ctx context.Context, account *domain.SocialAccount) (*domain.SocialAccount, error) {
+	if m.linkFn != nil {
+		return m.linkFn(ctx, account)
+	}
+	return account, nil
+}
+
+// mockProvider implements Provider for service tests with controllable exchange results.
+type mockProvider struct {
+	name        domain.OAuthProvider
+	exchangeFn  func(ctx context.Context, code, codeVerifier string) (*domain.OAuthUserInfo, error)
+	authCodeURL string
+}
+
+func (m *mockProvider) Name() domain.OAuthProvider { return m.name }
+func (m *mockProvider) AuthCodeURL(state, _ string) string {
+	if m.authCodeURL != "" {
+		return m.authCodeURL + "?state=" + state
+	}
+	return "https://mock.provider/auth?state=" + state
+}
+func (m *mockProvider) ExchangeCode(ctx context.Context, code, codeVerifier string) (*domain.OAuthUserInfo, error) {
+	if m.exchangeFn != nil {
+		return m.exchangeFn(ctx, code, codeVerifier)
+	}
+	return &domain.OAuthUserInfo{
+		ProviderUserID: "provider-user-123",
+		Email:          "user@example.com",
+		Name:           "Test User",
+		EmailVerified:  true,
+	}, nil
+}
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+func newTestService(t *testing.T) (*Service, *mockUserRepo, *mockSocialRepo, *mockProvider) {
+	t.Helper()
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	registry := NewRegistry()
+	provider := &mockProvider{name: domain.OAuthProviderGoogle}
+	registry.Register(provider, true)
+
+	secret := []byte("test-hmac-secret-32-bytes-long!!")
+	stateMgr := NewStateManager(rdb, secret, 10*time.Minute)
+
+	userRepo := &mockUserRepo{}
+	socialRepo := &mockSocialRepo{}
+	logger, _ := zap.NewDevelopment()
+
+	svc := NewService(registry, stateMgr, userRepo, socialRepo, logger, audit.NopLogger{})
+	return svc, userRepo, socialRepo, provider
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+func TestService_BeginAuth(t *testing.T) {
+	svc, _, _, _ := newTestService(t)
+	ctx := context.Background()
+
+	t.Run("success returns auth URL and code verifier", func(t *testing.T) {
+		result, err := svc.BeginAuth(ctx, domain.OAuthProviderGoogle)
+		require.NoError(t, err)
+		assert.NotEmpty(t, result.AuthURL)
+		assert.NotEmpty(t, result.CodeVerifier)
+		assert.Contains(t, result.AuthURL, "state=")
+	})
+
+	t.Run("unregistered provider returns error", func(t *testing.T) {
+		_, err := svc.BeginAuth(ctx, domain.OAuthProviderApple)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("disabled provider returns error", func(t *testing.T) {
+		disabled := &stubProvider{name: domain.OAuthProviderGitHub}
+		svc.registry.Register(disabled, false)
+
+		_, err := svc.BeginAuth(ctx, domain.OAuthProviderGitHub)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "disabled")
+	})
+}
+
+func TestService_CompleteAuth_NewUser(t *testing.T) {
+	svc, userRepo, socialRepo, _ := newTestService(t)
+	ctx := context.Background()
+
+	userRepo.findByEmailFn = func(_ context.Context, _ string) (*domain.User, error) {
+		return nil, storage.ErrNotFound
+	}
+	userRepo.createFn = func(_ context.Context, user *domain.User) (*domain.User, error) {
+		return user, nil
+	}
+	socialRepo.findByProviderUserFn = func(_ context.Context, _ domain.OAuthProvider, _ string) (*domain.SocialAccount, error) {
+		return nil, storage.ErrNotFound
+	}
+	socialRepo.linkFn = func(_ context.Context, account *domain.SocialAccount) (*domain.SocialAccount, error) {
+		return account, nil
+	}
+
+	// Start the flow to get a valid state token.
+	begin, err := svc.BeginAuth(ctx, domain.OAuthProviderGoogle)
+	require.NoError(t, err)
+
+	// Extract state from the URL.
+	state := extractState(begin.AuthURL)
+
+	result, err := svc.CompleteAuth(ctx, state, "auth-code-123", begin.CodeVerifier)
+	require.NoError(t, err)
+	assert.True(t, result.IsNewUser)
+	assert.Equal(t, "user@example.com", result.User.Email)
+	assert.Equal(t, "Test User", result.User.Name)
+	assert.Equal(t, domain.OAuthProviderGoogle, result.SocialAccount.Provider)
+}
+
+func TestService_CompleteAuth_ExistingUserByEmail(t *testing.T) {
+	svc, userRepo, socialRepo, _ := newTestService(t)
+	ctx := context.Background()
+
+	existingUser := &domain.User{
+		ID:    "existing-user-id",
+		Email: "user@example.com",
+		Name:  "Existing User",
+	}
+
+	userRepo.findByEmailFn = func(_ context.Context, email string) (*domain.User, error) {
+		if email == "user@example.com" {
+			return existingUser, nil
+		}
+		return nil, storage.ErrNotFound
+	}
+	socialRepo.findByProviderUserFn = func(_ context.Context, _ domain.OAuthProvider, _ string) (*domain.SocialAccount, error) {
+		return nil, storage.ErrNotFound
+	}
+	socialRepo.linkFn = func(_ context.Context, account *domain.SocialAccount) (*domain.SocialAccount, error) {
+		return account, nil
+	}
+
+	begin, err := svc.BeginAuth(ctx, domain.OAuthProviderGoogle)
+	require.NoError(t, err)
+	state := extractState(begin.AuthURL)
+
+	result, err := svc.CompleteAuth(ctx, state, "auth-code-456", begin.CodeVerifier)
+	require.NoError(t, err)
+	assert.False(t, result.IsNewUser)
+	assert.Equal(t, "existing-user-id", result.User.ID)
+	assert.Equal(t, domain.OAuthProviderGoogle, result.SocialAccount.Provider)
+}
+
+func TestService_CompleteAuth_ExistingSocialAccount(t *testing.T) {
+	svc, userRepo, socialRepo, _ := newTestService(t)
+	ctx := context.Background()
+
+	existingUser := &domain.User{
+		ID:    "existing-user-id",
+		Email: "user@example.com",
+		Name:  "Existing User",
+	}
+	existingSocial := &domain.SocialAccount{
+		ID:             "social-id-1",
+		UserID:         "existing-user-id",
+		Provider:       domain.OAuthProviderGoogle,
+		ProviderUserID: "provider-user-123",
+		Email:          "user@example.com",
+	}
+
+	socialRepo.findByProviderUserFn = func(_ context.Context, _ domain.OAuthProvider, pid string) (*domain.SocialAccount, error) {
+		if pid == "provider-user-123" {
+			return existingSocial, nil
+		}
+		return nil, storage.ErrNotFound
+	}
+	userRepo.findByEmailFn = func(_ context.Context, email string) (*domain.User, error) {
+		if email == "user@example.com" {
+			return existingUser, nil
+		}
+		return nil, storage.ErrNotFound
+	}
+
+	begin, err := svc.BeginAuth(ctx, domain.OAuthProviderGoogle)
+	require.NoError(t, err)
+	state := extractState(begin.AuthURL)
+
+	result, err := svc.CompleteAuth(ctx, state, "auth-code-789", begin.CodeVerifier)
+	require.NoError(t, err)
+	assert.False(t, result.IsNewUser)
+	assert.Equal(t, "existing-user-id", result.User.ID)
+	assert.Equal(t, "social-id-1", result.SocialAccount.ID)
+}
+
+func TestService_CompleteAuth_InvalidState(t *testing.T) {
+	svc, _, _, _ := newTestService(t)
+	ctx := context.Background()
+
+	_, err := svc.CompleteAuth(ctx, "bogus-state-token", "code", "verifier")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "validate state")
+}
+
+func TestService_CompleteAuth_DuplicateSocialAccount(t *testing.T) {
+	svc, userRepo, socialRepo, _ := newTestService(t)
+	ctx := context.Background()
+
+	userRepo.findByEmailFn = func(_ context.Context, _ string) (*domain.User, error) {
+		return &domain.User{ID: "user-1", Email: "user@example.com"}, nil
+	}
+	socialRepo.findByProviderUserFn = func(_ context.Context, _ domain.OAuthProvider, _ string) (*domain.SocialAccount, error) {
+		return nil, storage.ErrNotFound
+	}
+	socialRepo.linkFn = func(_ context.Context, _ *domain.SocialAccount) (*domain.SocialAccount, error) {
+		return nil, storage.ErrDuplicateSocialAccount
+	}
+
+	begin, err := svc.BeginAuth(ctx, domain.OAuthProviderGoogle)
+	require.NoError(t, err)
+	state := extractState(begin.AuthURL)
+
+	_, err = svc.CompleteAuth(ctx, state, "code", begin.CodeVerifier)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "link social account")
+}
+
+// extractState extracts the state parameter from a URL string.
+func extractState(url string) string {
+	const marker = "state="
+	idx := 0
+	for i := 0; i < len(url)-len(marker); i++ {
+		if url[i:i+len(marker)] == marker {
+			idx = i + len(marker)
+			break
+		}
+	}
+	if idx == 0 {
+		return ""
+	}
+	end := idx
+	for end < len(url) && url[end] != '&' {
+		end++
+	}
+	return url[idx:end]
+}

--- a/internal/oauth/state.go
+++ b/internal/oauth/state.go
@@ -1,0 +1,146 @@
+package oauth
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// StateManager handles creation and validation of HMAC-signed, time-limited
+// OAuth state parameters backed by Redis for one-time consumption.
+type StateManager struct {
+	rdb        redis.Cmdable
+	hmacSecret []byte
+	ttl        time.Duration
+	nowFunc    func() time.Time // injectable clock for testing
+}
+
+// NewStateManager creates a state manager. hmacSecret must be non-empty.
+func NewStateManager(rdb redis.Cmdable, hmacSecret []byte, ttl time.Duration) *StateManager {
+	return &StateManager{
+		rdb:        rdb,
+		hmacSecret: hmacSecret,
+		ttl:        ttl,
+		nowFunc:    time.Now,
+	}
+}
+
+// statePayload is the JSON structure stored in Redis and signed by HMAC.
+type statePayload struct {
+	Nonce     string `json:"n"`
+	Provider  string `json:"p"`
+	Timestamp int64  `json:"t"`
+}
+
+const (
+	stateNonceBytes = 16
+	redisKeyPrefix  = "oauth:state:"
+)
+
+// Generate creates a new state token for the given provider. It stores the
+// state in Redis with a TTL and returns the HMAC-signed, base64url-encoded token.
+func (sm *StateManager) Generate(ctx context.Context, provider string) (string, error) {
+	nonceBuf := make([]byte, stateNonceBytes)
+	if _, err := rand.Read(nonceBuf); err != nil {
+		return "", fmt.Errorf("generate state nonce: %w", err)
+	}
+	nonce := base64.RawURLEncoding.EncodeToString(nonceBuf)
+
+	payload := statePayload{
+		Nonce:     nonce,
+		Provider:  provider,
+		Timestamp: sm.nowFunc().Unix(),
+	}
+
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal state payload: %w", err)
+	}
+
+	sig := sm.sign(payloadJSON)
+
+	// token = base64url(payload) + "." + base64url(sig)
+	token := base64.RawURLEncoding.EncodeToString(payloadJSON) +
+		"." +
+		base64.RawURLEncoding.EncodeToString(sig)
+
+	// Store in Redis for one-time consumption.
+	key := redisKeyPrefix + nonce
+	if err := sm.rdb.Set(ctx, key, provider, sm.ttl).Err(); err != nil {
+		return "", fmt.Errorf("store state in redis: %w", err)
+	}
+
+	return token, nil
+}
+
+// Validate verifies the state token's HMAC signature, checks TTL, ensures it
+// hasn't been consumed, and deletes it from Redis (one-time use). Returns the
+// provider name on success.
+func (sm *StateManager) Validate(ctx context.Context, token string) (string, error) {
+	payloadB64, sigB64, ok := splitToken(token)
+	if !ok {
+		return "", errors.New("invalid state token format")
+	}
+
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(payloadB64)
+	if err != nil {
+		return "", errors.New("invalid state token encoding")
+	}
+	sigBytes, err := base64.RawURLEncoding.DecodeString(sigB64)
+	if err != nil {
+		return "", errors.New("invalid state signature encoding")
+	}
+
+	// Verify HMAC.
+	expected := sm.sign(payloadJSON)
+	if !hmac.Equal(sigBytes, expected) {
+		return "", errors.New("state token signature mismatch")
+	}
+
+	var payload statePayload
+	if err := json.Unmarshal(payloadJSON, &payload); err != nil {
+		return "", errors.New("invalid state token payload")
+	}
+
+	// Check time-based expiry.
+	age := sm.nowFunc().Sub(time.Unix(payload.Timestamp, 0))
+	if age > sm.ttl || age < 0 {
+		return "", errors.New("state token expired")
+	}
+
+	// One-time consumption: delete from Redis.
+	key := redisKeyPrefix + payload.Nonce
+	deleted, err := sm.rdb.Del(ctx, key).Result()
+	if err != nil {
+		return "", fmt.Errorf("consume state from redis: %w", err)
+	}
+	if deleted == 0 {
+		return "", errors.New("state token already consumed or not found")
+	}
+
+	return payload.Provider, nil
+}
+
+func (sm *StateManager) sign(data []byte) []byte {
+	mac := hmac.New(sha256.New, sm.hmacSecret)
+	_, _ = mac.Write(data)
+	return mac.Sum(nil)
+}
+
+// splitToken splits "a.b" into ("a", "b", true). Returns false if no dot.
+func splitToken(token string) (string, string, bool) {
+	for i := len(token) - 1; i >= 0; i-- {
+		if token[i] == '.' {
+			return token[:i], token[i+1:], true
+		}
+	}
+	return "", "", false
+}

--- a/internal/oauth/state_test.go
+++ b/internal/oauth/state_test.go
@@ -1,0 +1,118 @@
+package oauth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestRedis(t *testing.T) (redis.Cmdable, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	return rdb, mr
+}
+
+func TestStateManager_GenerateAndValidate(t *testing.T) {
+	rdb, _ := newTestRedis(t)
+	secret := []byte("test-hmac-secret-32-bytes-long!!")
+	sm := NewStateManager(rdb, secret, 10*time.Minute)
+
+	ctx := context.Background()
+
+	t.Run("round-trip generate and validate", func(t *testing.T) {
+		token, err := sm.Generate(ctx, "google")
+		require.NoError(t, err)
+		assert.NotEmpty(t, token)
+		assert.Contains(t, token, ".")
+
+		provider, err := sm.Validate(ctx, token)
+		require.NoError(t, err)
+		assert.Equal(t, "google", provider)
+	})
+
+	t.Run("one-time consumption (replay rejected)", func(t *testing.T) {
+		token, err := sm.Generate(ctx, "github")
+		require.NoError(t, err)
+
+		// First validation succeeds.
+		provider, err := sm.Validate(ctx, token)
+		require.NoError(t, err)
+		assert.Equal(t, "github", provider)
+
+		// Second validation fails — token already consumed.
+		_, err = sm.Validate(ctx, token)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "already consumed")
+	})
+
+	t.Run("invalid format rejected", func(t *testing.T) {
+		_, err := sm.Validate(ctx, "no-dot-here")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid state token format")
+	})
+
+	t.Run("tampered signature rejected", func(t *testing.T) {
+		token, err := sm.Generate(ctx, "apple")
+		require.NoError(t, err)
+
+		// Tamper with the last character.
+		tampered := token[:len(token)-1] + "X"
+		_, err = sm.Validate(ctx, tampered)
+		assert.Error(t, err)
+	})
+
+	t.Run("wrong HMAC key rejected", func(t *testing.T) {
+		token, err := sm.Generate(ctx, "google")
+		require.NoError(t, err)
+
+		wrongSM := NewStateManager(rdb, []byte("wrong-secret-key-is-different!!!"), 10*time.Minute)
+		_, err = wrongSM.Validate(ctx, token)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "signature mismatch")
+	})
+}
+
+func TestStateManager_Expiry(t *testing.T) {
+	rdb, mr := newTestRedis(t)
+	secret := []byte("test-hmac-secret-32-bytes-long!!")
+	ttl := 5 * time.Minute
+	sm := NewStateManager(rdb, secret, ttl)
+
+	ctx := context.Background()
+
+	t.Run("expired token rejected", func(t *testing.T) {
+		now := time.Now()
+		sm.nowFunc = func() time.Time { return now }
+
+		token, err := sm.Generate(ctx, "google")
+		require.NoError(t, err)
+
+		// Advance clock past TTL.
+		sm.nowFunc = func() time.Time { return now.Add(6 * time.Minute) }
+
+		_, err = sm.Validate(ctx, token)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "expired")
+	})
+
+	t.Run("redis TTL causes key expiry", func(t *testing.T) {
+		now := time.Now()
+		sm.nowFunc = func() time.Time { return now }
+
+		token, err := sm.Generate(ctx, "github")
+		require.NoError(t, err)
+
+		// Fast-forward miniredis to expire the key.
+		mr.FastForward(6 * time.Minute)
+
+		_, err = sm.Validate(ctx, token)
+		assert.Error(t, err)
+	})
+}

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -41,4 +41,10 @@ var (
 
 	// ErrMFAMaxAttempts indicates the user has exceeded maximum MFA verification attempts.
 	ErrMFAMaxAttempts = errors.New("mfa max attempts exceeded")
+
+	// ErrDuplicateSocialAccount indicates the provider+provider_user_id pair already exists.
+	ErrDuplicateSocialAccount = errors.New("duplicate social account")
+
+	// ErrOAuthStateNotFound indicates the OAuth state token does not exist or has expired.
+	ErrOAuthStateNotFound = errors.New("oauth state not found")
 )

--- a/internal/storage/social_account_repository.go
+++ b/internal/storage/social_account_repository.go
@@ -1,0 +1,21 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// SocialAccountRepository defines persistence operations for OAuth social accounts.
+type SocialAccountRepository interface {
+	// FindByProviderUser looks up a social account by provider + provider user ID.
+	// Returns ErrNotFound if no match exists.
+	FindByProviderUser(ctx context.Context, provider domain.OAuthProvider, providerUserID string) (*domain.SocialAccount, error)
+
+	// FindByUserID returns all social accounts linked to a given user.
+	FindByUserID(ctx context.Context, userID string) ([]domain.SocialAccount, error)
+
+	// Link creates a new social account record linking a provider identity to a user.
+	// Returns ErrDuplicateSocialAccount if the provider+providerUserID pair already exists.
+	Link(ctx context.Context, account *domain.SocialAccount) (*domain.SocialAccount, error)
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-252.

Closes #252

## Changes

- Define `Provider` interface with `AuthCodeURL(state, codeVerifier)`, `ExchangeCode(ctx, code, codeVerifier)`, and `UserInfo` return type
- Build provider `Registry` (register/lookup providers, enable/disable via config)
- Implement PKCE utilities: `code_verifier` generation (RFC 7636 S256) and `code_challenge` computation
- Implement state parameter management with HMAC-signed, time-limited CSRF tokens (using Redis for state storage)
- Implement Google provider (`golang.org/x/oauth2/google`, email+profile scopes)
- Implement GitHub provider (`golang.org/x/oauth2/github`, `user:email` scope)
- Implement Apple provider (custom JWT-based ID token validation, email+name)
- Define internal repository interfaces for the OAuth orchestrating `Service` (account linking: find-or-create user by email, link social account, prevent duplicate provider+provider_user_id)
- Comprehensive unit tests: provider round-trips (mocked HTTP), PKCE generation/verification, state signing/validation/expiry, registry enable/disable, service account-linking logic with mocked repos