### PR TITLE
GH-307: Database migrations, domain models, and storage repositories

### DIFF
--- a/internal/domain/password_policy.go
+++ b/internal/domain/password_policy.go
@@ -1,0 +1,24 @@
+package domain
+
+import "time"
+
+// PasswordPolicy defines tenant-scoped password policy configuration.
+// The ID is either a tenant identifier or "default" for the global policy.
+type PasswordPolicy struct {
+	ID           string
+	MinLength    int
+	MaxLength    int
+	MaxAgeDays   int // 0 = no expiry
+	HistoryCount int // number of previous passwords to check against
+	RequireMFA   bool
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+// PasswordHistoryEntry records a previously used password hash for a user.
+type PasswordHistoryEntry struct {
+	ID           string
+	UserID       string
+	PasswordHash string
+	CreatedAt    time.Time
+}

--- a/internal/domain/sentinel_errors.go
+++ b/internal/domain/sentinel_errors.go
@@ -33,4 +33,10 @@ var (
 	ErrOAuthAccountNotFound      = errors.New("oauth account not found")
 	ErrOAuthStateMismatch        = errors.New("oauth state mismatch")
 	ErrOAuthCodeExchangeFailed   = errors.New("oauth code exchange failed")
+
+	// Password policy errors.
+	ErrPasswordPolicyNotFound  = errors.New("password policy not found")
+	ErrPasswordPolicyViolation = errors.New("password policy violation")
+	ErrPasswordReused          = errors.New("password reused")
+	ErrPasswordExpired         = errors.New("password expired")
 )

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -16,6 +16,8 @@ type User struct {
 	EmailVerifyToken          *string
 	EmailVerifyTokenExpiresAt *time.Time
 	LastLoginAt               *time.Time
+	PasswordChangedAt         *time.Time
+	ForcePasswordChange       bool
 	CreatedAt                 time.Time
 	UpdatedAt                 time.Time
 	DeletedAt                 *time.Time

--- a/internal/storage/admin_user_repository.go
+++ b/internal/storage/admin_user_repository.go
@@ -37,7 +37,7 @@ func NewPostgresAdminUserRepository(pool *pgxpool.Pool) *PostgresAdminUserReposi
 	return &PostgresAdminUserRepository{pool: pool}
 }
 
-const userColumns = `id, email, password_hash, name, roles, locked, locked_at, locked_reason, email_verified, email_verify_token, email_verify_token_expires_at, last_login_at, created_at, updated_at, deleted_at`
+const userColumns = `id, email, password_hash, name, roles, locked, locked_at, locked_reason, email_verified, email_verify_token, email_verify_token_expires_at, last_login_at, password_changed_at, force_password_change, created_at, updated_at, deleted_at`
 
 func scanUser(row pgx.Row) (*domain.User, error) {
 	u := &domain.User{}
@@ -45,7 +45,8 @@ func scanUser(row pgx.Row) (*domain.User, error) {
 		&u.ID, &u.Email, &u.PasswordHash, &u.Name, &u.Roles,
 		&u.Locked, &u.LockedAt, &u.LockedReason,
 		&u.EmailVerified, &u.EmailVerifyToken, &u.EmailVerifyTokenExpiresAt,
-		&u.LastLoginAt, &u.CreatedAt, &u.UpdatedAt, &u.DeletedAt,
+		&u.LastLoginAt, &u.PasswordChangedAt, &u.ForcePasswordChange,
+		&u.CreatedAt, &u.UpdatedAt, &u.DeletedAt,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -91,7 +92,8 @@ func (r *PostgresAdminUserRepository) List(ctx context.Context, limit, offset in
 			&u.ID, &u.Email, &u.PasswordHash, &u.Name, &u.Roles,
 			&u.Locked, &u.LockedAt, &u.LockedReason,
 			&u.EmailVerified, &u.EmailVerifyToken, &u.EmailVerifyTokenExpiresAt,
-			&u.LastLoginAt, &u.CreatedAt, &u.UpdatedAt, &u.DeletedAt,
+			&u.LastLoginAt, &u.PasswordChangedAt, &u.ForcePasswordChange,
+			&u.CreatedAt, &u.UpdatedAt, &u.DeletedAt,
 		); err != nil {
 			return nil, 0, fmt.Errorf("scan user: %w", err)
 		}

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -44,4 +44,13 @@ var (
 
 	// ErrDuplicateOAuthAccount indicates an OAuth account with the same provider and provider user ID already exists.
 	ErrDuplicateOAuthAccount = errors.New("duplicate oauth account")
+
+	// ErrPasswordPolicyViolation indicates the password does not meet the active policy requirements.
+	ErrPasswordPolicyViolation = errors.New("password policy violation")
+
+	// ErrPasswordReused indicates the password matches a previously used password within the history window.
+	ErrPasswordReused = errors.New("password reused")
+
+	// ErrPasswordExpired indicates the user's password has exceeded the maximum age.
+	ErrPasswordExpired = errors.New("password expired")
 )

--- a/internal/storage/password_history_repository.go
+++ b/internal/storage/password_history_repository.go
@@ -1,0 +1,105 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// PasswordHistoryRepository defines persistence operations for password history entries.
+type PasswordHistoryRepository interface {
+	// Append adds a new password hash to the user's history.
+	Append(ctx context.Context, entry *domain.PasswordHistoryEntry) error
+
+	// FindByUserID retrieves the most recent password history entries for a user,
+	// ordered by created_at descending, limited to the given count.
+	FindByUserID(ctx context.Context, userID string, limit int) ([]domain.PasswordHistoryEntry, error)
+
+	// Prune removes old entries beyond the retention count for a user,
+	// keeping only the most recent `keep` entries. Returns the number of pruned rows.
+	Prune(ctx context.Context, userID string, keep int) (int64, error)
+}
+
+// PostgresPasswordHistoryRepository implements PasswordHistoryRepository using PostgreSQL.
+type PostgresPasswordHistoryRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresPasswordHistoryRepository creates a new PostgreSQL-backed password history repository.
+func NewPostgresPasswordHistoryRepository(pool *pgxpool.Pool) *PostgresPasswordHistoryRepository {
+	return &PostgresPasswordHistoryRepository{pool: pool}
+}
+
+// Append inserts a new password history entry.
+func (r *PostgresPasswordHistoryRepository) Append(ctx context.Context, entry *domain.PasswordHistoryEntry) error {
+	now := time.Now().UTC()
+	query := `
+		INSERT INTO password_history (id, user_id, password_hash, created_at)
+		VALUES ($1, $2, $3, $4)`
+
+	_, err := r.pool.Exec(ctx, query, entry.ID, entry.UserID, entry.PasswordHash, now)
+	if err != nil {
+		var pgErr interface{ SQLState() string }
+		if errors.As(err, &pgErr) && pgErr.SQLState() == "23503" {
+			return fmt.Errorf("user %s: %w", entry.UserID, ErrNotFound)
+		}
+		return fmt.Errorf("append password history: %w", err)
+	}
+
+	return nil
+}
+
+// FindByUserID returns the most recent password history entries for a user.
+func (r *PostgresPasswordHistoryRepository) FindByUserID(ctx context.Context, userID string, limit int) ([]domain.PasswordHistoryEntry, error) {
+	query := `
+		SELECT id, user_id, password_hash, created_at
+		FROM password_history
+		WHERE user_id = $1
+		ORDER BY created_at DESC
+		LIMIT $2`
+
+	rows, err := r.pool.Query(ctx, query, userID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("find password history: %w", err)
+	}
+	defer rows.Close()
+
+	var entries []domain.PasswordHistoryEntry
+	for rows.Next() {
+		var e domain.PasswordHistoryEntry
+		if err := rows.Scan(&e.ID, &e.UserID, &e.PasswordHash, &e.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan password history: %w", err)
+		}
+		entries = append(entries, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate password history: %w", err)
+	}
+
+	return entries, nil
+}
+
+// Prune deletes old password history entries for a user, keeping only the most recent `keep` entries.
+func (r *PostgresPasswordHistoryRepository) Prune(ctx context.Context, userID string, keep int) (int64, error) {
+	query := `
+		DELETE FROM password_history
+		WHERE user_id = $1
+		AND id NOT IN (
+			SELECT id FROM password_history
+			WHERE user_id = $1
+			ORDER BY created_at DESC
+			LIMIT $2
+		)`
+
+	tag, err := r.pool.Exec(ctx, query, userID, keep)
+	if err != nil {
+		return 0, fmt.Errorf("prune password history: %w", err)
+	}
+
+	return tag.RowsAffected(), nil
+}

--- a/internal/storage/password_policy_repository.go
+++ b/internal/storage/password_policy_repository.go
@@ -1,0 +1,102 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// PasswordPolicyRepository defines persistence operations for password policies.
+type PasswordPolicyRepository interface {
+	// Upsert creates or updates a password policy by ID. Returns the saved record.
+	Upsert(ctx context.Context, policy *domain.PasswordPolicy) (*domain.PasswordPolicy, error)
+
+	// FindByID retrieves a password policy by ID. Returns ErrNotFound if absent.
+	FindByID(ctx context.Context, id string) (*domain.PasswordPolicy, error)
+
+	// Delete removes a password policy by ID. Returns ErrNotFound if absent.
+	Delete(ctx context.Context, id string) error
+}
+
+// PostgresPasswordPolicyRepository implements PasswordPolicyRepository using PostgreSQL.
+type PostgresPasswordPolicyRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresPasswordPolicyRepository creates a new PostgreSQL-backed password policy repository.
+func NewPostgresPasswordPolicyRepository(pool *pgxpool.Pool) *PostgresPasswordPolicyRepository {
+	return &PostgresPasswordPolicyRepository{pool: pool}
+}
+
+// Upsert creates or updates a password policy. Uses INSERT ... ON CONFLICT to handle both cases.
+func (r *PostgresPasswordPolicyRepository) Upsert(ctx context.Context, policy *domain.PasswordPolicy) (*domain.PasswordPolicy, error) {
+	now := time.Now().UTC()
+	query := `
+		INSERT INTO password_policies (id, min_length, max_length, max_age_days, history_count, require_mfa, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $7)
+		ON CONFLICT (id) DO UPDATE SET
+			min_length    = EXCLUDED.min_length,
+			max_length    = EXCLUDED.max_length,
+			max_age_days  = EXCLUDED.max_age_days,
+			history_count = EXCLUDED.history_count,
+			require_mfa   = EXCLUDED.require_mfa,
+			updated_at    = EXCLUDED.updated_at
+		RETURNING id, min_length, max_length, max_age_days, history_count, require_mfa, created_at, updated_at`
+
+	out := &domain.PasswordPolicy{}
+	err := r.pool.QueryRow(ctx, query,
+		policy.ID, policy.MinLength, policy.MaxLength, policy.MaxAgeDays,
+		policy.HistoryCount, policy.RequireMFA, now,
+	).Scan(
+		&out.ID, &out.MinLength, &out.MaxLength, &out.MaxAgeDays,
+		&out.HistoryCount, &out.RequireMFA, &out.CreatedAt, &out.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("upsert password policy: %w", err)
+	}
+
+	return out, nil
+}
+
+// FindByID retrieves a password policy by its ID.
+func (r *PostgresPasswordPolicyRepository) FindByID(ctx context.Context, id string) (*domain.PasswordPolicy, error) {
+	query := `
+		SELECT id, min_length, max_length, max_age_days, history_count, require_mfa, created_at, updated_at
+		FROM password_policies
+		WHERE id = $1`
+
+	out := &domain.PasswordPolicy{}
+	err := r.pool.QueryRow(ctx, query, id).Scan(
+		&out.ID, &out.MinLength, &out.MaxLength, &out.MaxAgeDays,
+		&out.HistoryCount, &out.RequireMFA, &out.CreatedAt, &out.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("policy %s: %w", id, ErrNotFound)
+		}
+		return nil, fmt.Errorf("find password policy: %w", err)
+	}
+
+	return out, nil
+}
+
+// Delete removes a password policy by ID.
+func (r *PostgresPasswordPolicyRepository) Delete(ctx context.Context, id string) error {
+	query := `DELETE FROM password_policies WHERE id = $1`
+
+	tag, err := r.pool.Exec(ctx, query, id)
+	if err != nil {
+		return fmt.Errorf("delete password policy: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("policy %s: %w", id, ErrNotFound)
+	}
+
+	return nil
+}

--- a/internal/storage/password_repository_integration_test.go
+++ b/internal/storage/password_repository_integration_test.go
@@ -1,0 +1,281 @@
+package storage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+// ────────────────────────────────────────────────────────────────────────────
+// PasswordPolicyRepository tests
+// ────────────────────────────────────────────────────────────────────────────
+
+func TestPostgresPasswordPolicyRepository_Upsert_Create(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresPasswordPolicyRepository(pool)
+	ctx := context.Background()
+
+	policy := &domain.PasswordPolicy{
+		ID:           "default",
+		MinLength:    15,
+		MaxLength:    128,
+		MaxAgeDays:   90,
+		HistoryCount: 5,
+		RequireMFA:   true,
+	}
+
+	created, err := repo.Upsert(ctx, policy)
+	require.NoError(t, err)
+
+	assert.Equal(t, "default", created.ID)
+	assert.Equal(t, 15, created.MinLength)
+	assert.Equal(t, 128, created.MaxLength)
+	assert.Equal(t, 90, created.MaxAgeDays)
+	assert.Equal(t, 5, created.HistoryCount)
+	assert.True(t, created.RequireMFA)
+	assert.False(t, created.CreatedAt.IsZero())
+	assert.False(t, created.UpdatedAt.IsZero())
+}
+
+func TestPostgresPasswordPolicyRepository_Upsert_Update(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresPasswordPolicyRepository(pool)
+	ctx := context.Background()
+
+	policy := &domain.PasswordPolicy{
+		ID:           "tenant-1",
+		MinLength:    15,
+		MaxLength:    128,
+		MaxAgeDays:   0,
+		HistoryCount: 3,
+		RequireMFA:   false,
+	}
+
+	_, err := repo.Upsert(ctx, policy)
+	require.NoError(t, err)
+
+	// Update the same policy.
+	policy.MinLength = 20
+	policy.MaxAgeDays = 60
+	policy.RequireMFA = true
+
+	updated, err := repo.Upsert(ctx, policy)
+	require.NoError(t, err)
+
+	assert.Equal(t, "tenant-1", updated.ID)
+	assert.Equal(t, 20, updated.MinLength)
+	assert.Equal(t, 60, updated.MaxAgeDays)
+	assert.True(t, updated.RequireMFA)
+}
+
+func TestPostgresPasswordPolicyRepository_FindByID(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresPasswordPolicyRepository(pool)
+	ctx := context.Background()
+
+	policy := &domain.PasswordPolicy{
+		ID:           "find-test",
+		MinLength:    10,
+		MaxLength:    64,
+		MaxAgeDays:   30,
+		HistoryCount: 2,
+		RequireMFA:   false,
+	}
+	_, err := repo.Upsert(ctx, policy)
+	require.NoError(t, err)
+
+	found, err := repo.FindByID(ctx, "find-test")
+	require.NoError(t, err)
+	assert.Equal(t, 10, found.MinLength)
+	assert.Equal(t, 64, found.MaxLength)
+	assert.Equal(t, 30, found.MaxAgeDays)
+}
+
+func TestPostgresPasswordPolicyRepository_FindByID_NotFound(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresPasswordPolicyRepository(pool)
+	ctx := context.Background()
+
+	_, err := repo.FindByID(ctx, "nonexistent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresPasswordPolicyRepository_Delete(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresPasswordPolicyRepository(pool)
+	ctx := context.Background()
+
+	policy := &domain.PasswordPolicy{
+		ID:        "delete-test",
+		MinLength: 15,
+		MaxLength: 128,
+	}
+	_, err := repo.Upsert(ctx, policy)
+	require.NoError(t, err)
+
+	err = repo.Delete(ctx, "delete-test")
+	require.NoError(t, err)
+
+	_, err = repo.FindByID(ctx, "delete-test")
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresPasswordPolicyRepository_Delete_NotFound(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresPasswordPolicyRepository(pool)
+	ctx := context.Background()
+
+	err := repo.Delete(ctx, "nonexistent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// PasswordHistoryRepository tests
+// ────────────────────────────────────────────────────────────────────────────
+
+func TestPostgresPasswordHistoryRepository_Append(t *testing.T) {
+	pool := testPool(t)
+	userRepo := storage.NewPostgresUserRepository(pool)
+	repo := storage.NewPostgresPasswordHistoryRepository(pool)
+	ctx := context.Background()
+
+	user := newTestUser()
+	_, err := userRepo.Create(ctx, user)
+	require.NoError(t, err)
+
+	entry := &domain.PasswordHistoryEntry{
+		ID:           uuid.New().String(),
+		UserID:       user.ID,
+		PasswordHash: "$argon2id$v=19$m=19456,t=2,p=1$salt$oldhash1",
+	}
+
+	err = repo.Append(ctx, entry)
+	require.NoError(t, err)
+}
+
+func TestPostgresPasswordHistoryRepository_Append_InvalidUser(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresPasswordHistoryRepository(pool)
+	ctx := context.Background()
+
+	entry := &domain.PasswordHistoryEntry{
+		ID:           uuid.New().String(),
+		UserID:       "nonexistent-user",
+		PasswordHash: "$argon2id$v=19$m=19456,t=2,p=1$salt$hash",
+	}
+
+	err := repo.Append(ctx, entry)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresPasswordHistoryRepository_FindByUserID(t *testing.T) {
+	pool := testPool(t)
+	userRepo := storage.NewPostgresUserRepository(pool)
+	repo := storage.NewPostgresPasswordHistoryRepository(pool)
+	ctx := context.Background()
+
+	user := newTestUser()
+	_, err := userRepo.Create(ctx, user)
+	require.NoError(t, err)
+
+	// Add 3 history entries.
+	for i := 0; i < 3; i++ {
+		entry := &domain.PasswordHistoryEntry{
+			ID:           uuid.New().String(),
+			UserID:       user.ID,
+			PasswordHash: "$argon2id$v=19$m=19456,t=2,p=1$salt$hash" + uuid.New().String(),
+		}
+		err := repo.Append(ctx, entry)
+		require.NoError(t, err)
+	}
+
+	// Retrieve with limit 2.
+	entries, err := repo.FindByUserID(ctx, user.ID, 2)
+	require.NoError(t, err)
+	assert.Len(t, entries, 2)
+
+	// Should be ordered by created_at DESC — most recent first.
+	assert.True(t, !entries[0].CreatedAt.Before(entries[1].CreatedAt))
+}
+
+func TestPostgresPasswordHistoryRepository_FindByUserID_Empty(t *testing.T) {
+	pool := testPool(t)
+	userRepo := storage.NewPostgresUserRepository(pool)
+	repo := storage.NewPostgresPasswordHistoryRepository(pool)
+	ctx := context.Background()
+
+	user := newTestUser()
+	_, err := userRepo.Create(ctx, user)
+	require.NoError(t, err)
+
+	entries, err := repo.FindByUserID(ctx, user.ID, 10)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestPostgresPasswordHistoryRepository_Prune(t *testing.T) {
+	pool := testPool(t)
+	userRepo := storage.NewPostgresUserRepository(pool)
+	repo := storage.NewPostgresPasswordHistoryRepository(pool)
+	ctx := context.Background()
+
+	user := newTestUser()
+	_, err := userRepo.Create(ctx, user)
+	require.NoError(t, err)
+
+	// Add 5 history entries.
+	for i := 0; i < 5; i++ {
+		entry := &domain.PasswordHistoryEntry{
+			ID:           uuid.New().String(),
+			UserID:       user.ID,
+			PasswordHash: "$argon2id$v=19$m=19456,t=2,p=1$salt$hash" + uuid.New().String(),
+		}
+		err := repo.Append(ctx, entry)
+		require.NoError(t, err)
+	}
+
+	// Keep only 2 most recent.
+	pruned, err := repo.Prune(ctx, user.ID, 2)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), pruned)
+
+	// Verify only 2 remain.
+	entries, err := repo.FindByUserID(ctx, user.ID, 10)
+	require.NoError(t, err)
+	assert.Len(t, entries, 2)
+}
+
+func TestPostgresPasswordHistoryRepository_Prune_NothingToRemove(t *testing.T) {
+	pool := testPool(t)
+	userRepo := storage.NewPostgresUserRepository(pool)
+	repo := storage.NewPostgresPasswordHistoryRepository(pool)
+	ctx := context.Background()
+
+	user := newTestUser()
+	_, err := userRepo.Create(ctx, user)
+	require.NoError(t, err)
+
+	// Add 2 entries, prune keeping 5.
+	for i := 0; i < 2; i++ {
+		entry := &domain.PasswordHistoryEntry{
+			ID:           uuid.New().String(),
+			UserID:       user.ID,
+			PasswordHash: "$argon2id$v=19$m=19456,t=2,p=1$salt$hash" + uuid.New().String(),
+		}
+		err := repo.Append(ctx, entry)
+		require.NoError(t, err)
+	}
+
+	pruned, err := repo.Prune(ctx, user.ID, 5)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), pruned)
+}

--- a/internal/storage/repository_integration_test.go
+++ b/internal/storage/repository_integration_test.go
@@ -60,6 +60,8 @@ func createTables(t *testing.T, pool *pgxpool.Pool) {
 			email_verify_token            TEXT,
 			email_verify_token_expires_at TIMESTAMPTZ,
 			last_login_at TIMESTAMPTZ,
+			password_changed_at           TIMESTAMPTZ,
+			force_password_change         BOOLEAN NOT NULL DEFAULT FALSE,
 			created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 			updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 			deleted_at    TIMESTAMPTZ
@@ -118,11 +120,29 @@ func createTables(t *testing.T, pool *pgxpool.Pool) {
 			used_at    TIMESTAMPTZ,
 			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		);
+
+		CREATE TABLE IF NOT EXISTS password_policies (
+			id             TEXT        PRIMARY KEY,
+			min_length     INTEGER     NOT NULL DEFAULT 15,
+			max_length     INTEGER     NOT NULL DEFAULT 128,
+			max_age_days   INTEGER     NOT NULL DEFAULT 0,
+			history_count  INTEGER     NOT NULL DEFAULT 0,
+			require_mfa    BOOLEAN     NOT NULL DEFAULT FALSE,
+			created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
+
+		CREATE TABLE IF NOT EXISTS password_history (
+			id            TEXT        PRIMARY KEY,
+			user_id       TEXT        NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+			password_hash TEXT        NOT NULL,
+			created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
 	`)
 	require.NoError(t, err)
 
 	// Clean tables before each test file run.
-	_, err = pool.Exec(ctx, `TRUNCATE users, refresh_tokens, clients, mfa_secrets, mfa_backup_codes`)
+	_, err = pool.Exec(ctx, `TRUNCATE users, refresh_tokens, clients, mfa_secrets, mfa_backup_codes, password_policies, password_history CASCADE`)
 	require.NoError(t, err)
 }
 

--- a/internal/storage/user_repository.go
+++ b/internal/storage/user_repository.go
@@ -48,21 +48,23 @@ func NewPostgresUserRepository(pool *pgxpool.Pool) *PostgresUserRepository {
 // Create inserts a new user row. Returns ErrDuplicateEmail if the email is already taken.
 func (r *PostgresUserRepository) Create(ctx context.Context, user *domain.User) (*domain.User, error) {
 	query := `
-		INSERT INTO users (id, email, password_hash, name, roles, locked, locked_at, locked_reason, email_verified, email_verify_token, email_verify_token_expires_at, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-		RETURNING id, email, password_hash, name, roles, locked, locked_at, locked_reason, email_verified, email_verify_token, email_verify_token_expires_at, last_login_at, created_at, updated_at, deleted_at`
+		INSERT INTO users (id, email, password_hash, name, roles, locked, locked_at, locked_reason, email_verified, email_verify_token, email_verify_token_expires_at, password_changed_at, force_password_change, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+		RETURNING id, email, password_hash, name, roles, locked, locked_at, locked_reason, email_verified, email_verify_token, email_verify_token_expires_at, last_login_at, password_changed_at, force_password_change, created_at, updated_at, deleted_at`
 
 	out := &domain.User{}
 	err := r.pool.QueryRow(ctx, query,
 		user.ID, user.Email, user.PasswordHash, user.Name, user.Roles,
 		user.Locked, user.LockedAt, user.LockedReason,
 		user.EmailVerified, user.EmailVerifyToken, user.EmailVerifyTokenExpiresAt,
+		user.PasswordChangedAt, user.ForcePasswordChange,
 		user.CreatedAt, user.UpdatedAt,
 	).Scan(
 		&out.ID, &out.Email, &out.PasswordHash, &out.Name, &out.Roles,
 		&out.Locked, &out.LockedAt, &out.LockedReason,
 		&out.EmailVerified, &out.EmailVerifyToken, &out.EmailVerifyTokenExpiresAt,
-		&out.LastLoginAt, &out.CreatedAt, &out.UpdatedAt, &out.DeletedAt,
+		&out.LastLoginAt, &out.PasswordChangedAt, &out.ForcePasswordChange,
+		&out.CreatedAt, &out.UpdatedAt, &out.DeletedAt,
 	)
 	if err != nil {
 		var pgErr *pgconn.PgError
@@ -106,7 +108,8 @@ func (r *PostgresUserRepository) findByColumn(ctx context.Context, column, value
 	query := fmt.Sprintf(`
 		SELECT id, email, password_hash, name, roles, locked, locked_at, locked_reason,
 		       email_verified, email_verify_token, email_verify_token_expires_at,
-		       last_login_at, created_at, updated_at, deleted_at
+		       last_login_at, password_changed_at, force_password_change,
+		       created_at, updated_at, deleted_at
 		FROM users
 		WHERE %s = $1`, column)
 
@@ -115,7 +118,8 @@ func (r *PostgresUserRepository) findByColumn(ctx context.Context, column, value
 		&user.ID, &user.Email, &user.PasswordHash, &user.Name, &user.Roles,
 		&user.Locked, &user.LockedAt, &user.LockedReason,
 		&user.EmailVerified, &user.EmailVerifyToken, &user.EmailVerifyTokenExpiresAt,
-		&user.LastLoginAt, &user.CreatedAt, &user.UpdatedAt, &user.DeletedAt,
+		&user.LastLoginAt, &user.PasswordChangedAt, &user.ForcePasswordChange,
+		&user.CreatedAt, &user.UpdatedAt, &user.DeletedAt,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -153,7 +157,8 @@ func (r *PostgresUserRepository) ConsumeEmailVerifyToken(ctx context.Context, to
 		WHERE email_verify_token = $2 AND deleted_at IS NULL
 		RETURNING id, email, password_hash, name, roles, locked, locked_at, locked_reason,
 		          email_verified, email_verify_token, email_verify_token_expires_at,
-		          last_login_at, created_at, updated_at, deleted_at`
+		          last_login_at, password_changed_at, force_password_change,
+		          created_at, updated_at, deleted_at`
 
 	now := time.Now().UTC()
 	user := &domain.User{}
@@ -161,7 +166,8 @@ func (r *PostgresUserRepository) ConsumeEmailVerifyToken(ctx context.Context, to
 		&user.ID, &user.Email, &user.PasswordHash, &user.Name, &user.Roles,
 		&user.Locked, &user.LockedAt, &user.LockedReason,
 		&user.EmailVerified, &user.EmailVerifyToken, &user.EmailVerifyTokenExpiresAt,
-		&user.LastLoginAt, &user.CreatedAt, &user.UpdatedAt, &user.DeletedAt,
+		&user.LastLoginAt, &user.PasswordChangedAt, &user.ForcePasswordChange,
+		&user.CreatedAt, &user.UpdatedAt, &user.DeletedAt,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/migrations/000009_add_password_policy_tables.down.sql
+++ b/migrations/000009_add_password_policy_tables.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS password_history;
+DROP TABLE IF EXISTS password_policies;
+ALTER TABLE users DROP COLUMN IF EXISTS force_password_change;
+ALTER TABLE users DROP COLUMN IF EXISTS password_changed_at;

--- a/migrations/000009_add_password_policy_tables.up.sql
+++ b/migrations/000009_add_password_policy_tables.up.sql
@@ -1,0 +1,26 @@
+-- Add password lifecycle columns to users table.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS password_changed_at    TIMESTAMPTZ;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS force_password_change  BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Password policies: one row per tenant (or "default" for global).
+CREATE TABLE IF NOT EXISTS password_policies (
+    id             TEXT        PRIMARY KEY,
+    min_length     INTEGER     NOT NULL DEFAULT 15,
+    max_length     INTEGER     NOT NULL DEFAULT 128,
+    max_age_days   INTEGER     NOT NULL DEFAULT 0,
+    history_count  INTEGER     NOT NULL DEFAULT 0,
+    require_mfa    BOOLEAN     NOT NULL DEFAULT FALSE,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Password history: append-only log of previous password hashes per user.
+CREATE TABLE IF NOT EXISTS password_history (
+    id            TEXT        PRIMARY KEY,
+    user_id       TEXT        NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    password_hash TEXT        NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_password_history_user_id ON password_history (user_id);
+CREATE INDEX idx_password_history_user_created ON password_history (user_id, created_at DESC);


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-307.

Closes #307

## Changes

Create the foundational data layer. Add migration `000009` with two tables: `password_policies` (tenant-scoped policy config: min_length, max_length, max_age_days, history_count, require_mfa) and `password_history` (user_id, password_hash, created_at). Add `password_changed_at` and `force_password_change` columns to the `users` table. Define domain structs (`PasswordPolicy`, `PasswordHistoryEntry`) in `internal/domain/`. Implement `PasswordPolicyRepository` and `PasswordHistoryRepository` interfaces in `internal/storage/` with Postgres implementations (CRUD for policies, append/query/prune for history). Add new sentinel errors (`ErrPasswordPolicyViolation`, `ErrPasswordReused`, `ErrPasswordExpired`). Touches: `migrations/`, `internal/domain/`, `internal/storage/`.