### PR TITLE
GH-295: Proto generation Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test test-cover bench bench-cpu bench-mem load-test lint lint-fix fmt clean migrate-up migrate-down docker-up docker-down
+.PHONY: build run test test-cover bench bench-cpu bench-mem load-test lint lint-fix fmt clean migrate-up migrate-down docker-up docker-down proto-generate proto-lint
 
 # Build
 build:
@@ -65,6 +65,21 @@ docker-up:
 
 docker-down:
 	docker-compose down
+
+# Proto
+proto-generate:
+	@if ! command -v buf >/dev/null 2>&1; then \
+		echo "Error: buf is not installed. Install from https://buf.build/docs/installation"; \
+		exit 1; \
+	fi
+	buf generate
+
+proto-lint:
+	@if ! command -v buf >/dev/null 2>&1; then \
+		echo "Error: buf is not installed. Install from https://buf.build/docs/installation"; \
+		exit 1; \
+	fi
+	buf lint
 
 # Clean
 clean:

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,0 +1,13 @@
+version: v2
+inputs:
+  - directory: proto
+plugins:
+  - remote: buf.build/protocolbuffers/go
+    out: .
+    opt:
+      - paths=source_relative
+  - remote: buf.build/grpc/go
+    out: .
+    opt:
+      - paths=source_relative
+      - require_unimplemented_servers=false

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,0 +1,9 @@
+version: v2
+lint:
+  use:
+    - STANDARD
+  except:
+    - PACKAGE_VERSION_SUFFIX
+breaking:
+  use:
+    - FILE


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-295.

Closes #295

## Changes

Add `proto-generate` (and optionally `proto-lint`) targets to the Makefile so developers can regenerate `.pb.go` files after modifying `.proto` definitions. May include a `buf.yaml` or shell script. Touches: `Makefile`, possibly `proto/buf.yaml` or `scripts/`.