### PR TITLE
GH-279: Go benchmarks for password and token packages

### DIFF
--- a/internal/password/hasher_test.go
+++ b/internal/password/hasher_test.go
@@ -128,3 +128,59 @@ func TestHash_EmptyPassword(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, hash)
 }
+
+// ── Benchmarks ────────────────────────────────────────────────────────────────
+
+func BenchmarkHash_NoPepper(b *testing.B) {
+	h := password.New(nil)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := h.Hash("correct-horse-battery-staple")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkHash_WithPepper(b *testing.B) {
+	pepper := []byte("bench-pepper-key-32-bytes-long!!")
+	h := password.New(pepper)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := h.Hash("correct-horse-battery-staple")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVerify_NoPepper(b *testing.B) {
+	h := password.New(nil)
+	hash, err := h.Hash("correct-horse-battery-staple")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := h.Verify("correct-horse-battery-staple", hash)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVerify_WithPepper(b *testing.B) {
+	pepper := []byte("bench-pepper-key-32-bytes-long!!")
+	h := password.New(pepper)
+	hash, err := h.Hash("correct-horse-battery-staple")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := h.Verify("correct-horse-battery-staple", hash)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/token/service_test.go
+++ b/internal/token/service_test.go
@@ -587,6 +587,130 @@ func TestEndToEnd_IssueValidateRevokeCheck(t *testing.T) {
 	assert.NotEqual(t, claims.TokenID, newClaims.TokenID)
 }
 
+// ── Benchmarks ───────────────────────────────────────────────────────────────
+
+func newBenchES256Service(b *testing.B) *token.Service {
+	b.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		b.Fatal(err)
+	}
+	mr := miniredis.RunT(b)
+	rc := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	b.Cleanup(func() { _ = rc.Close() })
+	cfg := config.JWTConfig{
+		Algorithm:       "ES256",
+		AccessTokenTTL:  15 * time.Minute,
+		RefreshTokenTTL: 7 * 24 * time.Hour,
+		SystemSecrets:   []string{"bench-secret"},
+	}
+	svc, err := token.NewServiceFromKey(cfg, key, rc, zap.NewNop(), audit.NopLogger{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	return svc
+}
+
+func BenchmarkIssueTokenPair(b *testing.B) {
+	svc := newBenchES256Service(b)
+	ctx := context.Background()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := svc.IssueTokenPair(ctx, "bench-user", []string{"user"}, []string{"read:all"}, domain.ClientTypeUser)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkValidateToken(b *testing.B) {
+	svc := newBenchES256Service(b)
+	ctx := context.Background()
+	result, err := svc.IssueTokenPair(ctx, "bench-user", []string{"user"}, []string{"read:all"}, domain.ClientTypeUser)
+	if err != nil {
+		b.Fatal(err)
+	}
+	rawJWT := strings.TrimPrefix(result.AccessToken, "qf_at_")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := svc.ValidateToken(ctx, rawJWT)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRefresh(b *testing.B) {
+	// Each iteration needs a fresh refresh token since Refresh() rotates tokens.
+	// We pre-issue b.N token pairs before the timer starts.
+	svc := newBenchES256Service(b)
+	ctx := context.Background()
+
+	tokens := make([]string, b.N)
+	for i := 0; i < b.N; i++ {
+		result, err := svc.IssueTokenPair(ctx, "bench-user", []string{"user"}, nil, domain.ClientTypeUser)
+		if err != nil {
+			b.Fatal(err)
+		}
+		tokens[i] = result.RefreshToken
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := svc.Refresh(ctx, tokens[i])
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkIsRevoked_NotRevoked(b *testing.B) {
+	svc := newBenchES256Service(b)
+	ctx := context.Background()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := svc.IsRevoked(ctx, "nonexistent-jti-bench")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkIsRevoked_Revoked(b *testing.B) {
+	svc := newBenchES256Service(b)
+	ctx := context.Background()
+	result, err := svc.IssueTokenPair(ctx, "bench-user", nil, nil, domain.ClientTypeUser)
+	if err != nil {
+		b.Fatal(err)
+	}
+	rawJWT := strings.TrimPrefix(result.AccessToken, "qf_at_")
+	claims, err := svc.ValidateToken(ctx, rawJWT)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := svc.Revoke(ctx, result.AccessToken); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := svc.IsRevoked(ctx, claims.TokenID)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkJWKS(b *testing.B) {
+	svc := newBenchES256Service(b)
+	ctx := context.Background()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := svc.JWKS(ctx)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 // ── IssueTokenPair with no system secrets ────────────────────────────────────
 
 func TestIssueTokenPair_NoSystemSecretsError(t *testing.T) {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-279.

Closes #279

## Changes

Add `Benchmark*` functions to `internal/password/hasher_test.go` (Argon2id hash/verify with pepper) and `internal/token/service_test.go` (JWT issue/validate, HMAC refresh token generation/verification, Redis blocklist check via `IsRevoked`). These are the CPU-hot paths. Use `testing.B` with proper reset timers around setup. Cover: `Hash()`, `Verify()`, `IssueTokenPair()`, `ValidateToken()`, `Refresh()`, `IsRevoked()`, and `JWKS()`.