### PR TITLE
GH-253: Config, domain model, migration, and storage layer (`internal/config/`, `internal/domain/`, `migrations/`, `internal/storage/`, `internal/storage/mocks/`)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,23 @@ type Config struct {
 	Email        EmailConfig
 	DPoP         DPoPConfig
 	MFA          MFAConfig
+	OAuth        OAuthConfig
+}
+
+// OAuthProviderConfig holds credentials for a single OAuth provider.
+type OAuthProviderConfig struct {
+	Enabled      bool   // OAUTH_{PROVIDER}_ENABLED
+	ClientID     string // OAUTH_{PROVIDER}_CLIENT_ID
+	ClientSecret string // OAUTH_{PROVIDER}_CLIENT_SECRET
+}
+
+// OAuthConfig holds social-login OAuth settings.
+type OAuthConfig struct {
+	Google          OAuthProviderConfig
+	GitHub          OAuthProviderConfig
+	Apple           OAuthProviderConfig
+	StateSecret     string // OAUTH_STATE_SECRET: HMAC key for state tokens
+	CallbackBaseURL string // OAUTH_CALLBACK_BASE_URL: base URL for redirect URIs
 }
 
 // MFAConfig holds multi-factor authentication settings.
@@ -232,6 +249,10 @@ func Load() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	oauthCfg, err := loadOAuth(l)
+	if err != nil {
+		return nil, err
+	}
 
 	if len(l.missing) > 0 {
 		return nil, fmt.Errorf("missing required environment variables: %s", strings.Join(l.missing, ", "))
@@ -254,6 +275,7 @@ func Load() (*Config, error) {
 		Email:        email,
 		DPoP:         dpop,
 		MFA:          mfaCfg,
+		OAuth:        oauthCfg,
 	}, nil
 }
 
@@ -547,6 +569,52 @@ func loadMFA(l *loader) (MFAConfig, error) {
 		Digits:          digits,
 		Period:          period,
 		BackupCodeCount: backupCount,
+	}, nil
+}
+
+func loadOAuth(l *loader) (OAuthConfig, error) {
+	stateSecret := l.optStr("OAUTH_STATE_SECRET", "")
+	callbackBaseURL := l.optStr("OAUTH_CALLBACK_BASE_URL", "")
+
+	googleEnabled, err := l.optBool("OAUTH_GOOGLE_ENABLED", false)
+	if err != nil {
+		return OAuthConfig{}, err
+	}
+	googleClientID := l.optStr("OAUTH_GOOGLE_CLIENT_ID", "")
+	googleClientSecret := l.optStr("OAUTH_GOOGLE_CLIENT_SECRET", "")
+
+	githubEnabled, err := l.optBool("OAUTH_GITHUB_ENABLED", false)
+	if err != nil {
+		return OAuthConfig{}, err
+	}
+	githubClientID := l.optStr("OAUTH_GITHUB_CLIENT_ID", "")
+	githubClientSecret := l.optStr("OAUTH_GITHUB_CLIENT_SECRET", "")
+
+	appleEnabled, err := l.optBool("OAUTH_APPLE_ENABLED", false)
+	if err != nil {
+		return OAuthConfig{}, err
+	}
+	appleClientID := l.optStr("OAUTH_APPLE_CLIENT_ID", "")
+	appleClientSecret := l.optStr("OAUTH_APPLE_CLIENT_SECRET", "")
+
+	return OAuthConfig{
+		Google: OAuthProviderConfig{
+			Enabled:      googleEnabled,
+			ClientID:     googleClientID,
+			ClientSecret: googleClientSecret,
+		},
+		GitHub: OAuthProviderConfig{
+			Enabled:      githubEnabled,
+			ClientID:     githubClientID,
+			ClientSecret: githubClientSecret,
+		},
+		Apple: OAuthProviderConfig{
+			Enabled:      appleEnabled,
+			ClientID:     appleClientID,
+			ClientSecret: appleClientSecret,
+		},
+		StateSecret:     stateSecret,
+		CallbackBaseURL: callbackBaseURL,
 	}, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -92,6 +92,15 @@ func TestLoad_AllDefaults(t *testing.T) {
 	assert.False(t, cfg.DPoP.Enabled)
 	assert.Equal(t, 5*time.Minute, cfg.DPoP.NonceTTL)
 	assert.Equal(t, 1*time.Minute, cfg.DPoP.JTIWindow)
+
+	// OAuth defaults
+	assert.False(t, cfg.OAuth.Google.Enabled)
+	assert.Equal(t, "", cfg.OAuth.Google.ClientID)
+	assert.Equal(t, "", cfg.OAuth.Google.ClientSecret)
+	assert.False(t, cfg.OAuth.GitHub.Enabled)
+	assert.False(t, cfg.OAuth.Apple.Enabled)
+	assert.Equal(t, "", cfg.OAuth.StateSecret)
+	assert.Equal(t, "", cfg.OAuth.CallbackBaseURL)
 }
 
 func TestLoad_EmailConfig(t *testing.T) {
@@ -436,6 +445,51 @@ func TestLoad_InvalidLockoutDuration(t *testing.T) {
 	_, err := Load()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "RATE_LIMIT_LOCKOUT_DURATION")
+}
+
+func TestLoad_OAuthCustomValues(t *testing.T) {
+	env := requiredEnv()
+	env["OAUTH_GOOGLE_ENABLED"] = "true"
+	env["OAUTH_GOOGLE_CLIENT_ID"] = "google-id"
+	env["OAUTH_GOOGLE_CLIENT_SECRET"] = "google-secret"
+	env["OAUTH_GITHUB_ENABLED"] = "true"
+	env["OAUTH_GITHUB_CLIENT_ID"] = "github-id"
+	env["OAUTH_GITHUB_CLIENT_SECRET"] = "github-secret"
+	env["OAUTH_APPLE_ENABLED"] = "true"
+	env["OAUTH_APPLE_CLIENT_ID"] = "apple-id"
+	env["OAUTH_APPLE_CLIENT_SECRET"] = "apple-secret"
+	env["OAUTH_STATE_SECRET"] = "hmac-key-123"
+	env["OAUTH_CALLBACK_BASE_URL"] = "https://auth.example.com/callback"
+	setEnv(t, env)
+
+	cfg, err := Load()
+	require.NoError(t, err)
+
+	assert.True(t, cfg.OAuth.Google.Enabled)
+	assert.Equal(t, "google-id", cfg.OAuth.Google.ClientID)
+	assert.Equal(t, "google-secret", cfg.OAuth.Google.ClientSecret)
+
+	assert.True(t, cfg.OAuth.GitHub.Enabled)
+	assert.Equal(t, "github-id", cfg.OAuth.GitHub.ClientID)
+	assert.Equal(t, "github-secret", cfg.OAuth.GitHub.ClientSecret)
+
+	assert.True(t, cfg.OAuth.Apple.Enabled)
+	assert.Equal(t, "apple-id", cfg.OAuth.Apple.ClientID)
+	assert.Equal(t, "apple-secret", cfg.OAuth.Apple.ClientSecret)
+
+	assert.Equal(t, "hmac-key-123", cfg.OAuth.StateSecret)
+	assert.Equal(t, "https://auth.example.com/callback", cfg.OAuth.CallbackBaseURL)
+}
+
+func TestLoad_OAuthInvalidBoolean(t *testing.T) {
+	env := requiredEnv()
+	env["OAUTH_GOOGLE_ENABLED"] = "nope"
+	setEnv(t, env)
+
+	_, err := Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "OAUTH_GOOGLE_ENABLED")
+	assert.Contains(t, err.Error(), "invalid boolean")
 }
 
 func TestLoad_DPoPCustomValues(t *testing.T) {

--- a/internal/domain/oauth.go
+++ b/internal/domain/oauth.go
@@ -1,0 +1,13 @@
+package domain
+
+import "time"
+
+// OAuthAccount represents a linked social-login identity for a user.
+type OAuthAccount struct {
+	ID             string    `json:"id"               db:"id"`
+	UserID         string    `json:"user_id"          db:"user_id"`
+	Provider       string    `json:"provider"         db:"provider"`
+	ProviderUserID string    `json:"provider_user_id" db:"provider_user_id"`
+	Email          string    `json:"email"            db:"email"`
+	CreatedAt      time.Time `json:"created_at"       db:"created_at"`
+}

--- a/internal/domain/sentinel_errors.go
+++ b/internal/domain/sentinel_errors.go
@@ -23,6 +23,10 @@ var (
 	// Session errors.
 	ErrSessionInactive = errors.New("session inactive due to inactivity")
 
+	// OAuth errors.
+	ErrOAuthAccountNotFound      = errors.New("oauth account not found")
+	ErrOAuthAccountAlreadyLinked = errors.New("oauth account already linked")
+
 	// Authorization errors.
 	ErrInsufficientScope = errors.New("insufficient scope")
 	ErrInsufficientRole  = errors.New("insufficient role")

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -41,4 +41,7 @@ var (
 
 	// ErrMFAMaxAttempts indicates the user has exceeded maximum MFA verification attempts.
 	ErrMFAMaxAttempts = errors.New("mfa max attempts exceeded")
+
+	// ErrDuplicateOAuthAccount indicates the provider+provider_user_id pair already exists.
+	ErrDuplicateOAuthAccount = errors.New("duplicate oauth account")
 )

--- a/internal/storage/mocks/mocks_test.go
+++ b/internal/storage/mocks/mocks_test.go
@@ -13,4 +13,5 @@ func TestInterfaceCompliance(t *testing.T) {
 	var _ storage.AdminUserRepository = (*mocks.MockAdminUserRepository)(nil)
 	var _ storage.ClientRepository = (*mocks.MockClientRepository)(nil)
 	var _ storage.RefreshTokenRepository = (*mocks.MockRefreshTokenRepository)(nil)
+	var _ storage.OAuthAccountRepository = (*mocks.MockOAuthAccountRepository)(nil)
 }

--- a/internal/storage/mocks/oauth_account_repository.go
+++ b/internal/storage/mocks/oauth_account_repository.go
@@ -1,0 +1,35 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// MockOAuthAccountRepository is a configurable mock for storage.OAuthAccountRepository.
+type MockOAuthAccountRepository struct {
+	CreateFn                          func(ctx context.Context, account *domain.OAuthAccount) (*domain.OAuthAccount, error)
+	FindByProviderAndProviderUserIDFn func(ctx context.Context, provider, providerUserID string) (*domain.OAuthAccount, error)
+	FindByUserIDFn                    func(ctx context.Context, userID string) ([]domain.OAuthAccount, error)
+	DeleteByUserIDAndProviderFn       func(ctx context.Context, userID, provider string) error
+}
+
+// Create delegates to CreateFn.
+func (m *MockOAuthAccountRepository) Create(ctx context.Context, account *domain.OAuthAccount) (*domain.OAuthAccount, error) {
+	return m.CreateFn(ctx, account)
+}
+
+// FindByProviderAndProviderUserID delegates to FindByProviderAndProviderUserIDFn.
+func (m *MockOAuthAccountRepository) FindByProviderAndProviderUserID(ctx context.Context, provider, providerUserID string) (*domain.OAuthAccount, error) {
+	return m.FindByProviderAndProviderUserIDFn(ctx, provider, providerUserID)
+}
+
+// FindByUserID delegates to FindByUserIDFn.
+func (m *MockOAuthAccountRepository) FindByUserID(ctx context.Context, userID string) ([]domain.OAuthAccount, error) {
+	return m.FindByUserIDFn(ctx, userID)
+}
+
+// DeleteByUserIDAndProvider delegates to DeleteByUserIDAndProviderFn.
+func (m *MockOAuthAccountRepository) DeleteByUserIDAndProvider(ctx context.Context, userID, provider string) error {
+	return m.DeleteByUserIDAndProviderFn(ctx, userID, provider)
+}

--- a/internal/storage/oauth_account_repository.go
+++ b/internal/storage/oauth_account_repository.go
@@ -1,0 +1,25 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// OAuthAccountRepository defines persistence operations for linked OAuth identities.
+type OAuthAccountRepository interface {
+	// Create inserts a new OAuth account link.
+	// Returns ErrDuplicateOAuthAccount if the provider+provider_user_id pair already exists.
+	Create(ctx context.Context, account *domain.OAuthAccount) (*domain.OAuthAccount, error)
+
+	// FindByProviderAndProviderUserID looks up an OAuth account by provider identity.
+	// Returns ErrNotFound if no matching record exists.
+	FindByProviderAndProviderUserID(ctx context.Context, provider, providerUserID string) (*domain.OAuthAccount, error)
+
+	// FindByUserID returns all OAuth accounts linked to the given user.
+	FindByUserID(ctx context.Context, userID string) ([]domain.OAuthAccount, error)
+
+	// DeleteByUserIDAndProvider removes an OAuth account link for a user and provider.
+	// Returns ErrNotFound if no matching record exists.
+	DeleteByUserIDAndProvider(ctx context.Context, userID, provider string) error
+}

--- a/internal/storage/postgres_oauth_account_repository.go
+++ b/internal/storage/postgres_oauth_account_repository.go
@@ -1,0 +1,115 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// PostgresOAuthAccountRepository implements OAuthAccountRepository using pgx against PostgreSQL.
+type PostgresOAuthAccountRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresOAuthAccountRepository creates a new PostgreSQL-backed OAuth account repository.
+func NewPostgresOAuthAccountRepository(pool *pgxpool.Pool) *PostgresOAuthAccountRepository {
+	return &PostgresOAuthAccountRepository{pool: pool}
+}
+
+// Create inserts a new OAuth account link.
+func (r *PostgresOAuthAccountRepository) Create(ctx context.Context, account *domain.OAuthAccount) (*domain.OAuthAccount, error) {
+	query := `
+		INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, email, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id, user_id, provider, provider_user_id, email, created_at`
+
+	out := &domain.OAuthAccount{}
+	err := r.pool.QueryRow(ctx, query,
+		account.ID, account.UserID, account.Provider,
+		account.ProviderUserID, account.Email, account.CreatedAt,
+	).Scan(
+		&out.ID, &out.UserID, &out.Provider,
+		&out.ProviderUserID, &out.Email, &out.CreatedAt,
+	)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return nil, fmt.Errorf("provider %s user %s: %w", account.Provider, account.ProviderUserID, ErrDuplicateOAuthAccount)
+		}
+		return nil, fmt.Errorf("insert oauth account: %w", err)
+	}
+
+	return out, nil
+}
+
+// FindByProviderAndProviderUserID looks up an OAuth account by provider identity.
+func (r *PostgresOAuthAccountRepository) FindByProviderAndProviderUserID(ctx context.Context, provider, providerUserID string) (*domain.OAuthAccount, error) {
+	query := `
+		SELECT id, user_id, provider, provider_user_id, email, created_at
+		FROM oauth_accounts
+		WHERE provider = $1 AND provider_user_id = $2`
+
+	out := &domain.OAuthAccount{}
+	err := r.pool.QueryRow(ctx, query, provider, providerUserID).Scan(
+		&out.ID, &out.UserID, &out.Provider,
+		&out.ProviderUserID, &out.Email, &out.CreatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("provider %s user %s: %w", provider, providerUserID, ErrNotFound)
+		}
+		return nil, fmt.Errorf("find oauth account by provider: %w", err)
+	}
+
+	return out, nil
+}
+
+// FindByUserID returns all OAuth accounts linked to the given user.
+func (r *PostgresOAuthAccountRepository) FindByUserID(ctx context.Context, userID string) ([]domain.OAuthAccount, error) {
+	query := `
+		SELECT id, user_id, provider, provider_user_id, email, created_at
+		FROM oauth_accounts
+		WHERE user_id = $1
+		ORDER BY created_at`
+
+	rows, err := r.pool.Query(ctx, query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("find oauth accounts by user: %w", err)
+	}
+	defer rows.Close()
+
+	var accounts []domain.OAuthAccount
+	for rows.Next() {
+		var a domain.OAuthAccount
+		if err := rows.Scan(&a.ID, &a.UserID, &a.Provider, &a.ProviderUserID, &a.Email, &a.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan oauth account: %w", err)
+		}
+		accounts = append(accounts, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate oauth accounts: %w", err)
+	}
+
+	return accounts, nil
+}
+
+// DeleteByUserIDAndProvider removes an OAuth account link for a user and provider.
+func (r *PostgresOAuthAccountRepository) DeleteByUserIDAndProvider(ctx context.Context, userID, provider string) error {
+	query := `DELETE FROM oauth_accounts WHERE user_id = $1 AND provider = $2`
+
+	tag, err := r.pool.Exec(ctx, query, userID, provider)
+	if err != nil {
+		return fmt.Errorf("delete oauth account: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("user %s provider %s: %w", userID, provider, ErrNotFound)
+	}
+
+	return nil
+}

--- a/migrations/000008_create_oauth_accounts_table.down.sql
+++ b/migrations/000008_create_oauth_accounts_table.down.sql
@@ -1,0 +1,3 @@
+-- 000008_create_oauth_accounts_table.down.sql
+
+DROP TABLE IF EXISTS oauth_accounts;

--- a/migrations/000008_create_oauth_accounts_table.up.sql
+++ b/migrations/000008_create_oauth_accounts_table.up.sql
@@ -1,0 +1,15 @@
+-- 000008_create_oauth_accounts_table.up.sql
+-- Stores linked social-login identities for users.
+
+CREATE TABLE oauth_accounts (
+    id               TEXT        PRIMARY KEY,
+    user_id          TEXT        NOT NULL REFERENCES users(id),
+    provider         TEXT        NOT NULL,
+    provider_user_id TEXT        NOT NULL,
+    email            TEXT        NOT NULL DEFAULT '',
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT oauth_accounts_provider_user UNIQUE (provider, provider_user_id)
+);
+
+CREATE INDEX idx_oauth_accounts_user_id ON oauth_accounts (user_id);


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-253.

Closes #253

## Changes

- Add `OAuthConfig` to `config.Config` with per-provider settings: `OAUTH_GOOGLE_ENABLED`, `OAUTH_GOOGLE_CLIENT_ID`, `OAUTH_GOOGLE_CLIENT_SECRET`, (same for GitHub and Apple), `OAUTH_STATE_SECRET` (HMAC key for state tokens), `OAUTH_CALLBACK_BASE_URL`
- Add `loadOAuth(l *loader)` following the existing config loading pattern, wire into `Load()`
- Add `OAuthAccount` domain struct in `internal/domain/oauth.go`: `ID`, `UserID`, `Provider`, `ProviderUserID`, `Email`, `CreatedAt`
- Add sentinel errors: `ErrOAuthAccountNotFound`, `ErrOAuthAccountAlreadyLinked`
- Create migration `000008_create_oauth_accounts_table.{up,down}.sql` with `oauth_accounts` table (user_id FK → users, unique constraint on provider+provider_user_id, index on user_id)
- Implement `OAuthAccountRepository` interface + `PostgresOAuthAccountRepository` in `internal/storage/` with methods: `Create`, `FindByProviderAndProviderUserID`, `FindByUserID`, `DeleteByUserIDAndProvider`
- Add mock implementation in `internal/storage/mocks/`
- Update config tests for new OAuth env vars