### PR TITLE
GH-301: Database schema, domain models, and repository

### DIFF
--- a/internal/domain/sentinel_errors.go
+++ b/internal/domain/sentinel_errors.go
@@ -33,4 +33,11 @@ var (
 	ErrOAuthAccountNotFound      = errors.New("oauth account not found")
 	ErrOAuthStateMismatch        = errors.New("oauth state mismatch")
 	ErrOAuthCodeExchangeFailed   = errors.New("oauth code exchange failed")
+
+	// Validation errors.
+	ErrValidationRequired = errors.New("field is required")
+	ErrValidationInvalid  = errors.New("field is invalid")
+
+	// Webhook errors.
+	ErrWebhookNotFound = errors.New("webhook not found")
 )

--- a/internal/domain/webhook.go
+++ b/internal/domain/webhook.go
@@ -1,0 +1,112 @@
+package domain
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// Webhook event types.
+const (
+	EventUserCreated         = "user.created"
+	EventUserUpdated         = "user.updated"
+	EventUserDeleted         = "user.deleted"
+	EventUserLocked          = "user.locked"
+	EventUserUnlocked        = "user.unlocked"
+	EventTokenIssued         = "token.issued"
+	EventTokenRevoked        = "token.revoked"
+	EventClientCreated       = "client.created"
+	EventClientUpdated       = "client.updated"
+	EventClientDeleted       = "client.deleted"
+	EventPermissionChanged   = "permission.changed"
+	EventMFAEnabled          = "mfa.enabled"
+	EventMFADisabled         = "mfa.disabled"
+	EventLoginSuccess        = "login.success"
+	EventLoginFailed         = "login.failed"
+)
+
+// AllEventTypes returns all supported webhook event types.
+func AllEventTypes() []string {
+	return []string{
+		EventUserCreated, EventUserUpdated, EventUserDeleted,
+		EventUserLocked, EventUserUnlocked,
+		EventTokenIssued, EventTokenRevoked,
+		EventClientCreated, EventClientUpdated, EventClientDeleted,
+		EventPermissionChanged,
+		EventMFAEnabled, EventMFADisabled,
+		EventLoginSuccess, EventLoginFailed,
+	}
+}
+
+// Webhook delivery statuses.
+const (
+	DeliveryStatusPending   = "pending"
+	DeliveryStatusDelivered = "delivered"
+	DeliveryStatusFailed    = "failed"
+)
+
+// Webhook represents a registered webhook endpoint.
+type Webhook struct {
+	ID           string    `json:"id"`
+	URL          string    `json:"url"`
+	Secret       string    `json:"-"`
+	EventTypes   []string  `json:"event_types"`
+	Active       bool      `json:"active"`
+	FailureCount int       `json:"failure_count"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+// WebhookDelivery represents a single delivery attempt for a webhook.
+type WebhookDelivery struct {
+	ID           string     `json:"id"`
+	WebhookID    string     `json:"webhook_id"`
+	EventType    string     `json:"event_type"`
+	Payload      []byte     `json:"payload"`
+	Status       string     `json:"status"`
+	ResponseCode *int       `json:"response_code,omitempty"`
+	Attempt      int        `json:"attempt"`
+	NextRetryAt  *time.Time `json:"next_retry_at,omitempty"`
+	DeliveredAt  *time.Time `json:"delivered_at,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+}
+
+// Validate checks that the webhook has valid fields.
+func (w *Webhook) Validate() error {
+	if w.URL == "" {
+		return fmt.Errorf("webhook url: %w", ErrValidationRequired)
+	}
+	u, err := url.ParseRequestURI(w.URL)
+	if err != nil {
+		return fmt.Errorf("webhook url: %w", ErrValidationInvalid)
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return fmt.Errorf("webhook url scheme must be http or https: %w", ErrValidationInvalid)
+	}
+	if w.Secret == "" {
+		return fmt.Errorf("webhook secret: %w", ErrValidationRequired)
+	}
+	if len(w.EventTypes) == 0 {
+		return fmt.Errorf("webhook event_types: %w", ErrValidationRequired)
+	}
+	valid := validEventTypes()
+	for _, et := range w.EventTypes {
+		if !valid[et] {
+			return fmt.Errorf("webhook event_type %q: %w", et, ErrValidationInvalid)
+		}
+	}
+	return nil
+}
+
+// IsActive returns true if the webhook is active.
+func (w *Webhook) IsActive() bool {
+	return w.Active
+}
+
+func validEventTypes() map[string]bool {
+	m := make(map[string]bool, len(AllEventTypes()))
+	for _, et := range AllEventTypes() {
+		m[et] = true
+	}
+	return m
+}

--- a/internal/domain/webhook_test.go
+++ b/internal/domain/webhook_test.go
@@ -1,0 +1,112 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebhook_Validate(t *testing.T) {
+	validWebhook := func() *Webhook {
+		return &Webhook{
+			ID:         "wh_1",
+			URL:        "https://example.com/hook",
+			Secret:     "secret123",
+			EventTypes: []string{EventUserCreated},
+			Active:     true,
+		}
+	}
+
+	tests := []struct {
+		name    string
+		modify  func(w *Webhook)
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid webhook",
+			modify:  func(w *Webhook) {},
+			wantErr: false,
+		},
+		{
+			name:    "valid with http url",
+			modify:  func(w *Webhook) { w.URL = "http://localhost:8080/hook" },
+			wantErr: false,
+		},
+		{
+			name:    "valid with multiple event types",
+			modify:  func(w *Webhook) { w.EventTypes = []string{EventUserCreated, EventUserDeleted, EventTokenRevoked} },
+			wantErr: false,
+		},
+		{
+			name:    "empty url",
+			modify:  func(w *Webhook) { w.URL = "" },
+			wantErr: true,
+			errMsg:  "url",
+		},
+		{
+			name:    "invalid url",
+			modify:  func(w *Webhook) { w.URL = "not-a-url" },
+			wantErr: true,
+			errMsg:  "url",
+		},
+		{
+			name:    "ftp scheme",
+			modify:  func(w *Webhook) { w.URL = "ftp://example.com/hook" },
+			wantErr: true,
+			errMsg:  "scheme",
+		},
+		{
+			name:    "empty secret",
+			modify:  func(w *Webhook) { w.Secret = "" },
+			wantErr: true,
+			errMsg:  "secret",
+		},
+		{
+			name:    "empty event types",
+			modify:  func(w *Webhook) { w.EventTypes = nil },
+			wantErr: true,
+			errMsg:  "event_types",
+		},
+		{
+			name:    "invalid event type",
+			modify:  func(w *Webhook) { w.EventTypes = []string{"invalid.event"} },
+			wantErr: true,
+			errMsg:  "invalid.event",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := validWebhook()
+			tt.modify(w)
+			err := w.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestWebhook_IsActive(t *testing.T) {
+	w := &Webhook{Active: true}
+	assert.True(t, w.IsActive())
+
+	w.Active = false
+	assert.False(t, w.IsActive())
+}
+
+func TestAllEventTypes(t *testing.T) {
+	types := AllEventTypes()
+	assert.NotEmpty(t, types)
+	// Ensure no duplicates
+	seen := make(map[string]bool)
+	for _, et := range types {
+		assert.False(t, seen[et], "duplicate event type: %s", et)
+		seen[et] = true
+	}
+}

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -44,4 +44,7 @@ var (
 
 	// ErrDuplicateOAuthAccount indicates an OAuth account with the same provider and provider user ID already exists.
 	ErrDuplicateOAuthAccount = errors.New("duplicate oauth account")
+
+	// ErrDuplicateWebhook indicates a webhook with the same URL already exists.
+	ErrDuplicateWebhook = errors.New("duplicate webhook")
 )

--- a/internal/storage/mocks/mocks_test.go
+++ b/internal/storage/mocks/mocks_test.go
@@ -14,4 +14,5 @@ func TestInterfaceCompliance(t *testing.T) {
 	var _ storage.ClientRepository = (*mocks.MockClientRepository)(nil)
 	var _ storage.RefreshTokenRepository = (*mocks.MockRefreshTokenRepository)(nil)
 	var _ storage.OAuthAccountRepository = (*mocks.MockOAuthAccountRepository)(nil)
+	var _ storage.WebhookRepository = (*mocks.MockWebhookRepository)(nil)
 }

--- a/internal/storage/mocks/webhook_repository.go
+++ b/internal/storage/mocks/webhook_repository.go
@@ -1,0 +1,71 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// MockWebhookRepository is a test double for storage.WebhookRepository.
+type MockWebhookRepository struct {
+	CreateWebhookFn          func(ctx context.Context, webhook *domain.Webhook) (*domain.Webhook, error)
+	GetWebhookFn             func(ctx context.Context, id string) (*domain.Webhook, error)
+	ListWebhooksFn           func(ctx context.Context, activeOnly bool) ([]domain.Webhook, error)
+	UpdateWebhookFn          func(ctx context.Context, webhook *domain.Webhook) (*domain.Webhook, error)
+	DeleteWebhookFn          func(ctx context.Context, id string) error
+	CreateDeliveryFn         func(ctx context.Context, delivery *domain.WebhookDelivery) (*domain.WebhookDelivery, error)
+	GetDeliveryFn            func(ctx context.Context, id string) (*domain.WebhookDelivery, error)
+	ListDeliveriesByWebhookFn func(ctx context.Context, webhookID string) ([]domain.WebhookDelivery, error)
+	ListDeliveriesByStatusFn  func(ctx context.Context, status string) ([]domain.WebhookDelivery, error)
+	UpdateDeliveryFn         func(ctx context.Context, delivery *domain.WebhookDelivery) error
+	IncrementFailureCountFn  func(ctx context.Context, webhookID string) (int, error)
+	ResetFailureCountFn      func(ctx context.Context, webhookID string) error
+}
+
+func (m *MockWebhookRepository) CreateWebhook(ctx context.Context, webhook *domain.Webhook) (*domain.Webhook, error) {
+	return m.CreateWebhookFn(ctx, webhook)
+}
+
+func (m *MockWebhookRepository) GetWebhook(ctx context.Context, id string) (*domain.Webhook, error) {
+	return m.GetWebhookFn(ctx, id)
+}
+
+func (m *MockWebhookRepository) ListWebhooks(ctx context.Context, activeOnly bool) ([]domain.Webhook, error) {
+	return m.ListWebhooksFn(ctx, activeOnly)
+}
+
+func (m *MockWebhookRepository) UpdateWebhook(ctx context.Context, webhook *domain.Webhook) (*domain.Webhook, error) {
+	return m.UpdateWebhookFn(ctx, webhook)
+}
+
+func (m *MockWebhookRepository) DeleteWebhook(ctx context.Context, id string) error {
+	return m.DeleteWebhookFn(ctx, id)
+}
+
+func (m *MockWebhookRepository) CreateDelivery(ctx context.Context, delivery *domain.WebhookDelivery) (*domain.WebhookDelivery, error) {
+	return m.CreateDeliveryFn(ctx, delivery)
+}
+
+func (m *MockWebhookRepository) GetDelivery(ctx context.Context, id string) (*domain.WebhookDelivery, error) {
+	return m.GetDeliveryFn(ctx, id)
+}
+
+func (m *MockWebhookRepository) ListDeliveriesByWebhook(ctx context.Context, webhookID string) ([]domain.WebhookDelivery, error) {
+	return m.ListDeliveriesByWebhookFn(ctx, webhookID)
+}
+
+func (m *MockWebhookRepository) ListDeliveriesByStatus(ctx context.Context, status string) ([]domain.WebhookDelivery, error) {
+	return m.ListDeliveriesByStatusFn(ctx, status)
+}
+
+func (m *MockWebhookRepository) UpdateDelivery(ctx context.Context, delivery *domain.WebhookDelivery) error {
+	return m.UpdateDeliveryFn(ctx, delivery)
+}
+
+func (m *MockWebhookRepository) IncrementFailureCount(ctx context.Context, webhookID string) (int, error) {
+	return m.IncrementFailureCountFn(ctx, webhookID)
+}
+
+func (m *MockWebhookRepository) ResetFailureCount(ctx context.Context, webhookID string) error {
+	return m.ResetFailureCountFn(ctx, webhookID)
+}

--- a/internal/storage/webhook_repository.go
+++ b/internal/storage/webhook_repository.go
@@ -1,0 +1,28 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// WebhookRepository defines persistence operations for webhooks and deliveries.
+type WebhookRepository interface {
+	// Webhook CRUD
+	CreateWebhook(ctx context.Context, webhook *domain.Webhook) (*domain.Webhook, error)
+	GetWebhook(ctx context.Context, id string) (*domain.Webhook, error)
+	ListWebhooks(ctx context.Context, activeOnly bool) ([]domain.Webhook, error)
+	UpdateWebhook(ctx context.Context, webhook *domain.Webhook) (*domain.Webhook, error)
+	DeleteWebhook(ctx context.Context, id string) error
+
+	// Delivery operations
+	CreateDelivery(ctx context.Context, delivery *domain.WebhookDelivery) (*domain.WebhookDelivery, error)
+	GetDelivery(ctx context.Context, id string) (*domain.WebhookDelivery, error)
+	ListDeliveriesByWebhook(ctx context.Context, webhookID string) ([]domain.WebhookDelivery, error)
+	ListDeliveriesByStatus(ctx context.Context, status string) ([]domain.WebhookDelivery, error)
+	UpdateDelivery(ctx context.Context, delivery *domain.WebhookDelivery) error
+
+	// Failure tracking
+	IncrementFailureCount(ctx context.Context, webhookID string) (int, error)
+	ResetFailureCount(ctx context.Context, webhookID string) error
+}

--- a/internal/storage/webhook_repository_pg.go
+++ b/internal/storage/webhook_repository_pg.go
@@ -1,0 +1,262 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+const webhookColumns = `id, url, secret, event_types, active, failure_count, created_at, updated_at`
+const deliveryColumns = `id, webhook_id, event_type, payload, status, response_code, attempt, next_retry_at, delivered_at, created_at`
+
+// PostgresWebhookRepository implements WebhookRepository using PostgreSQL.
+type PostgresWebhookRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresWebhookRepository creates a new PostgresWebhookRepository.
+func NewPostgresWebhookRepository(pool *pgxpool.Pool) *PostgresWebhookRepository {
+	return &PostgresWebhookRepository{pool: pool}
+}
+
+func scanWebhook(row pgx.Row) (*domain.Webhook, error) {
+	w := &domain.Webhook{}
+	err := row.Scan(&w.ID, &w.URL, &w.Secret, &w.EventTypes, &w.Active, &w.FailureCount, &w.CreatedAt, &w.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return w, nil
+}
+
+func scanDelivery(row pgx.Row) (*domain.WebhookDelivery, error) {
+	d := &domain.WebhookDelivery{}
+	err := row.Scan(&d.ID, &d.WebhookID, &d.EventType, &d.Payload, &d.Status, &d.ResponseCode, &d.Attempt, &d.NextRetryAt, &d.DeliveredAt, &d.CreatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return d, nil
+}
+
+// CreateWebhook inserts a new webhook.
+func (r *PostgresWebhookRepository) CreateWebhook(ctx context.Context, webhook *domain.Webhook) (*domain.Webhook, error) {
+	query := fmt.Sprintf(`
+		INSERT INTO webhooks (id, url, secret, event_types, active, failure_count, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		RETURNING %s`, webhookColumns)
+
+	out, err := scanWebhook(r.pool.QueryRow(ctx, query,
+		webhook.ID, webhook.URL, webhook.Secret, webhook.EventTypes,
+		webhook.Active, webhook.FailureCount, webhook.CreatedAt, webhook.UpdatedAt,
+	))
+	if err != nil {
+		return nil, fmt.Errorf("insert webhook: %w", err)
+	}
+	return out, nil
+}
+
+// GetWebhook retrieves a webhook by ID.
+func (r *PostgresWebhookRepository) GetWebhook(ctx context.Context, id string) (*domain.Webhook, error) {
+	query := fmt.Sprintf(`SELECT %s FROM webhooks WHERE id = $1`, webhookColumns)
+	out, err := scanWebhook(r.pool.QueryRow(ctx, query, id))
+	if err != nil {
+		return nil, fmt.Errorf("get webhook %s: %w", id, err)
+	}
+	return out, nil
+}
+
+// ListWebhooks returns all webhooks, optionally filtering by active status.
+func (r *PostgresWebhookRepository) ListWebhooks(ctx context.Context, activeOnly bool) ([]domain.Webhook, error) {
+	var query string
+	var rows pgx.Rows
+	var err error
+
+	if activeOnly {
+		query = fmt.Sprintf(`SELECT %s FROM webhooks WHERE active = true ORDER BY created_at`, webhookColumns)
+		rows, err = r.pool.Query(ctx, query)
+	} else {
+		query = fmt.Sprintf(`SELECT %s FROM webhooks ORDER BY created_at`, webhookColumns)
+		rows, err = r.pool.Query(ctx, query)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("list webhooks: %w", err)
+	}
+	defer rows.Close()
+
+	var webhooks []domain.Webhook
+	for rows.Next() {
+		var w domain.Webhook
+		if err := rows.Scan(&w.ID, &w.URL, &w.Secret, &w.EventTypes, &w.Active, &w.FailureCount, &w.CreatedAt, &w.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan webhook: %w", err)
+		}
+		webhooks = append(webhooks, w)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate webhooks: %w", err)
+	}
+	return webhooks, nil
+}
+
+// UpdateWebhook updates a webhook's mutable fields.
+func (r *PostgresWebhookRepository) UpdateWebhook(ctx context.Context, webhook *domain.Webhook) (*domain.Webhook, error) {
+	query := fmt.Sprintf(`
+		UPDATE webhooks
+		SET url = $1, secret = $2, event_types = $3, active = $4, updated_at = $5
+		WHERE id = $6
+		RETURNING %s`, webhookColumns)
+
+	out, err := scanWebhook(r.pool.QueryRow(ctx, query,
+		webhook.URL, webhook.Secret, webhook.EventTypes, webhook.Active, webhook.UpdatedAt, webhook.ID,
+	))
+	if err != nil {
+		return nil, fmt.Errorf("update webhook %s: %w", webhook.ID, err)
+	}
+	return out, nil
+}
+
+// DeleteWebhook removes a webhook by ID.
+func (r *PostgresWebhookRepository) DeleteWebhook(ctx context.Context, id string) error {
+	tag, err := r.pool.Exec(ctx, `DELETE FROM webhooks WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("delete webhook: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("webhook %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
+// CreateDelivery inserts a new webhook delivery record.
+func (r *PostgresWebhookRepository) CreateDelivery(ctx context.Context, delivery *domain.WebhookDelivery) (*domain.WebhookDelivery, error) {
+	query := fmt.Sprintf(`
+		INSERT INTO webhook_deliveries (id, webhook_id, event_type, payload, status, response_code, attempt, next_retry_at, delivered_at, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		RETURNING %s`, deliveryColumns)
+
+	out, err := scanDelivery(r.pool.QueryRow(ctx, query,
+		delivery.ID, delivery.WebhookID, delivery.EventType, delivery.Payload,
+		delivery.Status, delivery.ResponseCode, delivery.Attempt,
+		delivery.NextRetryAt, delivery.DeliveredAt, delivery.CreatedAt,
+	))
+	if err != nil {
+		return nil, fmt.Errorf("insert delivery: %w", err)
+	}
+	return out, nil
+}
+
+// GetDelivery retrieves a delivery by ID.
+func (r *PostgresWebhookRepository) GetDelivery(ctx context.Context, id string) (*domain.WebhookDelivery, error) {
+	query := fmt.Sprintf(`SELECT %s FROM webhook_deliveries WHERE id = $1`, deliveryColumns)
+	out, err := scanDelivery(r.pool.QueryRow(ctx, query, id))
+	if err != nil {
+		return nil, fmt.Errorf("get delivery %s: %w", id, err)
+	}
+	return out, nil
+}
+
+// ListDeliveriesByWebhook returns all deliveries for a given webhook.
+func (r *PostgresWebhookRepository) ListDeliveriesByWebhook(ctx context.Context, webhookID string) ([]domain.WebhookDelivery, error) {
+	query := fmt.Sprintf(`SELECT %s FROM webhook_deliveries WHERE webhook_id = $1 ORDER BY created_at DESC`, deliveryColumns)
+	rows, err := r.pool.Query(ctx, query, webhookID)
+	if err != nil {
+		return nil, fmt.Errorf("list deliveries for webhook %s: %w", webhookID, err)
+	}
+	defer rows.Close()
+
+	var deliveries []domain.WebhookDelivery
+	for rows.Next() {
+		var d domain.WebhookDelivery
+		if err := rows.Scan(&d.ID, &d.WebhookID, &d.EventType, &d.Payload, &d.Status, &d.ResponseCode, &d.Attempt, &d.NextRetryAt, &d.DeliveredAt, &d.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan delivery: %w", err)
+		}
+		deliveries = append(deliveries, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate deliveries: %w", err)
+	}
+	return deliveries, nil
+}
+
+// ListDeliveriesByStatus returns all deliveries with a given status.
+func (r *PostgresWebhookRepository) ListDeliveriesByStatus(ctx context.Context, status string) ([]domain.WebhookDelivery, error) {
+	query := fmt.Sprintf(`SELECT %s FROM webhook_deliveries WHERE status = $1 ORDER BY created_at`, deliveryColumns)
+	rows, err := r.pool.Query(ctx, query, status)
+	if err != nil {
+		return nil, fmt.Errorf("list deliveries by status %s: %w", status, err)
+	}
+	defer rows.Close()
+
+	var deliveries []domain.WebhookDelivery
+	for rows.Next() {
+		var d domain.WebhookDelivery
+		if err := rows.Scan(&d.ID, &d.WebhookID, &d.EventType, &d.Payload, &d.Status, &d.ResponseCode, &d.Attempt, &d.NextRetryAt, &d.DeliveredAt, &d.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan delivery: %w", err)
+		}
+		deliveries = append(deliveries, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate deliveries: %w", err)
+	}
+	return deliveries, nil
+}
+
+// UpdateDelivery updates a delivery record (status, response_code, attempt, next_retry_at, delivered_at).
+func (r *PostgresWebhookRepository) UpdateDelivery(ctx context.Context, delivery *domain.WebhookDelivery) error {
+	query := `
+		UPDATE webhook_deliveries
+		SET status = $1, response_code = $2, attempt = $3, next_retry_at = $4, delivered_at = $5
+		WHERE id = $6`
+
+	tag, err := r.pool.Exec(ctx, query,
+		delivery.Status, delivery.ResponseCode, delivery.Attempt,
+		delivery.NextRetryAt, delivery.DeliveredAt, delivery.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("update delivery %s: %w", delivery.ID, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("delivery %s: %w", delivery.ID, ErrNotFound)
+	}
+	return nil
+}
+
+// IncrementFailureCount atomically increments the failure count and returns the new value.
+func (r *PostgresWebhookRepository) IncrementFailureCount(ctx context.Context, webhookID string) (int, error) {
+	var count int
+	err := r.pool.QueryRow(ctx,
+		`UPDATE webhooks SET failure_count = failure_count + 1, updated_at = now() WHERE id = $1 RETURNING failure_count`,
+		webhookID,
+	).Scan(&count)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return 0, fmt.Errorf("webhook %s: %w", webhookID, ErrNotFound)
+		}
+		return 0, fmt.Errorf("increment failure count: %w", err)
+	}
+	return count, nil
+}
+
+// ResetFailureCount sets the failure count back to zero.
+func (r *PostgresWebhookRepository) ResetFailureCount(ctx context.Context, webhookID string) error {
+	tag, err := r.pool.Exec(ctx,
+		`UPDATE webhooks SET failure_count = 0, updated_at = now() WHERE id = $1`,
+		webhookID,
+	)
+	if err != nil {
+		return fmt.Errorf("reset failure count: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("webhook %s: %w", webhookID, ErrNotFound)
+	}
+	return nil
+}

--- a/internal/storage/webhook_repository_pg_test.go
+++ b/internal/storage/webhook_repository_pg_test.go
@@ -1,0 +1,18 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPostgresWebhookRepository_ImplementsInterface(t *testing.T) {
+	// Compile-time check that PostgresWebhookRepository satisfies WebhookRepository.
+	var _ WebhookRepository = (*PostgresWebhookRepository)(nil)
+}
+
+func TestNewPostgresWebhookRepository(t *testing.T) {
+	repo := NewPostgresWebhookRepository(nil)
+	assert.NotNil(t, repo)
+	assert.Nil(t, repo.pool)
+}

--- a/migrations/000009_create_webhooks_tables.down.sql
+++ b/migrations/000009_create_webhooks_tables.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS webhook_deliveries;
+DROP TABLE IF EXISTS webhooks;

--- a/migrations/000009_create_webhooks_tables.up.sql
+++ b/migrations/000009_create_webhooks_tables.up.sql
@@ -1,0 +1,31 @@
+-- Webhook registrations
+CREATE TABLE webhooks (
+    id             TEXT        PRIMARY KEY,
+    url            TEXT        NOT NULL,
+    secret         TEXT        NOT NULL,
+    event_types    TEXT[]      NOT NULL DEFAULT '{}',
+    active         BOOLEAN     NOT NULL DEFAULT true,
+    failure_count  INTEGER     NOT NULL DEFAULT 0,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_webhooks_active ON webhooks (active) WHERE active = true;
+
+-- Webhook delivery log
+CREATE TABLE webhook_deliveries (
+    id             TEXT        PRIMARY KEY,
+    webhook_id     TEXT        NOT NULL REFERENCES webhooks (id) ON DELETE CASCADE,
+    event_type     TEXT        NOT NULL,
+    payload        JSONB       NOT NULL DEFAULT '{}',
+    status         TEXT        NOT NULL DEFAULT 'pending',
+    response_code  INTEGER,
+    attempt        INTEGER     NOT NULL DEFAULT 1,
+    next_retry_at  TIMESTAMPTZ,
+    delivered_at   TIMESTAMPTZ,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_webhook_deliveries_webhook_id ON webhook_deliveries (webhook_id);
+CREATE INDEX idx_webhook_deliveries_status ON webhook_deliveries (status);
+CREATE INDEX idx_webhook_deliveries_next_retry ON webhook_deliveries (next_retry_at) WHERE status = 'pending';


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-301.

Closes #301

## Changes

Create the webhook infrastructure layer: migration `000009_create_webhooks_tables` with `webhooks` (id, url, secret, event_types, active, failure_count, created_at, updated_at) and `webhook_deliveries` (id, webhook_id, event_type, payload, status, response_code, attempt, next_retry_at, delivered_at) tables. Add domain models in `internal/domain/` (Webhook, WebhookDelivery structs, event type constants, validation). Implement `WebhookRepository` in `internal/storage/` with CRUD for webhooks, delivery log persistence, querying deliveries by webhook/status, and failure count tracking. Include the embedded migration in `internal/migrations/`.