### PR TITLE
GH-266: Database migration + Storage repository implementation

### DIFF
--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -41,4 +41,7 @@ var (
 
 	// ErrMFAMaxAttempts indicates the user has exceeded maximum MFA verification attempts.
 	ErrMFAMaxAttempts = errors.New("mfa max attempts exceeded")
+
+	// ErrDuplicateOAuthAccount indicates an OAuth account with the same provider and provider user ID already exists.
+	ErrDuplicateOAuthAccount = errors.New("duplicate oauth account")
 )

--- a/internal/storage/mocks/mocks_test.go
+++ b/internal/storage/mocks/mocks_test.go
@@ -13,4 +13,5 @@ func TestInterfaceCompliance(t *testing.T) {
 	var _ storage.AdminUserRepository = (*mocks.MockAdminUserRepository)(nil)
 	var _ storage.ClientRepository = (*mocks.MockClientRepository)(nil)
 	var _ storage.RefreshTokenRepository = (*mocks.MockRefreshTokenRepository)(nil)
+	var _ storage.OAuthAccountRepository = (*mocks.MockOAuthAccountRepository)(nil)
 }

--- a/internal/storage/mocks/oauth_repository.go
+++ b/internal/storage/mocks/oauth_repository.go
@@ -1,0 +1,35 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// MockOAuthAccountRepository is a configurable mock for storage.OAuthAccountRepository.
+type MockOAuthAccountRepository struct {
+	CreateFn                          func(ctx context.Context, account *domain.OAuthAccount) (*domain.OAuthAccount, error)
+	FindByProviderAndProviderUserIDFn func(ctx context.Context, provider, providerUserID string) (*domain.OAuthAccount, error)
+	FindByUserIDFn                    func(ctx context.Context, userID string) ([]domain.OAuthAccount, error)
+	DeleteFn                          func(ctx context.Context, userID, provider string) error
+}
+
+// Create delegates to CreateFn.
+func (m *MockOAuthAccountRepository) Create(ctx context.Context, account *domain.OAuthAccount) (*domain.OAuthAccount, error) {
+	return m.CreateFn(ctx, account)
+}
+
+// FindByProviderAndProviderUserID delegates to FindByProviderAndProviderUserIDFn.
+func (m *MockOAuthAccountRepository) FindByProviderAndProviderUserID(ctx context.Context, provider, providerUserID string) (*domain.OAuthAccount, error) {
+	return m.FindByProviderAndProviderUserIDFn(ctx, provider, providerUserID)
+}
+
+// FindByUserID delegates to FindByUserIDFn.
+func (m *MockOAuthAccountRepository) FindByUserID(ctx context.Context, userID string) ([]domain.OAuthAccount, error) {
+	return m.FindByUserIDFn(ctx, userID)
+}
+
+// Delete delegates to DeleteFn.
+func (m *MockOAuthAccountRepository) Delete(ctx context.Context, userID, provider string) error {
+	return m.DeleteFn(ctx, userID, provider)
+}

--- a/internal/storage/oauth_repository_pg.go
+++ b/internal/storage/oauth_repository_pg.go
@@ -1,0 +1,116 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// oauthAccountColumns lists the columns returned by oauth_accounts queries.
+const oauthAccountColumns = `id, user_id, provider, provider_user_id, email, created_at`
+
+// PostgresOAuthAccountRepository implements OAuthAccountRepository using pgx against PostgreSQL.
+type PostgresOAuthAccountRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresOAuthAccountRepository creates a new PostgreSQL-backed OAuth account repository.
+func NewPostgresOAuthAccountRepository(pool *pgxpool.Pool) *PostgresOAuthAccountRepository {
+	return &PostgresOAuthAccountRepository{pool: pool}
+}
+
+// scanOAuthAccount scans a single row into a domain.OAuthAccount.
+func scanOAuthAccount(row pgx.Row) (*domain.OAuthAccount, error) {
+	a := &domain.OAuthAccount{}
+	err := row.Scan(&a.ID, &a.UserID, &a.Provider, &a.ProviderUserID, &a.Email, &a.CreatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return a, nil
+}
+
+// Create stores a new OAuth account link. Returns ErrDuplicateOAuthAccount if the
+// provider+provider_user_id combination already exists.
+func (r *PostgresOAuthAccountRepository) Create(ctx context.Context, account *domain.OAuthAccount) (*domain.OAuthAccount, error) {
+	query := fmt.Sprintf(`
+		INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, email, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING %s`, oauthAccountColumns)
+
+	out, err := scanOAuthAccount(r.pool.QueryRow(ctx, query,
+		account.ID, account.UserID, account.Provider,
+		account.ProviderUserID, account.Email, account.CreatedAt,
+	))
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return nil, fmt.Errorf("provider %s user %s: %w", account.Provider, account.ProviderUserID, ErrDuplicateOAuthAccount)
+		}
+		return nil, fmt.Errorf("insert oauth account: %w", err)
+	}
+	return out, nil
+}
+
+// FindByProviderAndProviderUserID returns the OAuth account for a given provider and provider user ID.
+// Returns ErrNotFound if no matching account exists.
+func (r *PostgresOAuthAccountRepository) FindByProviderAndProviderUserID(ctx context.Context, provider, providerUserID string) (*domain.OAuthAccount, error) {
+	query := fmt.Sprintf(`SELECT %s FROM oauth_accounts WHERE provider = $1 AND provider_user_id = $2`, oauthAccountColumns)
+
+	out, err := scanOAuthAccount(r.pool.QueryRow(ctx, query, provider, providerUserID))
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, fmt.Errorf("provider %s user %s: %w", provider, providerUserID, ErrNotFound)
+		}
+		return nil, fmt.Errorf("find oauth account: %w", err)
+	}
+	return out, nil
+}
+
+// FindByUserID returns all OAuth accounts linked to a user.
+func (r *PostgresOAuthAccountRepository) FindByUserID(ctx context.Context, userID string) ([]domain.OAuthAccount, error) {
+	query := fmt.Sprintf(`SELECT %s FROM oauth_accounts WHERE user_id = $1 ORDER BY created_at`, oauthAccountColumns)
+
+	rows, err := r.pool.Query(ctx, query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("find oauth accounts for user %s: %w", userID, err)
+	}
+	defer rows.Close()
+
+	var accounts []domain.OAuthAccount
+	for rows.Next() {
+		var a domain.OAuthAccount
+		if err := rows.Scan(&a.ID, &a.UserID, &a.Provider, &a.ProviderUserID, &a.Email, &a.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan oauth account: %w", err)
+		}
+		accounts = append(accounts, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate oauth accounts: %w", err)
+	}
+
+	return accounts, nil
+}
+
+// Delete removes the OAuth account link for a user and provider.
+// Returns ErrNotFound if no matching account exists.
+func (r *PostgresOAuthAccountRepository) Delete(ctx context.Context, userID, provider string) error {
+	query := `DELETE FROM oauth_accounts WHERE user_id = $1 AND provider = $2`
+
+	tag, err := r.pool.Exec(ctx, query, userID, provider)
+	if err != nil {
+		return fmt.Errorf("delete oauth account: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("user %s provider %s: %w", userID, provider, ErrNotFound)
+	}
+	return nil
+}

--- a/internal/storage/oauth_repository_pg_test.go
+++ b/internal/storage/oauth_repository_pg_test.go
@@ -1,0 +1,104 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+func TestScanOAuthAccount_ErrNoRows(t *testing.T) {
+	// scanOAuthAccount should map pgx.ErrNoRows to ErrNotFound.
+	mockRow := &errRow{err: pgx.ErrNoRows}
+	_, err := scanOAuthAccount(mockRow)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestScanOAuthAccount_Success(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	row := &fakeOAuthAccountRow{
+		id:             "oa-1",
+		userID:         "u-1",
+		provider:       "google",
+		providerUserID: "g-123",
+		email:          "test@example.com",
+		createdAt:      now,
+	}
+
+	account, err := scanOAuthAccount(row)
+	require.NoError(t, err)
+	assert.Equal(t, "oa-1", account.ID)
+	assert.Equal(t, "u-1", account.UserID)
+	assert.Equal(t, "google", account.Provider)
+	assert.Equal(t, "g-123", account.ProviderUserID)
+	assert.Equal(t, "test@example.com", account.Email)
+	assert.Equal(t, now, account.CreatedAt)
+}
+
+// errRow implements pgx.Row returning the configured error.
+type errRow struct {
+	err error
+}
+
+func (r *errRow) Scan(_ ...interface{}) error {
+	return r.err
+}
+
+// fakeOAuthAccountRow implements pgx.Row, populating scan destinations with preset values.
+type fakeOAuthAccountRow struct {
+	id, userID, provider, providerUserID, email string
+	createdAt                                   time.Time
+}
+
+func (r *fakeOAuthAccountRow) Scan(dest ...interface{}) error {
+	if len(dest) != 6 {
+		return pgx.ErrNoRows
+	}
+	*dest[0].(*string) = r.id
+	*dest[1].(*string) = r.userID
+	*dest[2].(*string) = r.provider
+	*dest[3].(*string) = r.providerUserID
+	*dest[4].(*string) = r.email
+	*dest[5].(*time.Time) = r.createdAt
+	return nil
+}
+
+// Verify the concrete type satisfies the interface at compile time.
+var _ OAuthAccountRepository = (*PostgresOAuthAccountRepository)(nil)
+
+// Verify domain model fields align with scan order.
+func TestOAuthAccountColumnCount(t *testing.T) {
+	// oauthAccountColumns should have exactly 6 fields matching scanOAuthAccount.
+	expected := "id, user_id, provider, provider_user_id, email, created_at"
+	assert.Equal(t, expected, oauthAccountColumns)
+}
+
+func TestNewPostgresOAuthAccountRepository(t *testing.T) {
+	repo := NewPostgresOAuthAccountRepository(nil)
+	assert.NotNil(t, repo)
+	assert.Nil(t, repo.pool)
+}
+
+// Verify the domain struct used by the repository has the expected fields.
+func TestOAuthAccountDomainFields(t *testing.T) {
+	now := time.Now().UTC()
+	a := domain.OAuthAccount{
+		ID:             "oa-1",
+		UserID:         "u-1",
+		Provider:       "github",
+		ProviderUserID: "gh-456",
+		Email:          "dev@example.com",
+		CreatedAt:      now,
+	}
+	assert.Equal(t, "oa-1", a.ID)
+	assert.Equal(t, "u-1", a.UserID)
+	assert.Equal(t, "github", a.Provider)
+	assert.Equal(t, "gh-456", a.ProviderUserID)
+	assert.Equal(t, "dev@example.com", a.Email)
+	assert.Equal(t, now, a.CreatedAt)
+}

--- a/migrations/000008_create_oauth_accounts_table.down.sql
+++ b/migrations/000008_create_oauth_accounts_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS oauth_accounts;

--- a/migrations/000008_create_oauth_accounts_table.up.sql
+++ b/migrations/000008_create_oauth_accounts_table.up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE oauth_accounts (
+    id               TEXT        PRIMARY KEY,
+    user_id          TEXT        NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    provider         TEXT        NOT NULL,
+    provider_user_id TEXT        NOT NULL,
+    email            TEXT        NOT NULL DEFAULT '',
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT oauth_accounts_provider_provider_user_id_unique UNIQUE (provider, provider_user_id)
+);
+
+CREATE INDEX idx_oauth_accounts_user_id ON oauth_accounts (user_id);
+CREATE INDEX idx_oauth_accounts_provider_user ON oauth_accounts (provider, provider_user_id);


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-266.

Closes #266

## Changes

Create the `oauth_accounts` table migration in `migrations/` (up + down SQL) and implement `PostgresOAuthAccountRepository` in `internal/storage/` with Create, FindByProviderAndProviderUserID, FindByUserID, and Delete methods. Also add a mock implementation in `internal/storage/mocks/` for testing. This is the data foundation that everything else depends on.