### PR TITLE
GH-296: Go Client SDK (pkg/authclient/) - Implement the full client library for service-to-service auth. Includes: `Client` struct with gRPC connection management (dial options, TLS, timeouts), retry logic with backoff, wrapper methods for all 4 RPCs (`ValidateToken`, `GetUser`, `CheckPermission`, `IntrospectToken`), convenience helpers (e.g., `NewClient`, `Close`), and integration tests using bufconn. All work is within `pkg/authclient/`

### DIFF
--- a/pkg/authclient/authclient.go
+++ b/pkg/authclient/authclient.go
@@ -1,2 +1,0 @@
-// Package authclient provides a Go SDK for verifying tokens issued by the auth service.
-package authclient

--- a/pkg/authclient/authclient_test.go
+++ b/pkg/authclient/authclient_test.go
@@ -1,0 +1,271 @@
+package authclient_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/qf-studio/auth-service/pkg/authclient"
+	authv1 "github.com/qf-studio/auth-service/proto/auth/v1"
+)
+
+const bufSize = 1024 * 1024
+
+// ── Mock server ───────────────────────────────────────────────────────────────
+
+type mockAuthServer struct {
+	authv1.UnimplementedAuthServiceServer
+
+	validateFn   func(ctx context.Context, req *authv1.ValidateTokenRequest) (*authv1.ValidateTokenResponse, error)
+	getUserFn    func(ctx context.Context, req *authv1.GetUserRequest) (*authv1.GetUserResponse, error)
+	checkPermFn  func(ctx context.Context, req *authv1.CheckPermissionRequest) (*authv1.CheckPermissionResponse, error)
+	introspectFn func(ctx context.Context, req *authv1.IntrospectTokenRequest) (*authv1.IntrospectTokenResponse, error)
+}
+
+func (m *mockAuthServer) ValidateToken(ctx context.Context, req *authv1.ValidateTokenRequest) (*authv1.ValidateTokenResponse, error) {
+	if m.validateFn != nil {
+		return m.validateFn(ctx, req)
+	}
+	return &authv1.ValidateTokenResponse{Valid: false}, nil
+}
+
+func (m *mockAuthServer) GetUser(ctx context.Context, req *authv1.GetUserRequest) (*authv1.GetUserResponse, error) {
+	if m.getUserFn != nil {
+		return m.getUserFn(ctx, req)
+	}
+	return nil, status.Error(codes.Unimplemented, "not configured")
+}
+
+func (m *mockAuthServer) CheckPermission(ctx context.Context, req *authv1.CheckPermissionRequest) (*authv1.CheckPermissionResponse, error) {
+	if m.checkPermFn != nil {
+		return m.checkPermFn(ctx, req)
+	}
+	return &authv1.CheckPermissionResponse{Allowed: false}, nil
+}
+
+func (m *mockAuthServer) IntrospectToken(ctx context.Context, req *authv1.IntrospectTokenRequest) (*authv1.IntrospectTokenResponse, error) {
+	if m.introspectFn != nil {
+		return m.introspectFn(ctx, req)
+	}
+	return &authv1.IntrospectTokenResponse{Active: false}, nil
+}
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+func setupClient(t *testing.T, srv authv1.AuthServiceServer) *authclient.Client {
+	t.Helper()
+
+	lis := bufconn.Listen(bufSize)
+	gs := grpc.NewServer()
+	authv1.RegisterAuthServiceServer(gs, srv)
+
+	go func() {
+		if err := gs.Serve(lis); err != nil {
+			// stopped during cleanup
+		}
+	}()
+	t.Cleanup(gs.Stop)
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(_ context.Context, _ string) (net.Conn, error) {
+			return lis.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return authclient.NewFromConn(conn, authclient.WithInsecure())
+}
+
+// ── ValidateToken tests ───────────────────────────────────────────────────────
+
+func TestValidateToken_Valid(t *testing.T) {
+	srv := &mockAuthServer{
+		validateFn: func(_ context.Context, req *authv1.ValidateTokenRequest) (*authv1.ValidateTokenResponse, error) {
+			require.Equal(t, "qf_at_testtoken", req.GetAccessToken())
+			return &authv1.ValidateTokenResponse{
+				Valid: true,
+				Claims: &authv1.TokenClaims{
+					Subject:    "user-123",
+					Roles:      []string{"admin"},
+					Scopes:     []string{"read", "write"},
+					ClientType: "user",
+					TokenId:    "tok-abc",
+				},
+			}, nil
+		},
+	}
+
+	client := setupClient(t, srv)
+	result, err := client.ValidateToken(context.Background(), "qf_at_testtoken")
+
+	require.NoError(t, err)
+	assert.True(t, result.Valid)
+	assert.Equal(t, "user-123", result.Claims.Subject)
+	assert.Equal(t, []string{"admin"}, result.Claims.Roles)
+	assert.Equal(t, []string{"read", "write"}, result.Claims.Scopes)
+	assert.Equal(t, "user", result.Claims.ClientType)
+	assert.Equal(t, "tok-abc", result.Claims.TokenID)
+}
+
+func TestValidateToken_Invalid(t *testing.T) {
+	srv := &mockAuthServer{
+		validateFn: func(_ context.Context, _ *authv1.ValidateTokenRequest) (*authv1.ValidateTokenResponse, error) {
+			return &authv1.ValidateTokenResponse{Valid: false}, nil
+		},
+	}
+
+	client := setupClient(t, srv)
+	result, err := client.ValidateToken(context.Background(), "bad-token")
+
+	require.NoError(t, err)
+	assert.False(t, result.Valid)
+	assert.Nil(t, result.Claims)
+}
+
+func TestValidateToken_TransportError(t *testing.T) {
+	srv := &mockAuthServer{
+		validateFn: func(_ context.Context, _ *authv1.ValidateTokenRequest) (*authv1.ValidateTokenResponse, error) {
+			return nil, status.Error(codes.InvalidArgument, "empty token")
+		},
+	}
+
+	client := setupClient(t, srv)
+	// Non-retryable error should be returned immediately.
+	_, err := client.ValidateToken(context.Background(), "")
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// ── IntrospectToken tests ─────────────────────────────────────────────────────
+
+func TestIntrospectToken_Active(t *testing.T) {
+	srv := &mockAuthServer{
+		introspectFn: func(_ context.Context, req *authv1.IntrospectTokenRequest) (*authv1.IntrospectTokenResponse, error) {
+			return &authv1.IntrospectTokenResponse{
+				Active: true,
+				Claims: &authv1.TokenClaims{Subject: "user-456"},
+			}, nil
+		},
+	}
+
+	client := setupClient(t, srv)
+	result, err := client.IntrospectToken(context.Background(), "qf_at_active")
+
+	require.NoError(t, err)
+	assert.True(t, result.Active)
+	assert.Equal(t, "user-456", result.Claims.Subject)
+}
+
+func TestIntrospectToken_Inactive(t *testing.T) {
+	srv := &mockAuthServer{
+		introspectFn: func(_ context.Context, _ *authv1.IntrospectTokenRequest) (*authv1.IntrospectTokenResponse, error) {
+			return &authv1.IntrospectTokenResponse{Active: false}, nil
+		},
+	}
+
+	client := setupClient(t, srv)
+	result, err := client.IntrospectToken(context.Background(), "expired-token")
+
+	require.NoError(t, err)
+	assert.False(t, result.Active)
+	assert.Nil(t, result.Claims)
+}
+
+// ── CheckPermission tests ─────────────────────────────────────────────────────
+
+func TestCheckPermission_Allowed(t *testing.T) {
+	srv := &mockAuthServer{
+		checkPermFn: func(_ context.Context, req *authv1.CheckPermissionRequest) (*authv1.CheckPermissionResponse, error) {
+			assert.Equal(t, "admin-user", req.GetSubject())
+			assert.Equal(t, "resource", req.GetObject())
+			assert.Equal(t, "read", req.GetAction())
+			return &authv1.CheckPermissionResponse{Allowed: true}, nil
+		},
+	}
+
+	client := setupClient(t, srv)
+	allowed, err := client.CheckPermission(context.Background(), "admin-user", "resource", "read")
+
+	require.NoError(t, err)
+	assert.True(t, allowed)
+}
+
+func TestCheckPermission_Denied(t *testing.T) {
+	srv := &mockAuthServer{
+		checkPermFn: func(_ context.Context, _ *authv1.CheckPermissionRequest) (*authv1.CheckPermissionResponse, error) {
+			return &authv1.CheckPermissionResponse{Allowed: false}, nil
+		},
+	}
+
+	client := setupClient(t, srv)
+	allowed, err := client.CheckPermission(context.Background(), "regular-user", "secret", "write")
+
+	require.NoError(t, err)
+	assert.False(t, allowed)
+}
+
+func TestCheckPermission_TransportError(t *testing.T) {
+	srv := &mockAuthServer{
+		checkPermFn: func(_ context.Context, _ *authv1.CheckPermissionRequest) (*authv1.CheckPermissionResponse, error) {
+			return nil, status.Error(codes.InvalidArgument, "missing fields")
+		},
+	}
+
+	client := setupClient(t, srv)
+	_, err := client.CheckPermission(context.Background(), "", "", "")
+	require.Error(t, err)
+}
+
+// ── GetUser tests ─────────────────────────────────────────────────────────────
+
+func TestGetUser_Found(t *testing.T) {
+	srv := &mockAuthServer{
+		getUserFn: func(_ context.Context, req *authv1.GetUserRequest) (*authv1.GetUserResponse, error) {
+			require.Equal(t, "user-123", req.GetUserId())
+			return &authv1.GetUserResponse{
+				User: &authv1.User{
+					Id:            "user-123",
+					Email:         "test@example.com",
+					Name:          "Test User",
+					Roles:         []string{"user"},
+					EmailVerified: true,
+				},
+			}, nil
+		},
+	}
+
+	client := setupClient(t, srv)
+	user, err := client.GetUser(context.Background(), "user-123")
+
+	require.NoError(t, err)
+	assert.Equal(t, "user-123", user.ID)
+	assert.Equal(t, "test@example.com", user.Email)
+	assert.Equal(t, "Test User", user.Name)
+	assert.Equal(t, []string{"user"}, user.Roles)
+	assert.True(t, user.EmailVerified)
+	assert.False(t, user.Locked)
+}
+
+func TestGetUser_NotFound(t *testing.T) {
+	srv := &mockAuthServer{
+		getUserFn: func(_ context.Context, _ *authv1.GetUserRequest) (*authv1.GetUserResponse, error) {
+			return nil, status.Error(codes.NotFound, "user not found")
+		},
+	}
+
+	client := setupClient(t, srv)
+	_, err := client.GetUser(context.Background(), "nonexistent")
+
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+}

--- a/pkg/authclient/client.go
+++ b/pkg/authclient/client.go
@@ -1,0 +1,144 @@
+// Package authclient provides a Go SDK for verifying tokens issued by the auth service.
+package authclient
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+
+	authv1 "github.com/qf-studio/auth-service/proto/auth/v1"
+)
+
+// Client wraps the gRPC AuthService client with helper methods, retry logic,
+// and connection lifecycle management.
+type Client struct {
+	conn   *grpc.ClientConn
+	auth   authv1.AuthServiceClient
+	opts   options
+}
+
+// New dials the auth-service at target and returns a ready Client.
+// target follows gRPC name-resolution syntax (e.g. "auth-service:4002").
+func New(target string, optFns ...Option) (*Client, error) {
+	opts := defaultOptions()
+	for _, fn := range optFns {
+		fn(&opts)
+	}
+
+	dialOpts, err := buildDialOpts(opts)
+	if err != nil {
+		return nil, fmt.Errorf("authclient: build dial options: %w", err)
+	}
+
+	conn, err := grpc.NewClient(target, dialOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("authclient: dial %s: %w", target, err)
+	}
+
+	return &Client{
+		conn: conn,
+		auth: authv1.NewAuthServiceClient(conn),
+		opts: opts,
+	}, nil
+}
+
+// NewFromConn creates a Client from an existing *grpc.ClientConn.
+// Intended for testing with in-process servers (bufconn).
+func NewFromConn(conn *grpc.ClientConn, optFns ...Option) *Client {
+	opts := defaultOptions()
+	for _, fn := range optFns {
+		fn(&opts)
+	}
+	return &Client{
+		conn: conn,
+		auth: authv1.NewAuthServiceClient(conn),
+		opts: opts,
+	}
+}
+
+// Close releases the underlying gRPC connection.
+func (c *Client) Close() error {
+	return c.conn.Close()
+}
+
+// buildDialOpts assembles grpc.DialOption slice from client options.
+func buildDialOpts(opts options) ([]grpc.DialOption, error) {
+	var dialOpts []grpc.DialOption
+
+	switch {
+	case opts.insecure:
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	case opts.tlsConfig != nil:
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(opts.tlsConfig)))
+	default:
+		// Default to system TLS pool.
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(nil, "")))
+	}
+
+	return dialOpts, nil
+}
+
+// withTimeout returns a context that expires after the configured timeout.
+func (c *Client) withTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if c.opts.timeout <= 0 {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, c.opts.timeout)
+}
+
+// retryable reports whether a gRPC status code should trigger a retry.
+// Only transient errors are retried; application-level errors are not.
+func retryable(code codes.Code) bool {
+	switch code {
+	case codes.Unavailable, codes.ResourceExhausted, codes.DeadlineExceeded:
+		return true
+	default:
+		return false
+	}
+}
+
+// do executes fn with exponential-backoff retries on transient gRPC errors.
+func (c *Client) do(ctx context.Context, fn func(ctx context.Context) error) error {
+	backoff := c.opts.initialBackoff
+	var lastErr error
+
+	for attempt := 0; attempt <= c.opts.maxRetries; attempt++ {
+		callCtx, cancel := c.withTimeout(ctx)
+		lastErr = fn(callCtx)
+		cancel()
+
+		if lastErr == nil {
+			return nil
+		}
+
+		// Don't retry if the parent context is done.
+		if ctx.Err() != nil {
+			return lastErr
+		}
+
+		code := status.Code(lastErr)
+		if !retryable(code) {
+			return lastErr
+		}
+
+		if attempt < c.opts.maxRetries {
+			select {
+			case <-time.After(backoff):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			backoff = time.Duration(float64(backoff) * c.opts.backoffFactor)
+			if backoff > c.opts.maxBackoff {
+				backoff = c.opts.maxBackoff
+			}
+		}
+	}
+
+	return lastErr
+}

--- a/pkg/authclient/options.go
+++ b/pkg/authclient/options.go
@@ -1,0 +1,71 @@
+package authclient
+
+import (
+	"crypto/tls"
+	"time"
+)
+
+const (
+	defaultTimeout        = 5 * time.Second
+	defaultMaxRetries     = 3
+	defaultInitialBackoff = 100 * time.Millisecond
+	defaultMaxBackoff     = 2 * time.Second
+	defaultBackoffFactor  = 2.0
+)
+
+// options holds client configuration populated via functional options.
+type options struct {
+	timeout        time.Duration
+	maxRetries     int
+	initialBackoff time.Duration
+	maxBackoff     time.Duration
+	backoffFactor  float64
+	tlsConfig      *tls.Config
+	insecure       bool
+}
+
+func defaultOptions() options {
+	return options{
+		timeout:        defaultTimeout,
+		maxRetries:     defaultMaxRetries,
+		initialBackoff: defaultInitialBackoff,
+		maxBackoff:     defaultMaxBackoff,
+		backoffFactor:  defaultBackoffFactor,
+	}
+}
+
+// Option configures the authclient.
+type Option func(*options)
+
+// WithTimeout sets the per-RPC timeout. Defaults to 5s.
+func WithTimeout(d time.Duration) Option {
+	return func(o *options) {
+		o.timeout = d
+	}
+}
+
+// WithRetry configures exponential-backoff retry behaviour.
+// maxRetries = 0 disables retries.
+func WithRetry(maxRetries int, initialBackoff, maxBackoff time.Duration, factor float64) Option {
+	return func(o *options) {
+		o.maxRetries = maxRetries
+		o.initialBackoff = initialBackoff
+		o.maxBackoff = maxBackoff
+		o.backoffFactor = factor
+	}
+}
+
+// WithTLS sets the TLS configuration used for the gRPC connection.
+// Mutually exclusive with WithInsecure.
+func WithTLS(cfg *tls.Config) Option {
+	return func(o *options) {
+		o.tlsConfig = cfg
+	}
+}
+
+// WithInsecure disables TLS. Only for development / testing.
+func WithInsecure() Option {
+	return func(o *options) {
+		o.insecure = true
+	}
+}

--- a/pkg/authclient/permission.go
+++ b/pkg/authclient/permission.go
@@ -1,0 +1,71 @@
+package authclient
+
+import (
+	"context"
+
+	authv1 "github.com/qf-studio/auth-service/proto/auth/v1"
+)
+
+// CheckPermission returns true when subject may perform action on object.
+// Returns an error only for transport failures; a "denied" result is returned
+// as (false, nil).
+func (c *Client) CheckPermission(ctx context.Context, subject, object, action string) (bool, error) {
+	var resp *authv1.CheckPermissionResponse
+
+	err := c.do(ctx, func(callCtx context.Context) error {
+		var callErr error
+		resp, callErr = c.auth.CheckPermission(callCtx, &authv1.CheckPermissionRequest{
+			Subject: subject,
+			Object:  object,
+			Action:  action,
+		})
+		return callErr
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return resp.GetAllowed(), nil
+}
+
+// GetUser retrieves a user by ID from the auth service.
+func (c *Client) GetUser(ctx context.Context, userID string) (*User, error) {
+	var resp *authv1.GetUserResponse
+
+	err := c.do(ctx, func(callCtx context.Context) error {
+		var callErr error
+		resp, callErr = c.auth.GetUser(callCtx, &authv1.GetUserRequest{
+			UserId: userID,
+		})
+		return callErr
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return userFromProto(resp.GetUser()), nil
+}
+
+// User is the SDK representation of a user returned by the auth service.
+type User struct {
+	ID            string
+	Email         string
+	Name          string
+	Roles         []string
+	Locked        bool
+	EmailVerified bool
+}
+
+func userFromProto(p *authv1.User) *User {
+	if p == nil {
+		return nil
+	}
+	return &User{
+		ID:            p.GetId(),
+		Email:         p.GetEmail(),
+		Name:          p.GetName(),
+		Roles:         p.GetRoles(),
+		Locked:        p.GetLocked(),
+		EmailVerified: p.GetEmailVerified(),
+	}
+}

--- a/pkg/authclient/token.go
+++ b/pkg/authclient/token.go
@@ -1,0 +1,93 @@
+package authclient
+
+import (
+	"context"
+	"time"
+
+	authv1 "github.com/qf-studio/auth-service/proto/auth/v1"
+)
+
+// TokenClaims holds validated token claims returned by the auth service.
+type TokenClaims struct {
+	Subject       string
+	Roles         []string
+	Scopes        []string
+	ClientType    string
+	TokenID       string
+	ExpiresAt     time.Time
+	IssuedAt      time.Time
+	JKTThumbprint string
+}
+
+// ValidationResult is the response from a ValidateToken call.
+type ValidationResult struct {
+	Valid  bool
+	Claims *TokenClaims
+}
+
+// ValidateToken verifies the given access token against the auth service.
+// Returns ValidationResult with Valid=false (and no error) when the token
+// is syntactically recognisable but invalid/expired. Returns an error only
+// for transport failures.
+func (c *Client) ValidateToken(ctx context.Context, accessToken string) (*ValidationResult, error) {
+	var resp *authv1.ValidateTokenResponse
+
+	err := c.do(ctx, func(callCtx context.Context) error {
+		var callErr error
+		resp, callErr = c.auth.ValidateToken(callCtx, &authv1.ValidateTokenRequest{
+			AccessToken: accessToken,
+		})
+		return callErr
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result := &ValidationResult{Valid: resp.GetValid()}
+	if resp.GetClaims() != nil {
+		result.Claims = claimsFromProto(resp.GetClaims())
+	}
+	return result, nil
+}
+
+// IntrospectToken returns detailed RFC 7662-style metadata for the token.
+// Active=false (with no error) when the token is inactive.
+type IntrospectResult struct {
+	Active bool
+	Claims *TokenClaims
+}
+
+// IntrospectToken calls the IntrospectToken RPC and returns structured metadata.
+func (c *Client) IntrospectToken(ctx context.Context, accessToken string) (*IntrospectResult, error) {
+	var resp *authv1.IntrospectTokenResponse
+
+	err := c.do(ctx, func(callCtx context.Context) error {
+		var callErr error
+		resp, callErr = c.auth.IntrospectToken(callCtx, &authv1.IntrospectTokenRequest{
+			AccessToken: accessToken,
+		})
+		return callErr
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result := &IntrospectResult{Active: resp.GetActive()}
+	if resp.GetClaims() != nil {
+		result.Claims = claimsFromProto(resp.GetClaims())
+	}
+	return result, nil
+}
+
+func claimsFromProto(p *authv1.TokenClaims) *TokenClaims {
+	return &TokenClaims{
+		Subject:       p.GetSubject(),
+		Roles:         p.GetRoles(),
+		Scopes:        p.GetScopes(),
+		ClientType:    p.GetClientType(),
+		TokenID:       p.GetTokenId(),
+		ExpiresAt:     time.Unix(p.GetExpiresAt(), 0),
+		IssuedAt:      time.Unix(p.GetIssuedAt(), 0),
+		JKTThumbprint: p.GetJktThumbprint(),
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-296.

Closes #296

## Changes

single package, single subtask.