### PR TITLE
GH-303: Admin API handlers, event integration, and service wiring

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/qf-studio/auth-service/internal/config"
 	"github.com/qf-studio/auth-service/internal/dpop"
 	grpcserver "github.com/qf-studio/auth-service/internal/grpc"
+	"github.com/qf-studio/auth-service/internal/webhook"
 	"github.com/qf-studio/auth-service/internal/rbac"
 	"github.com/qf-studio/auth-service/internal/health"
 	"github.com/qf-studio/auth-service/internal/hibp"
@@ -178,11 +179,19 @@ func run(log *zap.Logger, cfg *config.Config) error {
 	clientRepo := storage.NewPostgresClientRepository(pgPool)
 	apiKeyRepo := storage.NewPostgresAPIKeyRepository(pgPool)
 
+	// ── Webhook repositories ─────────────────────────────────────────────
+	webhookRepo := storage.NewPostgresWebhookRepository(pgPool)
+	webhookDeliveryRepo := storage.NewPostgresWebhookDeliveryRepository(pgPool)
+
+	// ── Webhook dispatcher ───────────────────────────────────────────────
+	webhookDispatcher := webhook.NewDispatcher(webhookRepo, webhookDeliveryRepo, log)
+
 	// ── Admin services ────────────────────────────────────────────────────
 	adminUserSvc := admin.NewUserService(adminUserRepo, hasher, log, auditSvc)
 	adminClientSvc := admin.NewClientService(clientRepo, hasher, log, auditSvc)
 	adminTokenSvc := admin.NewTokenService(tokenSvc, refreshTokenRepo, "auth-service", log, auditSvc)
 	adminAPIKeySvc := admin.NewAPIKeyService(apiKeyRepo, hasher, log, auditSvc)
+	adminWebhookSvc := admin.NewWebhookService(webhookRepo, webhookDeliveryRepo, webhookDispatcher, log, auditSvc)
 
 	// ── Middleware ─────────────────────────────────────────────────────────
 	rateLimiter := middleware.NewRateLimiter(cfg.Rate)
@@ -216,6 +225,7 @@ func run(log *zap.Logger, cfg *config.Config) error {
 		MFA:            mfaSvc,
 		Consent:        consentSvc,
 		ClientApproval: clientApprovalSvc,
+		Webhooks:       adminWebhookSvc,
 	}
 
 	adminDeps := &api.AdminDeps{
@@ -263,6 +273,7 @@ func run(log *zap.Logger, cfg *config.Config) error {
 	// Decision: Redis is listed before any future DB closer so that
 	// token-revocation lookups during drain can still reach the cache.
 	closers := []httpserver.Closer{
+		webhookDispatcher,
 		auditSvc,
 		&redisCloser{client: redisClient},
 	}

--- a/internal/admin/webhook_service.go
+++ b/internal/admin/webhook_service.go
@@ -1,0 +1,392 @@
+package admin
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/audit"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+	"github.com/qf-studio/auth-service/internal/webhook"
+)
+
+const (
+	// webhookSecretBytes is the number of random bytes for webhook secret generation (256-bit).
+	webhookSecretBytes = 32
+)
+
+// WebhookService implements api.AdminWebhookService.
+type WebhookService struct {
+	webhookRepo  storage.WebhookRepository
+	deliveryRepo storage.WebhookDeliveryRepository
+	dispatcher   *webhook.Dispatcher
+	logger       *zap.Logger
+	audit        audit.EventLogger
+}
+
+// NewWebhookService creates a new admin webhook service.
+func NewWebhookService(
+	webhookRepo storage.WebhookRepository,
+	deliveryRepo storage.WebhookDeliveryRepository,
+	dispatcher *webhook.Dispatcher,
+	logger *zap.Logger,
+	auditor audit.EventLogger,
+) *WebhookService {
+	return &WebhookService{
+		webhookRepo:  webhookRepo,
+		deliveryRepo: deliveryRepo,
+		dispatcher:   dispatcher,
+		logger:       logger,
+		audit:        auditor,
+	}
+}
+
+// ListWebhooks returns a paginated list of webhooks.
+func (s *WebhookService) ListWebhooks(ctx context.Context, page, perPage int, activeOnly bool) (*api.AdminWebhookList, error) {
+	offset := (page - 1) * perPage
+
+	webhooks, total, err := s.webhookRepo.List(ctx, perPage, offset, activeOnly)
+	if err != nil {
+		s.logger.Error("list webhooks failed", zap.Error(err))
+		return nil, fmt.Errorf("list webhooks: %w", api.ErrInternalError)
+	}
+
+	result := &api.AdminWebhookList{
+		Webhooks: make([]api.AdminWebhook, 0, len(webhooks)),
+		Total:    total,
+		Page:     page,
+		PerPage:  perPage,
+	}
+
+	for _, wh := range webhooks {
+		result.Webhooks = append(result.Webhooks, domainWebhookToAdmin(wh))
+	}
+
+	return result, nil
+}
+
+// GetWebhook retrieves a single webhook by ID.
+func (s *WebhookService) GetWebhook(ctx context.Context, webhookID string) (*api.AdminWebhook, error) {
+	id, err := uuid.Parse(webhookID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid webhook ID: %w", api.ErrNotFound)
+	}
+
+	wh, err := s.webhookRepo.FindByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("webhook %s: %w", webhookID, api.ErrNotFound)
+		}
+		s.logger.Error("get webhook failed", zap.String("webhook_id", webhookID), zap.Error(err))
+		return nil, fmt.Errorf("get webhook: %w", api.ErrInternalError)
+	}
+
+	admin := domainWebhookToAdmin(wh)
+	return &admin, nil
+}
+
+// CreateWebhook creates a new webhook subscription with a generated signing secret.
+func (s *WebhookService) CreateWebhook(ctx context.Context, req *api.CreateWebhookRequest) (*api.AdminWebhookWithSecret, error) {
+	secret, err := generateWebhookSecret()
+	if err != nil {
+		s.logger.Error("generate webhook secret failed", zap.Error(err))
+		return nil, fmt.Errorf("create webhook: %w", api.ErrInternalError)
+	}
+
+	now := time.Now().UTC()
+	eventTypes := req.EventTypes
+	if eventTypes == nil {
+		eventTypes = []string{}
+	}
+
+	wh := &domain.Webhook{
+		ID:           uuid.New(),
+		URL:          req.URL,
+		SecretHash:   secret, // stored as the raw secret for HMAC signing
+		EventTypes:   eventTypes,
+		Active:       true,
+		FailureCount: 0,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+
+	created, err := s.webhookRepo.Create(ctx, wh)
+	if err != nil {
+		s.logger.Error("create webhook failed", zap.Error(err))
+		return nil, fmt.Errorf("create webhook: %w", api.ErrInternalError)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminWebhookCreate,
+		TargetID: created.ID.String(),
+		Metadata: map[string]string{"url": created.URL},
+	})
+
+	return &api.AdminWebhookWithSecret{
+		AdminWebhook: domainWebhookToAdmin(created),
+		Secret:       secret,
+	}, nil
+}
+
+// UpdateWebhook modifies webhook fields (url, event_types, active).
+func (s *WebhookService) UpdateWebhook(ctx context.Context, webhookID string, req *api.UpdateWebhookRequest) (*api.AdminWebhook, error) {
+	id, err := uuid.Parse(webhookID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid webhook ID: %w", api.ErrNotFound)
+	}
+
+	existing, err := s.webhookRepo.FindByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("webhook %s: %w", webhookID, api.ErrNotFound)
+		}
+		s.logger.Error("find webhook for update failed", zap.String("webhook_id", webhookID), zap.Error(err))
+		return nil, fmt.Errorf("update webhook: %w", api.ErrInternalError)
+	}
+
+	if req.URL != nil {
+		existing.URL = *req.URL
+	}
+	if req.EventTypes != nil {
+		existing.EventTypes = req.EventTypes
+	}
+	if req.Active != nil {
+		existing.Active = *req.Active
+	}
+
+	updated, err := s.webhookRepo.Update(ctx, existing)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("webhook %s: %w", webhookID, api.ErrNotFound)
+		}
+		s.logger.Error("update webhook failed", zap.String("webhook_id", webhookID), zap.Error(err))
+		return nil, fmt.Errorf("update webhook: %w", api.ErrInternalError)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminWebhookUpdate,
+		TargetID: webhookID,
+	})
+
+	admin := domainWebhookToAdmin(updated)
+	return &admin, nil
+}
+
+// DeleteWebhook removes a webhook by ID.
+func (s *WebhookService) DeleteWebhook(ctx context.Context, webhookID string) error {
+	id, err := uuid.Parse(webhookID)
+	if err != nil {
+		return fmt.Errorf("invalid webhook ID: %w", api.ErrNotFound)
+	}
+
+	err = s.webhookRepo.Delete(ctx, id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return fmt.Errorf("webhook %s: %w", webhookID, api.ErrNotFound)
+		}
+		s.logger.Error("delete webhook failed", zap.String("webhook_id", webhookID), zap.Error(err))
+		return fmt.Errorf("delete webhook: %w", api.ErrInternalError)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminWebhookDelete,
+		TargetID: webhookID,
+	})
+	return nil
+}
+
+// ListDeliveries returns a paginated list of delivery log entries for a webhook.
+func (s *WebhookService) ListDeliveries(ctx context.Context, webhookID string, page, perPage int) (*api.AdminWebhookDeliveryList, error) {
+	id, err := uuid.Parse(webhookID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid webhook ID: %w", api.ErrNotFound)
+	}
+
+	// Verify webhook exists.
+	if _, err := s.webhookRepo.FindByID(ctx, id); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("webhook %s: %w", webhookID, api.ErrNotFound)
+		}
+		s.logger.Error("find webhook for deliveries failed", zap.String("webhook_id", webhookID), zap.Error(err))
+		return nil, fmt.Errorf("list deliveries: %w", api.ErrInternalError)
+	}
+
+	offset := (page - 1) * perPage
+	deliveries, total, err := s.deliveryRepo.List(ctx, id, perPage, offset)
+	if err != nil {
+		s.logger.Error("list deliveries failed", zap.String("webhook_id", webhookID), zap.Error(err))
+		return nil, fmt.Errorf("list deliveries: %w", api.ErrInternalError)
+	}
+
+	result := &api.AdminWebhookDeliveryList{
+		Deliveries: make([]api.AdminWebhookDelivery, 0, len(deliveries)),
+		Total:      total,
+		Page:       page,
+		PerPage:    perPage,
+	}
+
+	for _, d := range deliveries {
+		result.Deliveries = append(result.Deliveries, domainDeliveryToAdmin(d))
+	}
+
+	return result, nil
+}
+
+// RetryDelivery manually retries a failed webhook delivery.
+func (s *WebhookService) RetryDelivery(ctx context.Context, webhookID, deliveryID string) (*api.AdminWebhookDelivery, error) {
+	whID, err := uuid.Parse(webhookID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid webhook ID: %w", api.ErrNotFound)
+	}
+
+	dID, err := uuid.Parse(deliveryID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid delivery ID: %w", api.ErrNotFound)
+	}
+
+	wh, err := s.webhookRepo.FindByID(ctx, whID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("webhook %s: %w", webhookID, api.ErrNotFound)
+		}
+		s.logger.Error("find webhook for retry failed", zap.String("webhook_id", webhookID), zap.Error(err))
+		return nil, fmt.Errorf("retry delivery: %w", api.ErrInternalError)
+	}
+
+	existing, err := s.deliveryRepo.FindByID(ctx, dID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("delivery %s: %w", deliveryID, api.ErrNotFound)
+		}
+		s.logger.Error("find delivery for retry failed", zap.String("delivery_id", deliveryID), zap.Error(err))
+		return nil, fmt.Errorf("retry delivery: %w", api.ErrInternalError)
+	}
+
+	if existing.WebhookID != whID {
+		return nil, fmt.Errorf("delivery %s does not belong to webhook %s: %w", deliveryID, webhookID, api.ErrNotFound)
+	}
+
+	// Re-deliver using the existing payload.
+	var payload webhook.Payload
+	if err := json.Unmarshal([]byte(existing.Payload), &payload); err != nil {
+		// If we can't parse the stored payload, construct a minimal one.
+		payload = webhook.Payload{
+			ID:        uuid.New().String(),
+			EventType: existing.EventType,
+			Timestamp: time.Now().UTC(),
+		}
+	}
+
+	delivery, err := s.dispatcher.DeliverSingle(ctx, wh, payload)
+	if err != nil {
+		// Delivery failed but we still return the delivery record.
+		if delivery != nil {
+			s.audit.LogEvent(ctx, audit.Event{
+				Type:     audit.EventAdminWebhookRetry,
+				TargetID: deliveryID,
+				Metadata: map[string]string{"webhook_id": webhookID, "status": delivery.Status},
+			})
+			admin := domainDeliveryToAdmin(delivery)
+			return &admin, nil
+		}
+		s.logger.Error("retry delivery failed", zap.String("delivery_id", deliveryID), zap.Error(err))
+		return nil, fmt.Errorf("retry delivery: %w", api.ErrInternalError)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminWebhookRetry,
+		TargetID: deliveryID,
+		Metadata: map[string]string{"webhook_id": webhookID, "status": delivery.Status},
+	})
+
+	admin := domainDeliveryToAdmin(delivery)
+	return &admin, nil
+}
+
+// TestWebhook sends a test event to a webhook and returns the delivery result.
+func (s *WebhookService) TestWebhook(ctx context.Context, webhookID string, req *api.TestWebhookRequest) (*api.TestWebhookResponse, error) {
+	id, err := uuid.Parse(webhookID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid webhook ID: %w", api.ErrNotFound)
+	}
+
+	wh, err := s.webhookRepo.FindByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("webhook %s: %w", webhookID, api.ErrNotFound)
+		}
+		s.logger.Error("find webhook for test failed", zap.String("webhook_id", webhookID), zap.Error(err))
+		return nil, fmt.Errorf("test webhook: %w", api.ErrInternalError)
+	}
+
+	payload := webhook.Payload{
+		ID:        uuid.New().String(),
+		EventType: req.EventType,
+		Timestamp: time.Now().UTC(),
+		Data:      map[string]string{"test": "true"},
+	}
+
+	delivery, deliverErr := s.dispatcher.DeliverSingle(ctx, wh, payload)
+	if delivery == nil {
+		s.logger.Error("test webhook delivery returned nil", zap.String("webhook_id", webhookID), zap.Error(deliverErr))
+		return nil, fmt.Errorf("test webhook: %w", api.ErrInternalError)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminWebhookTest,
+		TargetID: webhookID,
+		Metadata: map[string]string{"event_type": req.EventType, "delivery_status": delivery.Status},
+	})
+
+	return &api.TestWebhookResponse{
+		DeliveryID:   delivery.ID.String(),
+		Status:       delivery.Status,
+		ResponseCode: delivery.ResponseCode,
+	}, nil
+}
+
+// generateWebhookSecret generates a cryptographically random secret for HMAC signing.
+func generateWebhookSecret() (string, error) {
+	b := make([]byte, webhookSecretBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate random bytes: %w", err)
+	}
+	return "whsec_" + hex.EncodeToString(b), nil
+}
+
+func domainWebhookToAdmin(wh *domain.Webhook) api.AdminWebhook {
+	return api.AdminWebhook{
+		ID:           wh.ID.String(),
+		URL:          wh.URL,
+		EventTypes:   wh.EventTypes,
+		Active:       wh.Active,
+		FailureCount: wh.FailureCount,
+		CreatedAt:    wh.CreatedAt,
+		UpdatedAt:    wh.UpdatedAt,
+	}
+}
+
+func domainDeliveryToAdmin(d *domain.WebhookDelivery) api.AdminWebhookDelivery {
+	return api.AdminWebhookDelivery{
+		ID:           d.ID.String(),
+		WebhookID:    d.WebhookID.String(),
+		EventType:    d.EventType,
+		Payload:      d.Payload,
+		Status:       d.Status,
+		ResponseCode: d.ResponseCode,
+		ResponseBody: d.ResponseBody,
+		Attempt:      d.Attempt,
+		NextRetryAt:  d.NextRetryAt,
+		DeliveredAt:  d.DeliveredAt,
+		CreatedAt:    d.CreatedAt,
+	}
+}

--- a/internal/api/admin_router.go
+++ b/internal/api/admin_router.go
@@ -97,6 +97,22 @@ func NewAdminRouter(svc *AdminServices, deps *AdminDeps) *gin.Engine {
 		}
 	}
 
+	// Webhook management.
+	if svc.Webhooks != nil {
+		webhookH := NewAdminWebhookHandlers(svc.Webhooks)
+		webhooks := admin.Group("/webhooks")
+		{
+			webhooks.GET("", webhookH.List)
+			webhooks.GET("/:id", webhookH.Get)
+			webhooks.POST("", webhookH.Create)
+			webhooks.PATCH("/:id", webhookH.Update)
+			webhooks.DELETE("/:id", webhookH.Delete)
+			webhooks.GET("/:id/deliveries", webhookH.ListDeliveries)
+			webhooks.POST("/:id/deliveries/:delivery_id/retry", webhookH.RetryDelivery)
+			webhooks.POST("/:id/test", webhookH.Test)
+		}
+	}
+
 	// Token introspection.
 	if svc.Tokens != nil {
 		tokenH := NewAdminTokenHandlers(svc.Tokens)

--- a/internal/api/admin_services.go
+++ b/internal/api/admin_services.go
@@ -196,6 +196,93 @@ type AdminAPIKeyService interface {
 	RotateAPIKey(ctx context.Context, keyID string) (*AdminAPIKeyWithSecret, error)
 }
 
+// --- Webhook admin types ---
+
+// AdminWebhook represents a webhook subscription in admin API responses.
+type AdminWebhook struct {
+	ID           string    `json:"id"`
+	URL          string    `json:"url"`
+	EventTypes   []string  `json:"event_types"`
+	Active       bool      `json:"active"`
+	FailureCount int       `json:"failure_count"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+// AdminWebhookWithSecret is returned only on create (includes the raw signing secret).
+type AdminWebhookWithSecret struct {
+	AdminWebhook
+	Secret string `json:"secret"`
+}
+
+// AdminWebhookList is the paginated response for listing webhooks.
+type AdminWebhookList struct {
+	Webhooks []AdminWebhook `json:"webhooks"`
+	Total    int            `json:"total"`
+	Page     int            `json:"page"`
+	PerPage  int            `json:"per_page"`
+}
+
+// AdminWebhookDelivery represents a webhook delivery log entry.
+type AdminWebhookDelivery struct {
+	ID           string     `json:"id"`
+	WebhookID    string     `json:"webhook_id"`
+	EventType    string     `json:"event_type"`
+	Payload      string     `json:"payload"`
+	Status       string     `json:"status"`
+	ResponseCode *int       `json:"response_code,omitempty"`
+	ResponseBody *string    `json:"response_body,omitempty"`
+	Attempt      int        `json:"attempt"`
+	NextRetryAt  *time.Time `json:"next_retry_at,omitempty"`
+	DeliveredAt  *time.Time `json:"delivered_at,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+}
+
+// AdminWebhookDeliveryList is the paginated response for listing deliveries.
+type AdminWebhookDeliveryList struct {
+	Deliveries []AdminWebhookDelivery `json:"deliveries"`
+	Total      int                    `json:"total"`
+	Page       int                    `json:"page"`
+	PerPage    int                    `json:"per_page"`
+}
+
+// CreateWebhookRequest is the request body for creating a webhook.
+type CreateWebhookRequest struct {
+	URL        string   `json:"url"         validate:"required,url"`
+	EventTypes []string `json:"event_types" validate:"required,min=1"`
+}
+
+// UpdateWebhookRequest is the request body for updating a webhook.
+type UpdateWebhookRequest struct {
+	URL        *string  `json:"url"         validate:"omitempty,url"`
+	EventTypes []string `json:"event_types" validate:"omitempty"`
+	Active     *bool    `json:"active"      validate:"omitempty"`
+}
+
+// TestWebhookRequest is the request body for sending a test webhook event.
+type TestWebhookRequest struct {
+	EventType string `json:"event_type" validate:"required"`
+}
+
+// TestWebhookResponse is the response for a test webhook delivery.
+type TestWebhookResponse struct {
+	DeliveryID   string `json:"delivery_id"`
+	Status       string `json:"status"`
+	ResponseCode *int   `json:"response_code,omitempty"`
+}
+
+// AdminWebhookService defines admin operations for webhook management.
+type AdminWebhookService interface {
+	ListWebhooks(ctx context.Context, page, perPage int, activeOnly bool) (*AdminWebhookList, error)
+	GetWebhook(ctx context.Context, webhookID string) (*AdminWebhook, error)
+	CreateWebhook(ctx context.Context, req *CreateWebhookRequest) (*AdminWebhookWithSecret, error)
+	UpdateWebhook(ctx context.Context, webhookID string, req *UpdateWebhookRequest) (*AdminWebhook, error)
+	DeleteWebhook(ctx context.Context, webhookID string) error
+	ListDeliveries(ctx context.Context, webhookID string, page, perPage int) (*AdminWebhookDeliveryList, error)
+	RetryDelivery(ctx context.Context, webhookID, deliveryID string) (*AdminWebhookDelivery, error)
+	TestWebhook(ctx context.Context, webhookID string, req *TestWebhookRequest) (*TestWebhookResponse, error)
+}
+
 // AdminServices aggregates all admin service interfaces required by admin API handlers.
 type AdminServices struct {
 	Users          AdminUserService
@@ -205,4 +292,5 @@ type AdminServices struct {
 	MFA            MFAService
 	Consent        ConsentService
 	ClientApproval AdminClientApprovalService
+	Webhooks       AdminWebhookService
 }

--- a/internal/api/admin_webhook_handlers.go
+++ b/internal/api/admin_webhook_handlers.go
@@ -1,0 +1,158 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// AdminWebhookHandlers groups HTTP handlers for admin webhook management endpoints.
+type AdminWebhookHandlers struct {
+	webhooks AdminWebhookService
+}
+
+// NewAdminWebhookHandlers creates a new AdminWebhookHandlers with the given AdminWebhookService.
+func NewAdminWebhookHandlers(webhooks AdminWebhookService) *AdminWebhookHandlers {
+	return &AdminWebhookHandlers{webhooks: webhooks}
+}
+
+// List handles GET /admin/webhooks.
+// Query params: page (default 1), per_page (default 20), active (filter active only).
+func (h *AdminWebhookHandlers) List(c *gin.Context) {
+	page, perPage := parsePagination(c)
+	activeOnly := c.DefaultQuery("active", "") == "true"
+
+	result, err := h.webhooks.ListWebhooks(c.Request.Context(), page, perPage, activeOnly)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// Get handles GET /admin/webhooks/:id.
+func (h *AdminWebhookHandlers) Get(c *gin.Context) {
+	webhookID := c.Param("id")
+
+	wh, err := h.webhooks.GetWebhook(c.Request.Context(), webhookID)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, wh)
+}
+
+// Create handles POST /admin/webhooks.
+// Returns the webhook with the generated signing secret (only time secret is visible).
+func (h *AdminWebhookHandlers) Create(c *gin.Context) {
+	var req CreateWebhookRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid request body")
+		return
+	}
+
+	if err := adminValidator.Struct(req); err != nil {
+		handleValidationError(c, err)
+		return
+	}
+
+	wh, err := h.webhooks.CreateWebhook(c.Request.Context(), &req)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, wh)
+}
+
+// Update handles PATCH /admin/webhooks/:id.
+func (h *AdminWebhookHandlers) Update(c *gin.Context) {
+	webhookID := c.Param("id")
+
+	var req UpdateWebhookRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid request body")
+		return
+	}
+
+	if err := adminValidator.Struct(req); err != nil {
+		handleValidationError(c, err)
+		return
+	}
+
+	wh, err := h.webhooks.UpdateWebhook(c.Request.Context(), webhookID, &req)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, wh)
+}
+
+// Delete handles DELETE /admin/webhooks/:id.
+func (h *AdminWebhookHandlers) Delete(c *gin.Context) {
+	webhookID := c.Param("id")
+
+	if err := h.webhooks.DeleteWebhook(c.Request.Context(), webhookID); err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "webhook deleted"})
+}
+
+// ListDeliveries handles GET /admin/webhooks/:id/deliveries.
+func (h *AdminWebhookHandlers) ListDeliveries(c *gin.Context) {
+	webhookID := c.Param("id")
+	page, perPage := parsePagination(c)
+
+	result, err := h.webhooks.ListDeliveries(c.Request.Context(), webhookID, page, perPage)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// RetryDelivery handles POST /admin/webhooks/:id/deliveries/:delivery_id/retry.
+func (h *AdminWebhookHandlers) RetryDelivery(c *gin.Context) {
+	webhookID := c.Param("id")
+	deliveryID := c.Param("delivery_id")
+
+	delivery, err := h.webhooks.RetryDelivery(c.Request.Context(), webhookID, deliveryID)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, delivery)
+}
+
+// Test handles POST /admin/webhooks/:id/test.
+func (h *AdminWebhookHandlers) Test(c *gin.Context) {
+	webhookID := c.Param("id")
+
+	var req TestWebhookRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid request body")
+		return
+	}
+
+	if err := adminValidator.Struct(req); err != nil {
+		handleValidationError(c, err)
+		return
+	}
+
+	result, err := h.webhooks.TestWebhook(c.Request.Context(), webhookID, &req)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}

--- a/internal/api/admin_webhook_handlers_test.go
+++ b/internal/api/admin_webhook_handlers_test.go
@@ -1,0 +1,525 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/health"
+)
+
+// --- Mock AdminWebhookService ---
+
+type mockAdminWebhookService struct {
+	listWebhooksFn   func(ctx context.Context, page, perPage int, activeOnly bool) (*api.AdminWebhookList, error)
+	getWebhookFn     func(ctx context.Context, webhookID string) (*api.AdminWebhook, error)
+	createWebhookFn  func(ctx context.Context, req *api.CreateWebhookRequest) (*api.AdminWebhookWithSecret, error)
+	updateWebhookFn  func(ctx context.Context, webhookID string, req *api.UpdateWebhookRequest) (*api.AdminWebhook, error)
+	deleteWebhookFn  func(ctx context.Context, webhookID string) error
+	listDeliveriesFn func(ctx context.Context, webhookID string, page, perPage int) (*api.AdminWebhookDeliveryList, error)
+	retryDeliveryFn  func(ctx context.Context, webhookID, deliveryID string) (*api.AdminWebhookDelivery, error)
+	testWebhookFn    func(ctx context.Context, webhookID string, req *api.TestWebhookRequest) (*api.TestWebhookResponse, error)
+}
+
+func (m *mockAdminWebhookService) ListWebhooks(ctx context.Context, page, perPage int, activeOnly bool) (*api.AdminWebhookList, error) {
+	if m.listWebhooksFn != nil {
+		return m.listWebhooksFn(ctx, page, perPage, activeOnly)
+	}
+	return &api.AdminWebhookList{
+		Webhooks: []api.AdminWebhook{{
+			ID:           "wh1",
+			URL:          "https://example.com/webhook",
+			EventTypes:   []string{"admin_user_create"},
+			Active:       true,
+			FailureCount: 0,
+			CreatedAt:    time.Now(),
+			UpdatedAt:    time.Now(),
+		}},
+		Total:   1,
+		Page:    page,
+		PerPage: perPage,
+	}, nil
+}
+
+func (m *mockAdminWebhookService) GetWebhook(ctx context.Context, webhookID string) (*api.AdminWebhook, error) {
+	if m.getWebhookFn != nil {
+		return m.getWebhookFn(ctx, webhookID)
+	}
+	return &api.AdminWebhook{
+		ID:           webhookID,
+		URL:          "https://example.com/webhook",
+		EventTypes:   []string{"admin_user_create"},
+		Active:       true,
+		FailureCount: 0,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}, nil
+}
+
+func (m *mockAdminWebhookService) CreateWebhook(ctx context.Context, req *api.CreateWebhookRequest) (*api.AdminWebhookWithSecret, error) {
+	if m.createWebhookFn != nil {
+		return m.createWebhookFn(ctx, req)
+	}
+	return &api.AdminWebhookWithSecret{
+		AdminWebhook: api.AdminWebhook{
+			ID:           "new-webhook",
+			URL:          req.URL,
+			EventTypes:   req.EventTypes,
+			Active:       true,
+			FailureCount: 0,
+			CreatedAt:    time.Now(),
+			UpdatedAt:    time.Now(),
+		},
+		Secret: "whsec_abcdef0123456789",
+	}, nil
+}
+
+func (m *mockAdminWebhookService) UpdateWebhook(ctx context.Context, webhookID string, req *api.UpdateWebhookRequest) (*api.AdminWebhook, error) {
+	if m.updateWebhookFn != nil {
+		return m.updateWebhookFn(ctx, webhookID, req)
+	}
+	url := "https://example.com/webhook"
+	if req.URL != nil {
+		url = *req.URL
+	}
+	active := true
+	if req.Active != nil {
+		active = *req.Active
+	}
+	eventTypes := []string{"admin_user_create"}
+	if req.EventTypes != nil {
+		eventTypes = req.EventTypes
+	}
+	return &api.AdminWebhook{
+		ID:           webhookID,
+		URL:          url,
+		EventTypes:   eventTypes,
+		Active:       active,
+		FailureCount: 0,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}, nil
+}
+
+func (m *mockAdminWebhookService) DeleteWebhook(ctx context.Context, webhookID string) error {
+	if m.deleteWebhookFn != nil {
+		return m.deleteWebhookFn(ctx, webhookID)
+	}
+	return nil
+}
+
+func (m *mockAdminWebhookService) ListDeliveries(ctx context.Context, webhookID string, page, perPage int) (*api.AdminWebhookDeliveryList, error) {
+	if m.listDeliveriesFn != nil {
+		return m.listDeliveriesFn(ctx, webhookID, page, perPage)
+	}
+	return &api.AdminWebhookDeliveryList{
+		Deliveries: []api.AdminWebhookDelivery{{
+			ID:        "del1",
+			WebhookID: webhookID,
+			EventType: "admin_user_create",
+			Payload:   `{"event_type":"admin_user_create"}`,
+			Status:    "delivered",
+			Attempt:   1,
+			CreatedAt: time.Now(),
+		}},
+		Total:   1,
+		Page:    page,
+		PerPage: perPage,
+	}, nil
+}
+
+func (m *mockAdminWebhookService) RetryDelivery(ctx context.Context, webhookID, deliveryID string) (*api.AdminWebhookDelivery, error) {
+	if m.retryDeliveryFn != nil {
+		return m.retryDeliveryFn(ctx, webhookID, deliveryID)
+	}
+	return &api.AdminWebhookDelivery{
+		ID:        deliveryID,
+		WebhookID: webhookID,
+		EventType: "admin_user_create",
+		Payload:   `{"event_type":"admin_user_create"}`,
+		Status:    "delivered",
+		Attempt:   2,
+		CreatedAt: time.Now(),
+	}, nil
+}
+
+func (m *mockAdminWebhookService) TestWebhook(ctx context.Context, webhookID string, req *api.TestWebhookRequest) (*api.TestWebhookResponse, error) {
+	if m.testWebhookFn != nil {
+		return m.testWebhookFn(ctx, webhookID, req)
+	}
+	code := 200
+	return &api.TestWebhookResponse{
+		DeliveryID:   "test-delivery-1",
+		Status:       "delivered",
+		ResponseCode: &code,
+	}, nil
+}
+
+// --- Helper ---
+
+func newAdminWebhookRouter(webhookSvc api.AdminWebhookService) *gin.Engine {
+	svc := &api.AdminServices{Webhooks: webhookSvc}
+	return api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+}
+
+// --- List Webhooks ---
+
+func TestAdminListWebhooks_Success(t *testing.T) {
+	r := newAdminWebhookRouter(&mockAdminWebhookService{})
+	w := doRequest(r, http.MethodGet, "/admin/webhooks", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminWebhookList
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.Total)
+	assert.Len(t, resp.Webhooks, 1)
+}
+
+func TestAdminListWebhooks_Pagination(t *testing.T) {
+	svc := &mockAdminWebhookService{
+		listWebhooksFn: func(_ context.Context, page, perPage int, activeOnly bool) (*api.AdminWebhookList, error) {
+			assert.Equal(t, 2, page)
+			assert.Equal(t, 10, perPage)
+			assert.False(t, activeOnly)
+			return &api.AdminWebhookList{Webhooks: []api.AdminWebhook{}, Total: 50, Page: page, PerPage: perPage}, nil
+		},
+	}
+	r := newAdminWebhookRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/webhooks?page=2&per_page=10", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminWebhookList
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 2, resp.Page)
+	assert.Equal(t, 10, resp.PerPage)
+}
+
+func TestAdminListWebhooks_ActiveFilter(t *testing.T) {
+	svc := &mockAdminWebhookService{
+		listWebhooksFn: func(_ context.Context, page, perPage int, activeOnly bool) (*api.AdminWebhookList, error) {
+			assert.True(t, activeOnly)
+			return &api.AdminWebhookList{Webhooks: []api.AdminWebhook{}, Total: 0, Page: page, PerPage: perPage}, nil
+		},
+	}
+	r := newAdminWebhookRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/webhooks?active=true", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestAdminListWebhooks_ServiceError(t *testing.T) {
+	svc := &mockAdminWebhookService{
+		listWebhooksFn: func(_ context.Context, _, _ int, _ bool) (*api.AdminWebhookList, error) {
+			return nil, fmt.Errorf("list failed: %w", api.ErrInternalError)
+		},
+	}
+	r := newAdminWebhookRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/webhooks", nil)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- Get Webhook ---
+
+func TestAdminGetWebhook_Success(t *testing.T) {
+	r := newAdminWebhookRouter(&mockAdminWebhookService{})
+	w := doRequest(r, http.MethodGet, "/admin/webhooks/wh-1", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminWebhook
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "wh-1", resp.ID)
+}
+
+func TestAdminGetWebhook_NotFound(t *testing.T) {
+	svc := &mockAdminWebhookService{
+		getWebhookFn: func(_ context.Context, _ string) (*api.AdminWebhook, error) {
+			return nil, fmt.Errorf("webhook not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminWebhookRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/webhooks/nonexistent", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- Create Webhook ---
+
+func TestAdminCreateWebhook_Success(t *testing.T) {
+	r := newAdminWebhookRouter(&mockAdminWebhookService{})
+	body := map[string]interface{}{
+		"url":         "https://example.com/webhook",
+		"event_types": []string{"admin_user_create", "admin_user_delete"},
+	}
+	w := doRequest(r, http.MethodPost, "/admin/webhooks", body)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp api.AdminWebhookWithSecret
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "https://example.com/webhook", resp.URL)
+	assert.NotEmpty(t, resp.Secret, "secret must be returned on create")
+}
+
+func TestAdminCreateWebhook_MissingURL(t *testing.T) {
+	r := newAdminWebhookRouter(&mockAdminWebhookService{})
+	body := map[string]interface{}{
+		"event_types": []string{"admin_user_create"},
+	}
+	w := doRequest(r, http.MethodPost, "/admin/webhooks", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestAdminCreateWebhook_MissingEventTypes(t *testing.T) {
+	r := newAdminWebhookRouter(&mockAdminWebhookService{})
+	body := map[string]interface{}{
+		"url": "https://example.com/webhook",
+	}
+	w := doRequest(r, http.MethodPost, "/admin/webhooks", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestAdminCreateWebhook_InvalidJSON(t *testing.T) {
+	r := newAdminWebhookRouter(&mockAdminWebhookService{})
+	w := doRequest(r, http.MethodPost, "/admin/webhooks", nil)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminCreateWebhook_ServiceError(t *testing.T) {
+	svc := &mockAdminWebhookService{
+		createWebhookFn: func(_ context.Context, _ *api.CreateWebhookRequest) (*api.AdminWebhookWithSecret, error) {
+			return nil, fmt.Errorf("create failed: %w", api.ErrInternalError)
+		},
+	}
+	r := newAdminWebhookRouter(svc)
+	body := map[string]interface{}{
+		"url":         "https://example.com/webhook",
+		"event_types": []string{"admin_user_create"},
+	}
+	w := doRequest(r, http.MethodPost, "/admin/webhooks", body)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- Update Webhook ---
+
+func TestAdminUpdateWebhook_Success(t *testing.T) {
+	r := newAdminWebhookRouter(&mockAdminWebhookService{})
+	url := "https://new-url.com/webhook"
+	body := map[string]interface{}{"url": url}
+	w := doRequest(r, http.MethodPatch, "/admin/webhooks/wh-1", body)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminWebhook
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "https://new-url.com/webhook", resp.URL)
+}
+
+func TestAdminUpdateWebhook_NotFound(t *testing.T) {
+	svc := &mockAdminWebhookService{
+		updateWebhookFn: func(_ context.Context, _ string, _ *api.UpdateWebhookRequest) (*api.AdminWebhook, error) {
+			return nil, fmt.Errorf("webhook not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminWebhookRouter(svc)
+	body := map[string]interface{}{"url": "https://example.com"}
+	w := doRequest(r, http.MethodPatch, "/admin/webhooks/nonexistent", body)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestAdminUpdateWebhook_InvalidJSON(t *testing.T) {
+	r := newAdminWebhookRouter(&mockAdminWebhookService{})
+	w := doRequest(r, http.MethodPatch, "/admin/webhooks/wh-1", nil)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminUpdateWebhook_DisableWebhook(t *testing.T) {
+	svc := &mockAdminWebhookService{
+		updateWebhookFn: func(_ context.Context, webhookID string, req *api.UpdateWebhookRequest) (*api.AdminWebhook, error) {
+			assert.Equal(t, "wh-1", webhookID)
+			require.NotNil(t, req.Active)
+			assert.False(t, *req.Active)
+			return &api.AdminWebhook{
+				ID:         webhookID,
+				URL:        "https://example.com/webhook",
+				EventTypes: []string{"admin_user_create"},
+				Active:     false,
+				CreatedAt:  time.Now(),
+				UpdatedAt:  time.Now(),
+			}, nil
+		},
+	}
+	r := newAdminWebhookRouter(svc)
+	body := map[string]interface{}{"active": false}
+	w := doRequest(r, http.MethodPatch, "/admin/webhooks/wh-1", body)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminWebhook
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.False(t, resp.Active)
+}
+
+// --- Delete Webhook ---
+
+func TestAdminDeleteWebhook_Success(t *testing.T) {
+	r := newAdminWebhookRouter(&mockAdminWebhookService{})
+	w := doRequest(r, http.MethodDelete, "/admin/webhooks/wh-1", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestAdminDeleteWebhook_NotFound(t *testing.T) {
+	svc := &mockAdminWebhookService{
+		deleteWebhookFn: func(_ context.Context, _ string) error {
+			return fmt.Errorf("webhook not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminWebhookRouter(svc)
+	w := doRequest(r, http.MethodDelete, "/admin/webhooks/nonexistent", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- List Deliveries ---
+
+func TestAdminListDeliveries_Success(t *testing.T) {
+	r := newAdminWebhookRouter(&mockAdminWebhookService{})
+	w := doRequest(r, http.MethodGet, "/admin/webhooks/wh-1/deliveries", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminWebhookDeliveryList
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.Total)
+	assert.Len(t, resp.Deliveries, 1)
+}
+
+func TestAdminListDeliveries_NotFound(t *testing.T) {
+	svc := &mockAdminWebhookService{
+		listDeliveriesFn: func(_ context.Context, _ string, _, _ int) (*api.AdminWebhookDeliveryList, error) {
+			return nil, fmt.Errorf("webhook not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminWebhookRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/webhooks/nonexistent/deliveries", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- Retry Delivery ---
+
+func TestAdminRetryDelivery_Success(t *testing.T) {
+	r := newAdminWebhookRouter(&mockAdminWebhookService{})
+	w := doRequest(r, http.MethodPost, "/admin/webhooks/wh-1/deliveries/del-1/retry", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminWebhookDelivery
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "del-1", resp.ID)
+	assert.Equal(t, 2, resp.Attempt)
+}
+
+func TestAdminRetryDelivery_WebhookNotFound(t *testing.T) {
+	svc := &mockAdminWebhookService{
+		retryDeliveryFn: func(_ context.Context, _, _ string) (*api.AdminWebhookDelivery, error) {
+			return nil, fmt.Errorf("webhook not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminWebhookRouter(svc)
+	w := doRequest(r, http.MethodPost, "/admin/webhooks/nonexistent/deliveries/del-1/retry", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestAdminRetryDelivery_DeliveryNotFound(t *testing.T) {
+	svc := &mockAdminWebhookService{
+		retryDeliveryFn: func(_ context.Context, _, _ string) (*api.AdminWebhookDelivery, error) {
+			return nil, fmt.Errorf("delivery not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminWebhookRouter(svc)
+	w := doRequest(r, http.MethodPost, "/admin/webhooks/wh-1/deliveries/nonexistent/retry", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- Test Webhook ---
+
+func TestAdminTestWebhook_Success(t *testing.T) {
+	r := newAdminWebhookRouter(&mockAdminWebhookService{})
+	body := map[string]interface{}{
+		"event_type": "admin_user_create",
+	}
+	w := doRequest(r, http.MethodPost, "/admin/webhooks/wh-1/test", body)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.TestWebhookResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "delivered", resp.Status)
+	assert.NotEmpty(t, resp.DeliveryID)
+}
+
+func TestAdminTestWebhook_MissingEventType(t *testing.T) {
+	r := newAdminWebhookRouter(&mockAdminWebhookService{})
+	body := map[string]interface{}{}
+	w := doRequest(r, http.MethodPost, "/admin/webhooks/wh-1/test", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestAdminTestWebhook_InvalidJSON(t *testing.T) {
+	r := newAdminWebhookRouter(&mockAdminWebhookService{})
+	w := doRequest(r, http.MethodPost, "/admin/webhooks/wh-1/test", nil)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminTestWebhook_NotFound(t *testing.T) {
+	svc := &mockAdminWebhookService{
+		testWebhookFn: func(_ context.Context, _ string, _ *api.TestWebhookRequest) (*api.TestWebhookResponse, error) {
+			return nil, fmt.Errorf("webhook not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminWebhookRouter(svc)
+	body := map[string]interface{}{
+		"event_type": "admin_user_create",
+	}
+	w := doRequest(r, http.MethodPost, "/admin/webhooks/nonexistent/test", body)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestAdminTestWebhook_ServiceError(t *testing.T) {
+	svc := &mockAdminWebhookService{
+		testWebhookFn: func(_ context.Context, _ string, _ *api.TestWebhookRequest) (*api.TestWebhookResponse, error) {
+			return nil, fmt.Errorf("test failed: %w", api.ErrInternalError)
+		},
+	}
+	r := newAdminWebhookRouter(svc)
+	body := map[string]interface{}{
+		"event_type": "admin_user_create",
+	}
+	w := doRequest(r, http.MethodPost, "/admin/webhooks/wh-1/test", body)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -36,6 +36,11 @@ const (
 	EventAdminAPIKeyUpdate  = "admin_apikey_update"
 	EventAdminAPIKeyRevoke  = "admin_apikey_revoke"
 	EventAdminAPIKeyRotate  = "admin_apikey_rotate"
+	EventAdminWebhookCreate = "admin_webhook_create"
+	EventAdminWebhookUpdate = "admin_webhook_update"
+	EventAdminWebhookDelete = "admin_webhook_delete"
+	EventAdminWebhookTest   = "admin_webhook_test"
+	EventAdminWebhookRetry  = "admin_webhook_retry"
 )
 
 // Event represents a single audit log entry.

--- a/internal/domain/webhook.go
+++ b/internal/domain/webhook.go
@@ -1,0 +1,50 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Webhook status constants.
+const (
+	WebhookStatusActive   = "active"
+	WebhookStatusDisabled = "disabled"
+)
+
+// Webhook delivery status constants.
+const (
+	WebhookDeliveryStatusPending   = "pending"
+	WebhookDeliveryStatusDelivered = "delivered"
+	WebhookDeliveryStatusFailed    = "failed"
+)
+
+// MaxWebhookFailures is the number of consecutive failures before a webhook is auto-disabled.
+const MaxWebhookFailures = 10
+
+// Webhook represents a webhook subscription that receives event notifications via HTTP POST.
+type Webhook struct {
+	ID           uuid.UUID `json:"id"            db:"id"`
+	URL          string    `json:"url"           db:"url"`
+	SecretHash   string    `json:"-"             db:"secret_hash"`
+	EventTypes   []string  `json:"event_types"   db:"event_types"`
+	Active       bool      `json:"active"        db:"active"`
+	FailureCount int       `json:"failure_count" db:"failure_count"`
+	CreatedAt    time.Time `json:"created_at"    db:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"    db:"updated_at"`
+}
+
+// WebhookDelivery represents a single delivery attempt for a webhook event.
+type WebhookDelivery struct {
+	ID           uuid.UUID  `json:"id"                      db:"id"`
+	WebhookID    uuid.UUID  `json:"webhook_id"              db:"webhook_id"`
+	EventType    string     `json:"event_type"              db:"event_type"`
+	Payload      string     `json:"payload"                 db:"payload"`
+	Status       string     `json:"status"                  db:"status"`
+	ResponseCode *int       `json:"response_code,omitempty" db:"response_code"`
+	ResponseBody *string    `json:"response_body,omitempty" db:"response_body"`
+	Attempt      int        `json:"attempt"                 db:"attempt"`
+	NextRetryAt  *time.Time `json:"next_retry_at,omitempty" db:"next_retry_at"`
+	DeliveredAt  *time.Time `json:"delivered_at,omitempty"  db:"delivered_at"`
+	CreatedAt    time.Time  `json:"created_at"              db:"created_at"`
+}

--- a/internal/storage/webhook_repository.go
+++ b/internal/storage/webhook_repository.go
@@ -1,0 +1,351 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// WebhookRepository defines persistence operations for webhook management.
+type WebhookRepository interface {
+	List(ctx context.Context, limit, offset int, activeOnly bool) ([]*domain.Webhook, int, error)
+	FindByID(ctx context.Context, id uuid.UUID) (*domain.Webhook, error)
+	FindActiveByEventType(ctx context.Context, eventType string) ([]*domain.Webhook, error)
+	Create(ctx context.Context, wh *domain.Webhook) (*domain.Webhook, error)
+	Update(ctx context.Context, wh *domain.Webhook) (*domain.Webhook, error)
+	Delete(ctx context.Context, id uuid.UUID) error
+	IncrementFailureCount(ctx context.Context, id uuid.UUID) error
+	ResetFailureCount(ctx context.Context, id uuid.UUID) error
+	Disable(ctx context.Context, id uuid.UUID) error
+}
+
+// WebhookDeliveryRepository defines persistence operations for webhook delivery logs.
+type WebhookDeliveryRepository interface {
+	List(ctx context.Context, webhookID uuid.UUID, limit, offset int) ([]*domain.WebhookDelivery, int, error)
+	FindByID(ctx context.Context, id uuid.UUID) (*domain.WebhookDelivery, error)
+	Create(ctx context.Context, d *domain.WebhookDelivery) (*domain.WebhookDelivery, error)
+	UpdateStatus(ctx context.Context, id uuid.UUID, status string, responseCode *int, responseBody *string, deliveredAt *time.Time) error
+	FindPendingRetries(ctx context.Context, before time.Time, limit int) ([]*domain.WebhookDelivery, error)
+}
+
+const webhookColumns = `id, url, secret_hash, event_types, active, failure_count, created_at, updated_at`
+
+func scanWebhook(row pgx.Row) (*domain.Webhook, error) {
+	wh := &domain.Webhook{}
+	err := row.Scan(
+		&wh.ID, &wh.URL, &wh.SecretHash, &wh.EventTypes,
+		&wh.Active, &wh.FailureCount, &wh.CreatedAt, &wh.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return wh, nil
+}
+
+const webhookDeliveryColumns = `id, webhook_id, event_type, payload, status, response_code, response_body, attempt, next_retry_at, delivered_at, created_at`
+
+func scanWebhookDelivery(row pgx.Row) (*domain.WebhookDelivery, error) {
+	d := &domain.WebhookDelivery{}
+	err := row.Scan(
+		&d.ID, &d.WebhookID, &d.EventType, &d.Payload, &d.Status,
+		&d.ResponseCode, &d.ResponseBody, &d.Attempt, &d.NextRetryAt,
+		&d.DeliveredAt, &d.CreatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return d, nil
+}
+
+// PostgresWebhookRepository implements WebhookRepository using PostgreSQL.
+type PostgresWebhookRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresWebhookRepository creates a new PostgreSQL-backed webhook repository.
+func NewPostgresWebhookRepository(pool *pgxpool.Pool) *PostgresWebhookRepository {
+	return &PostgresWebhookRepository{pool: pool}
+}
+
+// List returns a paginated list of webhooks, optionally filtered to active only.
+func (r *PostgresWebhookRepository) List(ctx context.Context, limit, offset int, activeOnly bool) ([]*domain.Webhook, int, error) {
+	whereClause := ""
+	args := []interface{}{}
+
+	if activeOnly {
+		whereClause = "WHERE active = true"
+	}
+
+	countQuery := fmt.Sprintf(`SELECT COUNT(*) FROM webhooks %s`, whereClause)
+	var total int
+	if err := r.pool.QueryRow(ctx, countQuery, args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count webhooks: %w", err)
+	}
+
+	args = append(args, limit, offset)
+	query := fmt.Sprintf(`SELECT %s FROM webhooks %s ORDER BY created_at DESC LIMIT $%d OFFSET $%d`,
+		webhookColumns, whereClause, len(args)-1, len(args))
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list webhooks: %w", err)
+	}
+	defer rows.Close()
+
+	var webhooks []*domain.Webhook
+	for rows.Next() {
+		wh := &domain.Webhook{}
+		if err := rows.Scan(
+			&wh.ID, &wh.URL, &wh.SecretHash, &wh.EventTypes,
+			&wh.Active, &wh.FailureCount, &wh.CreatedAt, &wh.UpdatedAt,
+		); err != nil {
+			return nil, 0, fmt.Errorf("scan webhook: %w", err)
+		}
+		webhooks = append(webhooks, wh)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate webhooks: %w", err)
+	}
+
+	return webhooks, total, nil
+}
+
+// FindByID retrieves a webhook by primary key.
+func (r *PostgresWebhookRepository) FindByID(ctx context.Context, id uuid.UUID) (*domain.Webhook, error) {
+	query := fmt.Sprintf(`SELECT %s FROM webhooks WHERE id = $1`, webhookColumns)
+	wh, err := scanWebhook(r.pool.QueryRow(ctx, query, id))
+	if err != nil {
+		return nil, fmt.Errorf("find webhook %s: %w", id, err)
+	}
+	return wh, nil
+}
+
+// FindActiveByEventType returns all active webhooks subscribed to a given event type.
+func (r *PostgresWebhookRepository) FindActiveByEventType(ctx context.Context, eventType string) ([]*domain.Webhook, error) {
+	query := fmt.Sprintf(`SELECT %s FROM webhooks WHERE active = true AND $1 = ANY(event_types)`, webhookColumns)
+	rows, err := r.pool.Query(ctx, query, eventType)
+	if err != nil {
+		return nil, fmt.Errorf("find webhooks by event type: %w", err)
+	}
+	defer rows.Close()
+
+	var webhooks []*domain.Webhook
+	for rows.Next() {
+		wh := &domain.Webhook{}
+		if err := rows.Scan(
+			&wh.ID, &wh.URL, &wh.SecretHash, &wh.EventTypes,
+			&wh.Active, &wh.FailureCount, &wh.CreatedAt, &wh.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan webhook: %w", err)
+		}
+		webhooks = append(webhooks, wh)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate webhooks: %w", err)
+	}
+
+	return webhooks, nil
+}
+
+// Create inserts a new webhook.
+func (r *PostgresWebhookRepository) Create(ctx context.Context, wh *domain.Webhook) (*domain.Webhook, error) {
+	query := fmt.Sprintf(`
+		INSERT INTO webhooks (id, url, secret_hash, event_types, active, failure_count, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		RETURNING %s`, webhookColumns)
+
+	result, err := scanWebhook(r.pool.QueryRow(ctx, query,
+		wh.ID, wh.URL, wh.SecretHash, wh.EventTypes,
+		wh.Active, wh.FailureCount, wh.CreatedAt, wh.UpdatedAt,
+	))
+	if err != nil {
+		return nil, fmt.Errorf("insert webhook: %w", err)
+	}
+	return result, nil
+}
+
+// Update modifies mutable fields of a webhook (url, event_types, active).
+func (r *PostgresWebhookRepository) Update(ctx context.Context, wh *domain.Webhook) (*domain.Webhook, error) {
+	query := fmt.Sprintf(`
+		UPDATE webhooks SET url = $1, event_types = $2, active = $3, updated_at = $4
+		WHERE id = $5
+		RETURNING %s`, webhookColumns)
+
+	result, err := scanWebhook(r.pool.QueryRow(ctx, query,
+		wh.URL, wh.EventTypes, wh.Active, time.Now().UTC(), wh.ID,
+	))
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, fmt.Errorf("webhook %s: %w", wh.ID, ErrNotFound)
+		}
+		return nil, fmt.Errorf("update webhook: %w", err)
+	}
+	return result, nil
+}
+
+// Delete removes a webhook by ID.
+func (r *PostgresWebhookRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	query := `DELETE FROM webhooks WHERE id = $1`
+	tag, err := r.pool.Exec(ctx, query, id)
+	if err != nil {
+		return fmt.Errorf("delete webhook %s: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("webhook %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
+// IncrementFailureCount increments the failure counter for a webhook.
+func (r *PostgresWebhookRepository) IncrementFailureCount(ctx context.Context, id uuid.UUID) error {
+	query := `UPDATE webhooks SET failure_count = failure_count + 1, updated_at = $1 WHERE id = $2`
+	_, err := r.pool.Exec(ctx, query, time.Now().UTC(), id)
+	if err != nil {
+		return fmt.Errorf("increment webhook failure count: %w", err)
+	}
+	return nil
+}
+
+// ResetFailureCount resets the failure counter for a webhook to zero.
+func (r *PostgresWebhookRepository) ResetFailureCount(ctx context.Context, id uuid.UUID) error {
+	query := `UPDATE webhooks SET failure_count = 0, updated_at = $1 WHERE id = $2`
+	_, err := r.pool.Exec(ctx, query, time.Now().UTC(), id)
+	if err != nil {
+		return fmt.Errorf("reset webhook failure count: %w", err)
+	}
+	return nil
+}
+
+// Disable sets a webhook to inactive.
+func (r *PostgresWebhookRepository) Disable(ctx context.Context, id uuid.UUID) error {
+	query := `UPDATE webhooks SET active = false, updated_at = $1 WHERE id = $2`
+	_, err := r.pool.Exec(ctx, query, time.Now().UTC(), id)
+	if err != nil {
+		return fmt.Errorf("disable webhook: %w", err)
+	}
+	return nil
+}
+
+// PostgresWebhookDeliveryRepository implements WebhookDeliveryRepository using PostgreSQL.
+type PostgresWebhookDeliveryRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresWebhookDeliveryRepository creates a new PostgreSQL-backed webhook delivery repository.
+func NewPostgresWebhookDeliveryRepository(pool *pgxpool.Pool) *PostgresWebhookDeliveryRepository {
+	return &PostgresWebhookDeliveryRepository{pool: pool}
+}
+
+// List returns a paginated list of deliveries for a given webhook.
+func (r *PostgresWebhookDeliveryRepository) List(ctx context.Context, webhookID uuid.UUID, limit, offset int) ([]*domain.WebhookDelivery, int, error) {
+	countQuery := `SELECT COUNT(*) FROM webhook_deliveries WHERE webhook_id = $1`
+	var total int
+	if err := r.pool.QueryRow(ctx, countQuery, webhookID).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count webhook deliveries: %w", err)
+	}
+
+	query := fmt.Sprintf(`SELECT %s FROM webhook_deliveries WHERE webhook_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3`,
+		webhookDeliveryColumns)
+	rows, err := r.pool.Query(ctx, query, webhookID, limit, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list webhook deliveries: %w", err)
+	}
+	defer rows.Close()
+
+	var deliveries []*domain.WebhookDelivery
+	for rows.Next() {
+		d := &domain.WebhookDelivery{}
+		if err := rows.Scan(
+			&d.ID, &d.WebhookID, &d.EventType, &d.Payload, &d.Status,
+			&d.ResponseCode, &d.ResponseBody, &d.Attempt, &d.NextRetryAt,
+			&d.DeliveredAt, &d.CreatedAt,
+		); err != nil {
+			return nil, 0, fmt.Errorf("scan webhook delivery: %w", err)
+		}
+		deliveries = append(deliveries, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate webhook deliveries: %w", err)
+	}
+
+	return deliveries, total, nil
+}
+
+// FindByID retrieves a webhook delivery by primary key.
+func (r *PostgresWebhookDeliveryRepository) FindByID(ctx context.Context, id uuid.UUID) (*domain.WebhookDelivery, error) {
+	query := fmt.Sprintf(`SELECT %s FROM webhook_deliveries WHERE id = $1`, webhookDeliveryColumns)
+	d, err := scanWebhookDelivery(r.pool.QueryRow(ctx, query, id))
+	if err != nil {
+		return nil, fmt.Errorf("find webhook delivery %s: %w", id, err)
+	}
+	return d, nil
+}
+
+// Create inserts a new webhook delivery record.
+func (r *PostgresWebhookDeliveryRepository) Create(ctx context.Context, d *domain.WebhookDelivery) (*domain.WebhookDelivery, error) {
+	query := fmt.Sprintf(`
+		INSERT INTO webhook_deliveries (id, webhook_id, event_type, payload, status, response_code, response_body, attempt, next_retry_at, delivered_at, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		RETURNING %s`, webhookDeliveryColumns)
+
+	result, err := scanWebhookDelivery(r.pool.QueryRow(ctx, query,
+		d.ID, d.WebhookID, d.EventType, d.Payload, d.Status,
+		d.ResponseCode, d.ResponseBody, d.Attempt, d.NextRetryAt,
+		d.DeliveredAt, d.CreatedAt,
+	))
+	if err != nil {
+		return nil, fmt.Errorf("insert webhook delivery: %w", err)
+	}
+	return result, nil
+}
+
+// UpdateStatus updates the status and response details of a delivery.
+func (r *PostgresWebhookDeliveryRepository) UpdateStatus(ctx context.Context, id uuid.UUID, status string, responseCode *int, responseBody *string, deliveredAt *time.Time) error {
+	query := `UPDATE webhook_deliveries SET status = $1, response_code = $2, response_body = $3, delivered_at = $4 WHERE id = $5`
+	_, err := r.pool.Exec(ctx, query, status, responseCode, responseBody, deliveredAt, id)
+	if err != nil {
+		return fmt.Errorf("update webhook delivery status: %w", err)
+	}
+	return nil
+}
+
+// FindPendingRetries returns deliveries with status 'pending' and next_retry_at before the given time.
+func (r *PostgresWebhookDeliveryRepository) FindPendingRetries(ctx context.Context, before time.Time, limit int) ([]*domain.WebhookDelivery, error) {
+	query := fmt.Sprintf(`SELECT %s FROM webhook_deliveries WHERE status = 'pending' AND next_retry_at IS NOT NULL AND next_retry_at <= $1 ORDER BY next_retry_at ASC LIMIT $2`,
+		webhookDeliveryColumns)
+	rows, err := r.pool.Query(ctx, query, before, limit)
+	if err != nil {
+		return nil, fmt.Errorf("find pending retries: %w", err)
+	}
+	defer rows.Close()
+
+	var deliveries []*domain.WebhookDelivery
+	for rows.Next() {
+		d := &domain.WebhookDelivery{}
+		if err := rows.Scan(
+			&d.ID, &d.WebhookID, &d.EventType, &d.Payload, &d.Status,
+			&d.ResponseCode, &d.ResponseBody, &d.Attempt, &d.NextRetryAt,
+			&d.DeliveredAt, &d.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan pending delivery: %w", err)
+		}
+		deliveries = append(deliveries, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate pending deliveries: %w", err)
+	}
+
+	return deliveries, nil
+}

--- a/internal/webhook/dispatcher.go
+++ b/internal/webhook/dispatcher.go
@@ -1,0 +1,229 @@
+// Package webhook provides an async webhook dispatcher that delivers HTTP POST
+// notifications to registered webhook endpoints when audit events fire.
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+const (
+	deliveryTimeout   = 5 * time.Second
+	maxRetries        = 3
+	dispatchBufSize   = 256
+	signatureHeader   = "X-Signature-256"
+	eventTypeHeader   = "X-Webhook-Event"
+	deliveryIDHeader  = "X-Webhook-Delivery"
+)
+
+// retryDelays defines backoff intervals for retry attempts (1s, 5s, 25s).
+var retryDelays = []time.Duration{1 * time.Second, 5 * time.Second, 25 * time.Second}
+
+// Payload is the structure sent as the webhook HTTP body.
+type Payload struct {
+	ID        string            `json:"id"`
+	EventType string            `json:"event_type"`
+	Timestamp time.Time         `json:"timestamp"`
+	Data      map[string]string `json:"data,omitempty"`
+}
+
+// Dispatcher delivers webhook events asynchronously to subscribed endpoints.
+type Dispatcher struct {
+	webhookRepo  storage.WebhookRepository
+	deliveryRepo storage.WebhookDeliveryRepository
+	logger       *zap.Logger
+	httpClient   *http.Client
+	ch           chan dispatchJob
+	done         chan struct{}
+}
+
+type dispatchJob struct {
+	webhook *domain.Webhook
+	payload Payload
+}
+
+// NewDispatcher creates a webhook Dispatcher with background workers.
+func NewDispatcher(
+	webhookRepo storage.WebhookRepository,
+	deliveryRepo storage.WebhookDeliveryRepository,
+	logger *zap.Logger,
+) *Dispatcher {
+	d := &Dispatcher{
+		webhookRepo:  webhookRepo,
+		deliveryRepo: deliveryRepo,
+		logger:       logger,
+		httpClient: &http.Client{
+			Timeout: deliveryTimeout,
+		},
+		ch:   make(chan dispatchJob, dispatchBufSize),
+		done: make(chan struct{}),
+	}
+	go d.worker()
+	return d
+}
+
+// Dispatch enqueues a webhook delivery for all webhooks subscribed to the event type.
+func (d *Dispatcher) Dispatch(ctx context.Context, eventType string, data map[string]string) {
+	webhooks, err := d.webhookRepo.FindActiveByEventType(ctx, eventType)
+	if err != nil {
+		d.logger.Error("find webhooks for dispatch failed", zap.String("event_type", eventType), zap.Error(err))
+		return
+	}
+
+	payload := Payload{
+		ID:        uuid.New().String(),
+		EventType: eventType,
+		Timestamp: time.Now().UTC(),
+		Data:      data,
+	}
+
+	for _, wh := range webhooks {
+		select {
+		case d.ch <- dispatchJob{webhook: wh, payload: payload}:
+		default:
+			d.logger.Warn("webhook dispatch buffer full, dropping",
+				zap.String("webhook_id", wh.ID.String()),
+				zap.String("event_type", eventType),
+			)
+		}
+	}
+}
+
+// DeliverSingle performs a synchronous delivery to a specific webhook. Used for
+// test and manual retry endpoints.
+func (d *Dispatcher) DeliverSingle(ctx context.Context, wh *domain.Webhook, payload Payload) (*domain.WebhookDelivery, error) {
+	return d.deliver(ctx, wh, payload)
+}
+
+// Name returns the closer label for shutdown logging.
+func (d *Dispatcher) Name() string { return "webhook-dispatcher" }
+
+// Close signals the worker to drain and waits for completion.
+func (d *Dispatcher) Close() error {
+	close(d.ch)
+	<-d.done
+	return nil
+}
+
+func (d *Dispatcher) worker() {
+	defer close(d.done)
+	for job := range d.ch {
+		ctx := context.Background()
+		if _, err := d.deliver(ctx, job.webhook, job.payload); err != nil {
+			d.logger.Error("webhook delivery failed",
+				zap.String("webhook_id", job.webhook.ID.String()),
+				zap.Error(err),
+			)
+		}
+	}
+}
+
+func (d *Dispatcher) deliver(ctx context.Context, wh *domain.Webhook, payload Payload) (*domain.WebhookDelivery, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal webhook payload: %w", err)
+	}
+
+	now := time.Now().UTC()
+	delivery := &domain.WebhookDelivery{
+		ID:        uuid.New(),
+		WebhookID: wh.ID,
+		EventType: payload.EventType,
+		Payload:   string(body),
+		Status:    domain.WebhookDeliveryStatusPending,
+		Attempt:   1,
+		CreatedAt: now,
+	}
+
+	delivery, err = d.deliveryRepo.Create(ctx, delivery)
+	if err != nil {
+		return nil, fmt.Errorf("create delivery record: %w", err)
+	}
+
+	responseCode, responseBody, deliverErr := d.doHTTPPost(ctx, wh, body, payload)
+
+	if deliverErr == nil {
+		deliveredAt := time.Now().UTC()
+		delivery.Status = domain.WebhookDeliveryStatusDelivered
+		delivery.ResponseCode = responseCode
+		delivery.ResponseBody = responseBody
+		delivery.DeliveredAt = &deliveredAt
+		_ = d.deliveryRepo.UpdateStatus(ctx, delivery.ID, delivery.Status, responseCode, responseBody, &deliveredAt)
+		_ = d.webhookRepo.ResetFailureCount(ctx, wh.ID)
+		return delivery, nil
+	}
+
+	// Delivery failed — schedule retry if within limits.
+	delivery.ResponseCode = responseCode
+	delivery.ResponseBody = responseBody
+	_ = d.webhookRepo.IncrementFailureCount(ctx, wh.ID)
+
+	if delivery.Attempt < maxRetries {
+		retryAt := time.Now().UTC().Add(retryDelays[delivery.Attempt-1])
+		delivery.NextRetryAt = &retryAt
+		delivery.Status = domain.WebhookDeliveryStatusPending
+	} else {
+		delivery.Status = domain.WebhookDeliveryStatusFailed
+	}
+
+	_ = d.deliveryRepo.UpdateStatus(ctx, delivery.ID, delivery.Status, responseCode, responseBody, nil)
+
+	// Auto-disable webhook after too many consecutive failures.
+	if wh.FailureCount+1 >= domain.MaxWebhookFailures {
+		_ = d.webhookRepo.Disable(ctx, wh.ID)
+		d.logger.Warn("webhook auto-disabled due to excessive failures",
+			zap.String("webhook_id", wh.ID.String()),
+			zap.Int("failure_count", wh.FailureCount+1),
+		)
+	}
+
+	return delivery, deliverErr
+}
+
+func (d *Dispatcher) doHTTPPost(ctx context.Context, wh *domain.Webhook, body []byte, payload Payload) (*int, *string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, wh.URL, bytes.NewReader(body))
+	if err != nil {
+		return nil, nil, fmt.Errorf("create webhook request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(eventTypeHeader, payload.EventType)
+	req.Header.Set(deliveryIDHeader, payload.ID)
+
+	// HMAC-SHA256 signature using the webhook's secret hash as the key.
+	if wh.SecretHash != "" {
+		mac := hmac.New(sha256.New, []byte(wh.SecretHash))
+		mac.Write(body)
+		sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+		req.Header.Set(signatureHeader, sig)
+	}
+
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("webhook HTTP request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+	code := resp.StatusCode
+	respStr := string(respBody)
+
+	if code >= 200 && code < 300 {
+		return &code, &respStr, nil
+	}
+
+	return &code, &respStr, fmt.Errorf("webhook returned status %d", code)
+}

--- a/internal/webhook/dispatcher_test.go
+++ b/internal/webhook/dispatcher_test.go
@@ -1,0 +1,295 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// --- In-memory test repositories ---
+
+type memWebhookRepo struct {
+	webhooks []*domain.Webhook
+}
+
+func (r *memWebhookRepo) List(_ context.Context, limit, offset int, _ bool) ([]*domain.Webhook, int, error) {
+	total := len(r.webhooks)
+	if offset >= total {
+		return nil, total, nil
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+	return r.webhooks[offset:end], total, nil
+}
+
+func (r *memWebhookRepo) FindByID(_ context.Context, id uuid.UUID) (*domain.Webhook, error) {
+	for _, wh := range r.webhooks {
+		if wh.ID == id {
+			return wh, nil
+		}
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+func (r *memWebhookRepo) FindActiveByEventType(_ context.Context, eventType string) ([]*domain.Webhook, error) {
+	var result []*domain.Webhook
+	for _, wh := range r.webhooks {
+		if !wh.Active {
+			continue
+		}
+		for _, et := range wh.EventTypes {
+			if et == eventType {
+				result = append(result, wh)
+				break
+			}
+		}
+	}
+	return result, nil
+}
+
+func (r *memWebhookRepo) Create(_ context.Context, wh *domain.Webhook) (*domain.Webhook, error) {
+	r.webhooks = append(r.webhooks, wh)
+	return wh, nil
+}
+
+func (r *memWebhookRepo) Update(_ context.Context, wh *domain.Webhook) (*domain.Webhook, error) {
+	for i, existing := range r.webhooks {
+		if existing.ID == wh.ID {
+			r.webhooks[i] = wh
+			return wh, nil
+		}
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+func (r *memWebhookRepo) Delete(_ context.Context, id uuid.UUID) error {
+	for i, wh := range r.webhooks {
+		if wh.ID == id {
+			r.webhooks = append(r.webhooks[:i], r.webhooks[i+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("not found")
+}
+
+func (r *memWebhookRepo) IncrementFailureCount(_ context.Context, id uuid.UUID) error {
+	for _, wh := range r.webhooks {
+		if wh.ID == id {
+			wh.FailureCount++
+			return nil
+		}
+	}
+	return nil
+}
+
+func (r *memWebhookRepo) ResetFailureCount(_ context.Context, id uuid.UUID) error {
+	for _, wh := range r.webhooks {
+		if wh.ID == id {
+			wh.FailureCount = 0
+			return nil
+		}
+	}
+	return nil
+}
+
+func (r *memWebhookRepo) Disable(_ context.Context, id uuid.UUID) error {
+	for _, wh := range r.webhooks {
+		if wh.ID == id {
+			wh.Active = false
+			return nil
+		}
+	}
+	return nil
+}
+
+type memDeliveryRepo struct {
+	deliveries []*domain.WebhookDelivery
+}
+
+func (r *memDeliveryRepo) List(_ context.Context, webhookID uuid.UUID, limit, offset int) ([]*domain.WebhookDelivery, int, error) {
+	var filtered []*domain.WebhookDelivery
+	for _, d := range r.deliveries {
+		if d.WebhookID == webhookID {
+			filtered = append(filtered, d)
+		}
+	}
+	total := len(filtered)
+	if offset >= total {
+		return nil, total, nil
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+	return filtered[offset:end], total, nil
+}
+
+func (r *memDeliveryRepo) FindByID(_ context.Context, id uuid.UUID) (*domain.WebhookDelivery, error) {
+	for _, d := range r.deliveries {
+		if d.ID == id {
+			return d, nil
+		}
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+func (r *memDeliveryRepo) Create(_ context.Context, d *domain.WebhookDelivery) (*domain.WebhookDelivery, error) {
+	r.deliveries = append(r.deliveries, d)
+	return d, nil
+}
+
+func (r *memDeliveryRepo) UpdateStatus(_ context.Context, id uuid.UUID, status string, responseCode *int, responseBody *string, deliveredAt *time.Time) error {
+	for _, d := range r.deliveries {
+		if d.ID == id {
+			d.Status = status
+			d.ResponseCode = responseCode
+			d.ResponseBody = responseBody
+			d.DeliveredAt = deliveredAt
+			return nil
+		}
+	}
+	return nil
+}
+
+func (r *memDeliveryRepo) FindPendingRetries(_ context.Context, _ time.Time, _ int) ([]*domain.WebhookDelivery, error) {
+	return nil, nil
+}
+
+// --- Tests ---
+
+func TestDeliverSingle_Success(t *testing.T) {
+	var called atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Add(1)
+
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.NotEmpty(t, r.Header.Get(signatureHeader))
+		assert.Equal(t, "test_event", r.Header.Get(eventTypeHeader))
+		assert.NotEmpty(t, r.Header.Get(deliveryIDHeader))
+
+		var p Payload
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&p))
+		assert.Equal(t, "test_event", p.EventType)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer ts.Close()
+
+	whRepo := &memWebhookRepo{}
+	delRepo := &memDeliveryRepo{}
+	logger := zap.NewNop()
+	d := NewDispatcher(whRepo, delRepo, logger)
+	defer func() { _ = d.Close() }()
+
+	wh := &domain.Webhook{
+		ID:         uuid.New(),
+		URL:        ts.URL,
+		SecretHash: "test-secret",
+		EventTypes: []string{"test_event"},
+		Active:     true,
+	}
+
+	payload := Payload{
+		ID:        uuid.New().String(),
+		EventType: "test_event",
+		Timestamp: time.Now().UTC(),
+		Data:      map[string]string{"key": "value"},
+	}
+
+	delivery, err := d.DeliverSingle(context.Background(), wh, payload)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), called.Load())
+	assert.Equal(t, domain.WebhookDeliveryStatusDelivered, delivery.Status)
+	assert.NotNil(t, delivery.ResponseCode)
+	assert.Equal(t, 200, *delivery.ResponseCode)
+	assert.NotNil(t, delivery.DeliveredAt)
+}
+
+func TestDeliverSingle_ServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	}))
+	defer ts.Close()
+
+	whRepo := &memWebhookRepo{}
+	delRepo := &memDeliveryRepo{}
+	logger := zap.NewNop()
+	d := NewDispatcher(whRepo, delRepo, logger)
+	defer func() { _ = d.Close() }()
+
+	wh := &domain.Webhook{
+		ID:         uuid.New(),
+		URL:        ts.URL,
+		SecretHash: "test-secret",
+		EventTypes: []string{"test_event"},
+		Active:     true,
+	}
+
+	payload := Payload{
+		ID:        uuid.New().String(),
+		EventType: "test_event",
+		Timestamp: time.Now().UTC(),
+	}
+
+	delivery, err := d.DeliverSingle(context.Background(), wh, payload)
+	require.Error(t, err)
+	require.NotNil(t, delivery)
+	assert.Equal(t, 500, *delivery.ResponseCode)
+}
+
+func TestDispatcher_NameAndClose(t *testing.T) {
+	d := NewDispatcher(&memWebhookRepo{}, &memDeliveryRepo{}, zap.NewNop())
+	assert.Equal(t, "webhook-dispatcher", d.Name())
+	require.NoError(t, d.Close())
+}
+
+func TestHMACSignature(t *testing.T) {
+	var receivedSig string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedSig = r.Header.Get(signatureHeader)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer ts.Close()
+
+	whRepo := &memWebhookRepo{}
+	delRepo := &memDeliveryRepo{}
+	d := NewDispatcher(whRepo, delRepo, zap.NewNop())
+	defer func() { _ = d.Close() }()
+
+	wh := &domain.Webhook{
+		ID:         uuid.New(),
+		URL:        ts.URL,
+		SecretHash: "my-signing-key",
+		EventTypes: []string{"test"},
+		Active:     true,
+	}
+
+	payload := Payload{
+		ID:        "test-id",
+		EventType: "test",
+		Timestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	_, err := d.DeliverSingle(context.Background(), wh, payload)
+	require.NoError(t, err)
+	assert.True(t, len(receivedSig) > 7, "signature should be present")
+	assert.Equal(t, "sha256=", receivedSig[:7])
+}

--- a/migrations/000009_create_webhooks_tables.down.sql
+++ b/migrations/000009_create_webhooks_tables.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS webhook_deliveries;
+DROP TABLE IF EXISTS webhooks;

--- a/migrations/000009_create_webhooks_tables.up.sql
+++ b/migrations/000009_create_webhooks_tables.up.sql
@@ -1,0 +1,31 @@
+-- Webhook subscriptions for receiving event notifications.
+CREATE TABLE IF NOT EXISTS webhooks (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    url           TEXT NOT NULL,
+    secret_hash   TEXT NOT NULL,
+    event_types   TEXT[] NOT NULL DEFAULT '{}',
+    active        BOOLEAN NOT NULL DEFAULT true,
+    failure_count INTEGER NOT NULL DEFAULT 0,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_webhooks_active ON webhooks (active) WHERE active = true;
+
+-- Webhook delivery log for tracking delivery attempts.
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    webhook_id    UUID NOT NULL REFERENCES webhooks (id) ON DELETE CASCADE,
+    event_type    TEXT NOT NULL,
+    payload       TEXT NOT NULL,
+    status        TEXT NOT NULL DEFAULT 'pending',
+    response_code INTEGER,
+    response_body TEXT,
+    attempt       INTEGER NOT NULL DEFAULT 1,
+    next_retry_at TIMESTAMPTZ,
+    delivered_at  TIMESTAMPTZ,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_webhook_deliveries_webhook_id ON webhook_deliveries (webhook_id);
+CREATE INDEX idx_webhook_deliveries_status ON webhook_deliveries (status) WHERE status = 'pending';


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-303.

Closes #303

## Changes

Add webhook admin endpoints in `internal/api/` under `/admin/webhooks/` (CRUD, delivery log viewer, manual retry, test webhook endpoint). Wire the webhook service into `cmd/server/main.go` following the existing DI pattern (create after audit service, inject repository, register for graceful shutdown). Integrate with the audit event system so that when audit events fire, matching webhook subscriptions are dispatched. Add integration tests.