### PR TITLE
GH-309: Admin API for password policy management

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -183,6 +183,8 @@ func run(log *zap.Logger, cfg *config.Config) error {
 	adminClientSvc := admin.NewClientService(clientRepo, hasher, log, auditSvc)
 	adminTokenSvc := admin.NewTokenService(tokenSvc, refreshTokenRepo, "auth-service", log, auditSvc)
 	adminAPIKeySvc := admin.NewAPIKeyService(apiKeyRepo, hasher, log, auditSvc)
+	passwordPolicyRepo := storage.NewPostgresPasswordPolicyRepository(pgPool)
+	adminPasswordPolicySvc := admin.NewPasswordPolicyService(passwordPolicyRepo, log, auditSvc)
 
 	// ── Middleware ─────────────────────────────────────────────────────────
 	rateLimiter := middleware.NewRateLimiter(cfg.Rate)
@@ -209,13 +211,14 @@ func run(log *zap.Logger, cfg *config.Config) error {
 	var clientApprovalSvc api.AdminClientApprovalService
 
 	adminServices := &api.AdminServices{
-		Users:          adminUserSvc,
-		Clients:        adminClientSvc,
-		Tokens:         adminTokenSvc,
-		APIKeys:        adminAPIKeySvc,
-		MFA:            mfaSvc,
-		Consent:        consentSvc,
-		ClientApproval: clientApprovalSvc,
+		Users:            adminUserSvc,
+		Clients:          adminClientSvc,
+		Tokens:           adminTokenSvc,
+		APIKeys:          adminAPIKeySvc,
+		MFA:              mfaSvc,
+		Consent:          consentSvc,
+		ClientApproval:   clientApprovalSvc,
+		PasswordPolicies: adminPasswordPolicySvc,
 	}
 
 	adminDeps := &api.AdminDeps{

--- a/internal/admin/password_policy_service.go
+++ b/internal/admin/password_policy_service.go
@@ -1,0 +1,245 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/audit"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+// PasswordPolicyService implements api.AdminPasswordPolicyService.
+type PasswordPolicyService struct {
+	repo   storage.PasswordPolicyRepository
+	logger *zap.Logger
+	audit  audit.EventLogger
+}
+
+// NewPasswordPolicyService creates a new admin password policy service.
+func NewPasswordPolicyService(repo storage.PasswordPolicyRepository, logger *zap.Logger, auditor audit.EventLogger) *PasswordPolicyService {
+	return &PasswordPolicyService{
+		repo:   repo,
+		logger: logger,
+		audit:  auditor,
+	}
+}
+
+// ListPolicies returns a paginated list of password policies.
+func (s *PasswordPolicyService) ListPolicies(ctx context.Context, page, perPage int) (*api.AdminPasswordPolicyList, error) {
+	offset := (page - 1) * perPage
+
+	policies, total, err := s.repo.List(ctx, perPage, offset)
+	if err != nil {
+		s.logger.Error("list password policies failed", zap.Error(err))
+		return nil, fmt.Errorf("list password policies: %w", api.ErrInternalError)
+	}
+
+	result := &api.AdminPasswordPolicyList{
+		Policies: make([]api.AdminPasswordPolicy, 0, len(policies)),
+		Total:    total,
+		Page:     page,
+		PerPage:  perPage,
+	}
+
+	for _, p := range policies {
+		result.Policies = append(result.Policies, domainPolicyToAdmin(p))
+	}
+
+	return result, nil
+}
+
+// GetPolicy retrieves a single password policy by ID.
+func (s *PasswordPolicyService) GetPolicy(ctx context.Context, policyID string) (*api.AdminPasswordPolicy, error) {
+	p, err := s.repo.FindByID(ctx, policyID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("password policy %s: %w", policyID, api.ErrNotFound)
+		}
+		s.logger.Error("get password policy failed", zap.String("policy_id", policyID), zap.Error(err))
+		return nil, fmt.Errorf("get password policy: %w", api.ErrInternalError)
+	}
+
+	admin := domainPolicyToAdmin(p)
+	return &admin, nil
+}
+
+// CreatePolicy creates a new password policy.
+func (s *PasswordPolicyService) CreatePolicy(ctx context.Context, req *api.CreatePasswordPolicyRequest) (*api.AdminPasswordPolicy, error) {
+	now := time.Now().UTC()
+
+	policy := &domain.PasswordPolicy{
+		ID:           uuid.New().String(),
+		Name:         req.Name,
+		MinLength:    15,
+		MaxLength:    128,
+		MaxAgeDays:   0,
+		HistoryCount: 0,
+		RequireMFA:   false,
+		IsDefault:    false,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+
+	if req.MinLength != nil {
+		policy.MinLength = *req.MinLength
+	}
+	if req.MaxLength != nil {
+		policy.MaxLength = *req.MaxLength
+	}
+	if req.MaxAgeDays != nil {
+		policy.MaxAgeDays = *req.MaxAgeDays
+	}
+	if req.HistoryCount != nil {
+		policy.HistoryCount = *req.HistoryCount
+	}
+	if req.RequireMFA != nil {
+		policy.RequireMFA = *req.RequireMFA
+	}
+	if req.IsDefault != nil {
+		policy.IsDefault = *req.IsDefault
+	}
+
+	created, err := s.repo.Create(ctx, policy)
+	if err != nil {
+		if errors.Is(err, storage.ErrDuplicatePolicyName) {
+			return nil, fmt.Errorf("policy name already exists: %w", api.ErrConflict)
+		}
+		s.logger.Error("create password policy failed", zap.Error(err))
+		return nil, fmt.Errorf("create password policy: %w", api.ErrInternalError)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminPolicyCreate,
+		TargetID: created.ID,
+		Metadata: map[string]string{"name": created.Name},
+	})
+
+	admin := domainPolicyToAdmin(created)
+	return &admin, nil
+}
+
+// UpdatePolicy modifies password policy fields.
+func (s *PasswordPolicyService) UpdatePolicy(ctx context.Context, policyID string, req *api.UpdatePasswordPolicyRequest) (*api.AdminPasswordPolicy, error) {
+	existing, err := s.repo.FindByID(ctx, policyID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("password policy %s: %w", policyID, api.ErrNotFound)
+		}
+		s.logger.Error("find password policy for update failed", zap.String("policy_id", policyID), zap.Error(err))
+		return nil, fmt.Errorf("update password policy: %w", api.ErrInternalError)
+	}
+
+	if req.Name != nil {
+		existing.Name = *req.Name
+	}
+	if req.MinLength != nil {
+		existing.MinLength = *req.MinLength
+	}
+	if req.MaxLength != nil {
+		existing.MaxLength = *req.MaxLength
+	}
+	if req.MaxAgeDays != nil {
+		existing.MaxAgeDays = *req.MaxAgeDays
+	}
+	if req.HistoryCount != nil {
+		existing.HistoryCount = *req.HistoryCount
+	}
+	if req.RequireMFA != nil {
+		existing.RequireMFA = *req.RequireMFA
+	}
+	if req.IsDefault != nil {
+		existing.IsDefault = *req.IsDefault
+	}
+
+	updated, err := s.repo.Update(ctx, existing)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("password policy %s: %w", policyID, api.ErrNotFound)
+		}
+		if errors.Is(err, storage.ErrDuplicatePolicyName) {
+			return nil, fmt.Errorf("policy name already exists: %w", api.ErrConflict)
+		}
+		s.logger.Error("update password policy failed", zap.String("policy_id", policyID), zap.Error(err))
+		return nil, fmt.Errorf("update password policy: %w", api.ErrInternalError)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminPolicyUpdate,
+		TargetID: policyID,
+	})
+
+	admin := domainPolicyToAdmin(updated)
+	return &admin, nil
+}
+
+// DeletePolicy performs a soft delete on a password policy.
+func (s *PasswordPolicyService) DeletePolicy(ctx context.Context, policyID string) error {
+	err := s.repo.SoftDelete(ctx, policyID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return fmt.Errorf("password policy %s: %w", policyID, api.ErrNotFound)
+		}
+		if errors.Is(err, storage.ErrAlreadyDeleted) {
+			return fmt.Errorf("password policy %s already deleted: %w", policyID, api.ErrConflict)
+		}
+		s.logger.Error("delete password policy failed", zap.String("policy_id", policyID), zap.Error(err))
+		return fmt.Errorf("delete password policy: %w", api.ErrInternalError)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminPolicyDelete,
+		TargetID: policyID,
+	})
+
+	return nil
+}
+
+// ComplianceReport returns a summary of users violating password policies.
+func (s *PasswordPolicyService) ComplianceReport(ctx context.Context) (*api.ComplianceReport, error) {
+	data, err := s.repo.ComplianceReport(ctx)
+	if err != nil {
+		s.logger.Error("compliance report failed", zap.Error(err))
+		return nil, fmt.Errorf("compliance report: %w", api.ErrInternalError)
+	}
+
+	expiredIDs := data.ExpiredPasswordUserIDs
+	if expiredIDs == nil {
+		expiredIDs = []string{}
+	}
+	forceIDs := data.ForceChangeUserIDs
+	if forceIDs == nil {
+		forceIDs = []string{}
+	}
+
+	return &api.ComplianceReport{
+		ExpiredPasswordCount:   data.ExpiredPasswordCount,
+		ExpiredPasswordUserIDs: expiredIDs,
+		ForceChangeCount:       data.ForceChangeCount,
+		ForceChangeUserIDs:     forceIDs,
+		PolicyViolationCount:   data.PolicyViolationCount,
+	}, nil
+}
+
+// domainPolicyToAdmin converts a domain.PasswordPolicy to an api.AdminPasswordPolicy DTO.
+func domainPolicyToAdmin(p *domain.PasswordPolicy) api.AdminPasswordPolicy {
+	return api.AdminPasswordPolicy{
+		ID:           p.ID,
+		Name:         p.Name,
+		MinLength:    p.MinLength,
+		MaxLength:    p.MaxLength,
+		MaxAgeDays:   p.MaxAgeDays,
+		HistoryCount: p.HistoryCount,
+		RequireMFA:   p.RequireMFA,
+		IsDefault:    p.IsDefault,
+		CreatedAt:    p.CreatedAt,
+		UpdatedAt:    p.UpdatedAt,
+		DeletedAt:    p.DeletedAt,
+	}
+}

--- a/internal/admin/password_policy_service_test.go
+++ b/internal/admin/password_policy_service_test.go
@@ -1,0 +1,350 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/audit"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+// --- Mock PasswordPolicyRepository ---
+
+type mockPasswordPolicyRepo struct {
+	listFn             func(ctx context.Context, limit, offset int) ([]*domain.PasswordPolicy, int, error)
+	findByIDFn         func(ctx context.Context, id string) (*domain.PasswordPolicy, error)
+	createFn           func(ctx context.Context, policy *domain.PasswordPolicy) (*domain.PasswordPolicy, error)
+	updateFn           func(ctx context.Context, policy *domain.PasswordPolicy) (*domain.PasswordPolicy, error)
+	softDeleteFn       func(ctx context.Context, id string) error
+	complianceReportFn func(ctx context.Context) (*storage.ComplianceData, error)
+}
+
+func (m *mockPasswordPolicyRepo) List(ctx context.Context, limit, offset int) ([]*domain.PasswordPolicy, int, error) {
+	if m.listFn != nil {
+		return m.listFn(ctx, limit, offset)
+	}
+	return []*domain.PasswordPolicy{testPolicy()}, 1, nil
+}
+
+func (m *mockPasswordPolicyRepo) FindByID(ctx context.Context, id string) (*domain.PasswordPolicy, error) {
+	if m.findByIDFn != nil {
+		return m.findByIDFn(ctx, id)
+	}
+	p := testPolicy()
+	p.ID = id
+	return p, nil
+}
+
+func (m *mockPasswordPolicyRepo) Create(ctx context.Context, policy *domain.PasswordPolicy) (*domain.PasswordPolicy, error) {
+	if m.createFn != nil {
+		return m.createFn(ctx, policy)
+	}
+	return policy, nil
+}
+
+func (m *mockPasswordPolicyRepo) Update(ctx context.Context, policy *domain.PasswordPolicy) (*domain.PasswordPolicy, error) {
+	if m.updateFn != nil {
+		return m.updateFn(ctx, policy)
+	}
+	return policy, nil
+}
+
+func (m *mockPasswordPolicyRepo) SoftDelete(ctx context.Context, id string) error {
+	if m.softDeleteFn != nil {
+		return m.softDeleteFn(ctx, id)
+	}
+	return nil
+}
+
+func (m *mockPasswordPolicyRepo) ComplianceReport(ctx context.Context) (*storage.ComplianceData, error) {
+	if m.complianceReportFn != nil {
+		return m.complianceReportFn(ctx)
+	}
+	return &storage.ComplianceData{}, nil
+}
+
+// --- Helpers ---
+
+func testPolicy() *domain.PasswordPolicy {
+	now := time.Now()
+	return &domain.PasswordPolicy{
+		ID:           "policy-1",
+		Name:         "default",
+		MinLength:    15,
+		MaxLength:    128,
+		MaxAgeDays:   90,
+		HistoryCount: 5,
+		RequireMFA:   false,
+		IsDefault:    true,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+}
+
+func newTestPolicyService(repo *mockPasswordPolicyRepo) *PasswordPolicyService {
+	return NewPasswordPolicyService(repo, zap.NewNop(), audit.NopLogger{})
+}
+
+// --- ListPolicies ---
+
+func TestPasswordPolicyService_ListPolicies(t *testing.T) {
+	repo := &mockPasswordPolicyRepo{
+		listFn: func(_ context.Context, limit, offset int) ([]*domain.PasswordPolicy, int, error) {
+			assert.Equal(t, 20, limit)
+			assert.Equal(t, 0, offset)
+			return []*domain.PasswordPolicy{testPolicy()}, 1, nil
+		},
+	}
+	svc := newTestPolicyService(repo)
+
+	result, err := svc.ListPolicies(context.Background(), 1, 20)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Total)
+	assert.Len(t, result.Policies, 1)
+	assert.Equal(t, 1, result.Page)
+	assert.Equal(t, 20, result.PerPage)
+}
+
+func TestPasswordPolicyService_ListPolicies_Error(t *testing.T) {
+	repo := &mockPasswordPolicyRepo{
+		listFn: func(_ context.Context, _, _ int) ([]*domain.PasswordPolicy, int, error) {
+			return nil, 0, fmt.Errorf("db error")
+		},
+	}
+	svc := newTestPolicyService(repo)
+
+	_, err := svc.ListPolicies(context.Background(), 1, 20)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrInternalError)
+}
+
+// --- GetPolicy ---
+
+func TestPasswordPolicyService_GetPolicy(t *testing.T) {
+	svc := newTestPolicyService(&mockPasswordPolicyRepo{})
+
+	policy, err := svc.GetPolicy(context.Background(), "policy-42")
+	require.NoError(t, err)
+	assert.Equal(t, "policy-42", policy.ID)
+}
+
+func TestPasswordPolicyService_GetPolicy_NotFound(t *testing.T) {
+	repo := &mockPasswordPolicyRepo{
+		findByIDFn: func(_ context.Context, _ string) (*domain.PasswordPolicy, error) {
+			return nil, storage.ErrNotFound
+		},
+	}
+	svc := newTestPolicyService(repo)
+
+	_, err := svc.GetPolicy(context.Background(), "nonexistent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrNotFound)
+}
+
+// --- CreatePolicy ---
+
+func TestPasswordPolicyService_CreatePolicy(t *testing.T) {
+	svc := newTestPolicyService(&mockPasswordPolicyRepo{})
+
+	minLen := 20
+	req := &api.CreatePasswordPolicyRequest{
+		Name:      "strict",
+		MinLength: &minLen,
+	}
+	policy, err := svc.CreatePolicy(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, "strict", policy.Name)
+	assert.Equal(t, 20, policy.MinLength)
+	assert.Equal(t, 128, policy.MaxLength) // default
+}
+
+func TestPasswordPolicyService_CreatePolicy_Defaults(t *testing.T) {
+	svc := newTestPolicyService(&mockPasswordPolicyRepo{})
+
+	req := &api.CreatePasswordPolicyRequest{Name: "minimal"}
+	policy, err := svc.CreatePolicy(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, 15, policy.MinLength)
+	assert.Equal(t, 128, policy.MaxLength)
+	assert.Equal(t, 0, policy.MaxAgeDays)
+	assert.Equal(t, 0, policy.HistoryCount)
+	assert.False(t, policy.RequireMFA)
+	assert.False(t, policy.IsDefault)
+}
+
+func TestPasswordPolicyService_CreatePolicy_DuplicateName(t *testing.T) {
+	repo := &mockPasswordPolicyRepo{
+		createFn: func(_ context.Context, _ *domain.PasswordPolicy) (*domain.PasswordPolicy, error) {
+			return nil, fmt.Errorf("dup: %w", storage.ErrDuplicatePolicyName)
+		},
+	}
+	svc := newTestPolicyService(repo)
+
+	_, err := svc.CreatePolicy(context.Background(), &api.CreatePasswordPolicyRequest{Name: "dup"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrConflict)
+}
+
+// --- UpdatePolicy ---
+
+func TestPasswordPolicyService_UpdatePolicy(t *testing.T) {
+	svc := newTestPolicyService(&mockPasswordPolicyRepo{})
+
+	name := "updated-name"
+	policy, err := svc.UpdatePolicy(context.Background(), "policy-1", &api.UpdatePasswordPolicyRequest{Name: &name})
+	require.NoError(t, err)
+	assert.Equal(t, "updated-name", policy.Name)
+}
+
+func TestPasswordPolicyService_UpdatePolicy_NotFound(t *testing.T) {
+	repo := &mockPasswordPolicyRepo{
+		findByIDFn: func(_ context.Context, _ string) (*domain.PasswordPolicy, error) {
+			return nil, storage.ErrNotFound
+		},
+	}
+	svc := newTestPolicyService(repo)
+
+	name := "nope"
+	_, err := svc.UpdatePolicy(context.Background(), "nonexistent", &api.UpdatePasswordPolicyRequest{Name: &name})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrNotFound)
+}
+
+func TestPasswordPolicyService_UpdatePolicy_DuplicateName(t *testing.T) {
+	repo := &mockPasswordPolicyRepo{
+		updateFn: func(_ context.Context, _ *domain.PasswordPolicy) (*domain.PasswordPolicy, error) {
+			return nil, fmt.Errorf("dup: %w", storage.ErrDuplicatePolicyName)
+		},
+	}
+	svc := newTestPolicyService(repo)
+
+	name := "existing"
+	_, err := svc.UpdatePolicy(context.Background(), "policy-1", &api.UpdatePasswordPolicyRequest{Name: &name})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrConflict)
+}
+
+// --- DeletePolicy ---
+
+func TestPasswordPolicyService_DeletePolicy(t *testing.T) {
+	svc := newTestPolicyService(&mockPasswordPolicyRepo{})
+
+	err := svc.DeletePolicy(context.Background(), "policy-1")
+	require.NoError(t, err)
+}
+
+func TestPasswordPolicyService_DeletePolicy_NotFound(t *testing.T) {
+	repo := &mockPasswordPolicyRepo{
+		softDeleteFn: func(_ context.Context, _ string) error {
+			return fmt.Errorf("not found: %w", storage.ErrNotFound)
+		},
+	}
+	svc := newTestPolicyService(repo)
+
+	err := svc.DeletePolicy(context.Background(), "nonexistent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrNotFound)
+}
+
+func TestPasswordPolicyService_DeletePolicy_AlreadyDeleted(t *testing.T) {
+	repo := &mockPasswordPolicyRepo{
+		softDeleteFn: func(_ context.Context, _ string) error {
+			return fmt.Errorf("already deleted: %w", storage.ErrAlreadyDeleted)
+		},
+	}
+	svc := newTestPolicyService(repo)
+
+	err := svc.DeletePolicy(context.Background(), "deleted-policy")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrConflict)
+}
+
+// --- ComplianceReport ---
+
+func TestPasswordPolicyService_ComplianceReport(t *testing.T) {
+	repo := &mockPasswordPolicyRepo{
+		complianceReportFn: func(_ context.Context) (*storage.ComplianceData, error) {
+			return &storage.ComplianceData{
+				ExpiredPasswordCount:   2,
+				ExpiredPasswordUserIDs: []string{"user-1", "user-2"},
+				ForceChangeCount:       1,
+				ForceChangeUserIDs:     []string{"user-3"},
+				PolicyViolationCount:   3,
+			}, nil
+		},
+	}
+	svc := newTestPolicyService(repo)
+
+	report, err := svc.ComplianceReport(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, report.ExpiredPasswordCount)
+	assert.Equal(t, []string{"user-1", "user-2"}, report.ExpiredPasswordUserIDs)
+	assert.Equal(t, 1, report.ForceChangeCount)
+	assert.Equal(t, []string{"user-3"}, report.ForceChangeUserIDs)
+	assert.Equal(t, 3, report.PolicyViolationCount)
+}
+
+func TestPasswordPolicyService_ComplianceReport_NilSlices(t *testing.T) {
+	repo := &mockPasswordPolicyRepo{
+		complianceReportFn: func(_ context.Context) (*storage.ComplianceData, error) {
+			return &storage.ComplianceData{}, nil
+		},
+	}
+	svc := newTestPolicyService(repo)
+
+	report, err := svc.ComplianceReport(context.Background())
+	require.NoError(t, err)
+	assert.NotNil(t, report.ExpiredPasswordUserIDs)
+	assert.NotNil(t, report.ForceChangeUserIDs)
+	assert.Empty(t, report.ExpiredPasswordUserIDs)
+	assert.Empty(t, report.ForceChangeUserIDs)
+}
+
+func TestPasswordPolicyService_ComplianceReport_Error(t *testing.T) {
+	repo := &mockPasswordPolicyRepo{
+		complianceReportFn: func(_ context.Context) (*storage.ComplianceData, error) {
+			return nil, fmt.Errorf("db error")
+		},
+	}
+	svc := newTestPolicyService(repo)
+
+	_, err := svc.ComplianceReport(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrInternalError)
+}
+
+// --- domainPolicyToAdmin ---
+
+func TestDomainPolicyToAdmin(t *testing.T) {
+	now := time.Now()
+	p := &domain.PasswordPolicy{
+		ID:           "policy-1",
+		Name:         "strict",
+		MinLength:    20,
+		MaxLength:    256,
+		MaxAgeDays:   90,
+		HistoryCount: 10,
+		RequireMFA:   true,
+		IsDefault:    true,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+
+	admin := domainPolicyToAdmin(p)
+	assert.Equal(t, "policy-1", admin.ID)
+	assert.Equal(t, "strict", admin.Name)
+	assert.Equal(t, 20, admin.MinLength)
+	assert.Equal(t, 256, admin.MaxLength)
+	assert.Equal(t, 90, admin.MaxAgeDays)
+	assert.Equal(t, 10, admin.HistoryCount)
+	assert.True(t, admin.RequireMFA)
+	assert.True(t, admin.IsDefault)
+}

--- a/internal/api/admin_password_policy_handlers.go
+++ b/internal/api/admin_password_policy_handlers.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// AdminPasswordPolicyHandlers groups HTTP handlers for admin password policy endpoints.
+type AdminPasswordPolicyHandlers struct {
+	policies AdminPasswordPolicyService
+}
+
+// NewAdminPasswordPolicyHandlers creates a new AdminPasswordPolicyHandlers.
+func NewAdminPasswordPolicyHandlers(policies AdminPasswordPolicyService) *AdminPasswordPolicyHandlers {
+	return &AdminPasswordPolicyHandlers{policies: policies}
+}
+
+// List handles GET /admin/password-policies.
+func (h *AdminPasswordPolicyHandlers) List(c *gin.Context) {
+	page, perPage := parsePagination(c)
+
+	result, err := h.policies.ListPolicies(c.Request.Context(), page, perPage)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// Get handles GET /admin/password-policies/:id.
+func (h *AdminPasswordPolicyHandlers) Get(c *gin.Context) {
+	policyID := c.Param("id")
+
+	policy, err := h.policies.GetPolicy(c.Request.Context(), policyID)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, policy)
+}
+
+// Create handles POST /admin/password-policies.
+func (h *AdminPasswordPolicyHandlers) Create(c *gin.Context) {
+	var req CreatePasswordPolicyRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid request body")
+		return
+	}
+
+	if err := adminValidator.Struct(req); err != nil {
+		handleValidationError(c, err)
+		return
+	}
+
+	policy, err := h.policies.CreatePolicy(c.Request.Context(), &req)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, policy)
+}
+
+// Update handles PUT /admin/password-policies/:id.
+func (h *AdminPasswordPolicyHandlers) Update(c *gin.Context) {
+	policyID := c.Param("id")
+
+	var req UpdatePasswordPolicyRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid request body")
+		return
+	}
+
+	if err := adminValidator.Struct(req); err != nil {
+		handleValidationError(c, err)
+		return
+	}
+
+	policy, err := h.policies.UpdatePolicy(c.Request.Context(), policyID, &req)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, policy)
+}
+
+// Delete handles DELETE /admin/password-policies/:id.
+func (h *AdminPasswordPolicyHandlers) Delete(c *gin.Context) {
+	policyID := c.Param("id")
+
+	if err := h.policies.DeletePolicy(c.Request.Context(), policyID); err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "password policy deleted"})
+}
+
+// Compliance handles GET /admin/password-policies/compliance.
+func (h *AdminPasswordPolicyHandlers) Compliance(c *gin.Context) {
+	report, err := h.policies.ComplianceReport(c.Request.Context())
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, report)
+}

--- a/internal/api/admin_password_policy_handlers_test.go
+++ b/internal/api/admin_password_policy_handlers_test.go
@@ -1,0 +1,305 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/health"
+)
+
+// --- Mock AdminPasswordPolicyService ---
+
+type mockAdminPasswordPolicyService struct {
+	listPoliciesFn     func(ctx context.Context, page, perPage int) (*api.AdminPasswordPolicyList, error)
+	getPolicyFn        func(ctx context.Context, policyID string) (*api.AdminPasswordPolicy, error)
+	createPolicyFn     func(ctx context.Context, req *api.CreatePasswordPolicyRequest) (*api.AdminPasswordPolicy, error)
+	updatePolicyFn     func(ctx context.Context, policyID string, req *api.UpdatePasswordPolicyRequest) (*api.AdminPasswordPolicy, error)
+	deletePolicyFn     func(ctx context.Context, policyID string) error
+	complianceReportFn func(ctx context.Context) (*api.ComplianceReport, error)
+}
+
+func (m *mockAdminPasswordPolicyService) ListPolicies(ctx context.Context, page, perPage int) (*api.AdminPasswordPolicyList, error) {
+	if m.listPoliciesFn != nil {
+		return m.listPoliciesFn(ctx, page, perPage)
+	}
+	now := time.Now()
+	return &api.AdminPasswordPolicyList{
+		Policies: []api.AdminPasswordPolicy{{ID: "p1", Name: "default", MinLength: 15, MaxLength: 128, CreatedAt: now, UpdatedAt: now}},
+		Total:    1,
+		Page:     page,
+		PerPage:  perPage,
+	}, nil
+}
+
+func (m *mockAdminPasswordPolicyService) GetPolicy(ctx context.Context, policyID string) (*api.AdminPasswordPolicy, error) {
+	if m.getPolicyFn != nil {
+		return m.getPolicyFn(ctx, policyID)
+	}
+	now := time.Now()
+	return &api.AdminPasswordPolicy{ID: policyID, Name: "default", MinLength: 15, MaxLength: 128, CreatedAt: now, UpdatedAt: now}, nil
+}
+
+func (m *mockAdminPasswordPolicyService) CreatePolicy(ctx context.Context, req *api.CreatePasswordPolicyRequest) (*api.AdminPasswordPolicy, error) {
+	if m.createPolicyFn != nil {
+		return m.createPolicyFn(ctx, req)
+	}
+	now := time.Now()
+	minLen := 15
+	if req.MinLength != nil {
+		minLen = *req.MinLength
+	}
+	return &api.AdminPasswordPolicy{ID: "new-policy", Name: req.Name, MinLength: minLen, MaxLength: 128, CreatedAt: now, UpdatedAt: now}, nil
+}
+
+func (m *mockAdminPasswordPolicyService) UpdatePolicy(ctx context.Context, policyID string, req *api.UpdatePasswordPolicyRequest) (*api.AdminPasswordPolicy, error) {
+	if m.updatePolicyFn != nil {
+		return m.updatePolicyFn(ctx, policyID, req)
+	}
+	now := time.Now()
+	name := "default"
+	if req.Name != nil {
+		name = *req.Name
+	}
+	return &api.AdminPasswordPolicy{ID: policyID, Name: name, MinLength: 15, MaxLength: 128, CreatedAt: now, UpdatedAt: now}, nil
+}
+
+func (m *mockAdminPasswordPolicyService) DeletePolicy(ctx context.Context, policyID string) error {
+	if m.deletePolicyFn != nil {
+		return m.deletePolicyFn(ctx, policyID)
+	}
+	return nil
+}
+
+func (m *mockAdminPasswordPolicyService) ComplianceReport(ctx context.Context) (*api.ComplianceReport, error) {
+	if m.complianceReportFn != nil {
+		return m.complianceReportFn(ctx)
+	}
+	return &api.ComplianceReport{
+		ExpiredPasswordCount:   0,
+		ExpiredPasswordUserIDs: []string{},
+		ForceChangeCount:       0,
+		ForceChangeUserIDs:     []string{},
+		PolicyViolationCount:   0,
+	}, nil
+}
+
+// --- Helper ---
+
+func newAdminPasswordPolicyRouter(policySvc api.AdminPasswordPolicyService) *api.AdminServices {
+	return &api.AdminServices{PasswordPolicies: policySvc}
+}
+
+// --- List Policies ---
+
+func TestAdminListPasswordPolicies_Success(t *testing.T) {
+	svc := &api.AdminServices{PasswordPolicies: &mockAdminPasswordPolicyService{}}
+	r := api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+	w := doRequest(r, http.MethodGet, "/admin/password-policies", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminPasswordPolicyList
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.Total)
+	assert.Len(t, resp.Policies, 1)
+}
+
+func TestAdminListPasswordPolicies_ServiceError(t *testing.T) {
+	mock := &mockAdminPasswordPolicyService{
+		listPoliciesFn: func(_ context.Context, _, _ int) (*api.AdminPasswordPolicyList, error) {
+			return nil, fmt.Errorf("db down: %w", api.ErrInternalError)
+		},
+	}
+	svc := &api.AdminServices{PasswordPolicies: mock}
+	r := api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+	w := doRequest(r, http.MethodGet, "/admin/password-policies", nil)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- Get Policy ---
+
+func TestAdminGetPasswordPolicy_Success(t *testing.T) {
+	svc := &api.AdminServices{PasswordPolicies: &mockAdminPasswordPolicyService{}}
+	r := api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+	w := doRequest(r, http.MethodGet, "/admin/password-policies/policy-42", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminPasswordPolicy
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "policy-42", resp.ID)
+}
+
+func TestAdminGetPasswordPolicy_NotFound(t *testing.T) {
+	mock := &mockAdminPasswordPolicyService{
+		getPolicyFn: func(_ context.Context, _ string) (*api.AdminPasswordPolicy, error) {
+			return nil, fmt.Errorf("policy not found: %w", api.ErrNotFound)
+		},
+	}
+	svc := &api.AdminServices{PasswordPolicies: mock}
+	r := api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+	w := doRequest(r, http.MethodGet, "/admin/password-policies/nonexistent", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- Create Policy ---
+
+func TestAdminCreatePasswordPolicy_Success(t *testing.T) {
+	svc := &api.AdminServices{PasswordPolicies: &mockAdminPasswordPolicyService{}}
+	r := api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+	body := map[string]interface{}{
+		"name":       "strict",
+		"min_length": 20,
+	}
+	w := doRequest(r, http.MethodPost, "/admin/password-policies", body)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp api.AdminPasswordPolicy
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "strict", resp.Name)
+	assert.Equal(t, 20, resp.MinLength)
+}
+
+func TestAdminCreatePasswordPolicy_ValidationError(t *testing.T) {
+	svc := &api.AdminServices{PasswordPolicies: &mockAdminPasswordPolicyService{}}
+	r := api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+	// Missing required name field
+	body := map[string]interface{}{"min_length": 20}
+	w := doRequest(r, http.MethodPost, "/admin/password-policies", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestAdminCreatePasswordPolicy_InvalidJSON(t *testing.T) {
+	svc := &api.AdminServices{PasswordPolicies: &mockAdminPasswordPolicyService{}}
+	r := api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+	w := doRequest(r, http.MethodPost, "/admin/password-policies", nil)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminCreatePasswordPolicy_Conflict(t *testing.T) {
+	mock := &mockAdminPasswordPolicyService{
+		createPolicyFn: func(_ context.Context, _ *api.CreatePasswordPolicyRequest) (*api.AdminPasswordPolicy, error) {
+			return nil, fmt.Errorf("name already exists: %w", api.ErrConflict)
+		},
+	}
+	svc := &api.AdminServices{PasswordPolicies: mock}
+	r := api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+	body := map[string]interface{}{"name": "dup"}
+	w := doRequest(r, http.MethodPost, "/admin/password-policies", body)
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+// --- Update Policy ---
+
+func TestAdminUpdatePasswordPolicy_Success(t *testing.T) {
+	svc := &api.AdminServices{PasswordPolicies: &mockAdminPasswordPolicyService{}}
+	r := api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+	body := map[string]interface{}{"name": "updated"}
+	w := doRequest(r, http.MethodPut, "/admin/password-policies/policy-42", body)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminPasswordPolicy
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "updated", resp.Name)
+}
+
+func TestAdminUpdatePasswordPolicy_NotFound(t *testing.T) {
+	mock := &mockAdminPasswordPolicyService{
+		updatePolicyFn: func(_ context.Context, _ string, _ *api.UpdatePasswordPolicyRequest) (*api.AdminPasswordPolicy, error) {
+			return nil, fmt.Errorf("policy not found: %w", api.ErrNotFound)
+		},
+	}
+	svc := &api.AdminServices{PasswordPolicies: mock}
+	r := api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+	body := map[string]interface{}{"name": "nope"}
+	w := doRequest(r, http.MethodPut, "/admin/password-policies/nonexistent", body)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestAdminUpdatePasswordPolicy_InvalidJSON(t *testing.T) {
+	svc := &api.AdminServices{PasswordPolicies: &mockAdminPasswordPolicyService{}}
+	r := api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+	w := doRequest(r, http.MethodPut, "/admin/password-policies/policy-42", nil)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// --- Delete Policy ---
+
+func TestAdminDeletePasswordPolicy_Success(t *testing.T) {
+	svc := &api.AdminServices{PasswordPolicies: &mockAdminPasswordPolicyService{}}
+	r := api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+	w := doRequest(r, http.MethodDelete, "/admin/password-policies/policy-42", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestAdminDeletePasswordPolicy_NotFound(t *testing.T) {
+	mock := &mockAdminPasswordPolicyService{
+		deletePolicyFn: func(_ context.Context, _ string) error {
+			return fmt.Errorf("policy not found: %w", api.ErrNotFound)
+		},
+	}
+	svc := &api.AdminServices{PasswordPolicies: mock}
+	r := api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+	w := doRequest(r, http.MethodDelete, "/admin/password-policies/nonexistent", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- Compliance Report ---
+
+func TestAdminPasswordPolicyCompliance_Success(t *testing.T) {
+	mock := &mockAdminPasswordPolicyService{
+		complianceReportFn: func(_ context.Context) (*api.ComplianceReport, error) {
+			return &api.ComplianceReport{
+				ExpiredPasswordCount:   2,
+				ExpiredPasswordUserIDs: []string{"user-1", "user-2"},
+				ForceChangeCount:       1,
+				ForceChangeUserIDs:     []string{"user-3"},
+				PolicyViolationCount:   3,
+			}, nil
+		},
+	}
+	svc := &api.AdminServices{PasswordPolicies: mock}
+	r := api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+	w := doRequest(r, http.MethodGet, "/admin/password-policies/compliance", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.ComplianceReport
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 2, resp.ExpiredPasswordCount)
+	assert.Equal(t, []string{"user-1", "user-2"}, resp.ExpiredPasswordUserIDs)
+	assert.Equal(t, 1, resp.ForceChangeCount)
+	assert.Equal(t, 3, resp.PolicyViolationCount)
+}
+
+func TestAdminPasswordPolicyCompliance_Error(t *testing.T) {
+	mock := &mockAdminPasswordPolicyService{
+		complianceReportFn: func(_ context.Context) (*api.ComplianceReport, error) {
+			return nil, fmt.Errorf("db error: %w", api.ErrInternalError)
+		},
+	}
+	svc := &api.AdminServices{PasswordPolicies: mock}
+	r := api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+	w := doRequest(r, http.MethodGet, "/admin/password-policies/compliance", nil)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/internal/api/admin_router.go
+++ b/internal/api/admin_router.go
@@ -97,6 +97,20 @@ func NewAdminRouter(svc *AdminServices, deps *AdminDeps) *gin.Engine {
 		}
 	}
 
+	// Password policy management.
+	if svc.PasswordPolicies != nil {
+		policyH := NewAdminPasswordPolicyHandlers(svc.PasswordPolicies)
+		policies := admin.Group("/password-policies")
+		{
+			policies.GET("", policyH.List)
+			policies.GET("/compliance", policyH.Compliance)
+			policies.GET("/:id", policyH.Get)
+			policies.POST("", policyH.Create)
+			policies.PUT("/:id", policyH.Update)
+			policies.DELETE("/:id", policyH.Delete)
+		}
+	}
+
 	// Token introspection.
 	if svc.Tokens != nil {
 		tokenH := NewAdminTokenHandlers(svc.Tokens)

--- a/internal/api/admin_services.go
+++ b/internal/api/admin_services.go
@@ -100,6 +100,38 @@ type IntrospectionResponse struct {
 	ClientType string `json:"client_type,omitempty"`
 }
 
+// AdminPasswordPolicy represents a password policy in admin API responses.
+type AdminPasswordPolicy struct {
+	ID           string     `json:"id"`
+	Name         string     `json:"name"`
+	MinLength    int        `json:"min_length"`
+	MaxLength    int        `json:"max_length"`
+	MaxAgeDays   int        `json:"max_age_days"`
+	HistoryCount int        `json:"history_count"`
+	RequireMFA   bool       `json:"require_mfa"`
+	IsDefault    bool       `json:"is_default"`
+	CreatedAt    time.Time  `json:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at"`
+	DeletedAt    *time.Time `json:"deleted_at,omitempty"`
+}
+
+// AdminPasswordPolicyList is the paginated response for listing password policies.
+type AdminPasswordPolicyList struct {
+	Policies []AdminPasswordPolicy `json:"policies"`
+	Total    int                   `json:"total"`
+	Page     int                   `json:"page"`
+	PerPage  int                   `json:"per_page"`
+}
+
+// ComplianceReport represents the password policy compliance status.
+type ComplianceReport struct {
+	ExpiredPasswordCount   int      `json:"expired_password_count"`
+	ExpiredPasswordUserIDs []string `json:"expired_password_user_ids"`
+	ForceChangeCount       int      `json:"force_change_count"`
+	ForceChangeUserIDs     []string `json:"force_change_user_ids"`
+	PolicyViolationCount   int      `json:"policy_violation_count"`
+}
+
 // --- Admin request types ---
 
 // CreateUserRequest is the request body for creating a user via admin API.
@@ -158,6 +190,28 @@ type UpdateAPIKeyRequest struct {
 	RateLimit *int     `json:"rate_limit" validate:"omitempty,min=0,max=100000"`
 }
 
+// CreatePasswordPolicyRequest is the request body for creating a password policy.
+type CreatePasswordPolicyRequest struct {
+	Name         string `json:"name"          validate:"required,min=1,max=255"`
+	MinLength    *int   `json:"min_length"    validate:"omitempty,min=8,max=128"`
+	MaxLength    *int   `json:"max_length"    validate:"omitempty,min=15,max=1024"`
+	MaxAgeDays   *int   `json:"max_age_days"  validate:"omitempty,min=0,max=3650"`
+	HistoryCount *int   `json:"history_count" validate:"omitempty,min=0,max=100"`
+	RequireMFA   *bool  `json:"require_mfa"`
+	IsDefault    *bool  `json:"is_default"`
+}
+
+// UpdatePasswordPolicyRequest is the request body for updating a password policy.
+type UpdatePasswordPolicyRequest struct {
+	Name         *string `json:"name"          validate:"omitempty,min=1,max=255"`
+	MinLength    *int    `json:"min_length"    validate:"omitempty,min=8,max=128"`
+	MaxLength    *int    `json:"max_length"    validate:"omitempty,min=15,max=1024"`
+	MaxAgeDays   *int    `json:"max_age_days"  validate:"omitempty,min=0,max=3650"`
+	HistoryCount *int    `json:"history_count" validate:"omitempty,min=0,max=100"`
+	RequireMFA   *bool   `json:"require_mfa"`
+	IsDefault    *bool   `json:"is_default"`
+}
+
 // --- Admin service interfaces ---
 
 // AdminUserService defines admin operations for user management.
@@ -196,13 +250,24 @@ type AdminAPIKeyService interface {
 	RotateAPIKey(ctx context.Context, keyID string) (*AdminAPIKeyWithSecret, error)
 }
 
+// AdminPasswordPolicyService defines admin operations for password policy management.
+type AdminPasswordPolicyService interface {
+	ListPolicies(ctx context.Context, page, perPage int) (*AdminPasswordPolicyList, error)
+	GetPolicy(ctx context.Context, policyID string) (*AdminPasswordPolicy, error)
+	CreatePolicy(ctx context.Context, req *CreatePasswordPolicyRequest) (*AdminPasswordPolicy, error)
+	UpdatePolicy(ctx context.Context, policyID string, req *UpdatePasswordPolicyRequest) (*AdminPasswordPolicy, error)
+	DeletePolicy(ctx context.Context, policyID string) error
+	ComplianceReport(ctx context.Context) (*ComplianceReport, error)
+}
+
 // AdminServices aggregates all admin service interfaces required by admin API handlers.
 type AdminServices struct {
-	Users          AdminUserService
-	Clients        AdminClientService
-	Tokens         AdminTokenService
-	APIKeys        AdminAPIKeyService
-	MFA            MFAService
-	Consent        ConsentService
-	ClientApproval AdminClientApprovalService
+	Users            AdminUserService
+	Clients          AdminClientService
+	Tokens           AdminTokenService
+	APIKeys          AdminAPIKeyService
+	MFA              MFAService
+	Consent          ConsentService
+	ClientApproval   AdminClientApprovalService
+	PasswordPolicies AdminPasswordPolicyService
 }

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -36,6 +36,10 @@ const (
 	EventAdminAPIKeyUpdate  = "admin_apikey_update"
 	EventAdminAPIKeyRevoke  = "admin_apikey_revoke"
 	EventAdminAPIKeyRotate  = "admin_apikey_rotate"
+
+	EventAdminPolicyCreate = "admin_password_policy_create"
+	EventAdminPolicyUpdate = "admin_password_policy_update"
+	EventAdminPolicyDelete = "admin_password_policy_delete"
 )
 
 // Event represents a single audit log entry.

--- a/internal/domain/password_policy.go
+++ b/internal/domain/password_policy.go
@@ -1,0 +1,18 @@
+package domain
+
+import "time"
+
+// PasswordPolicy defines configurable password requirements for a tenant or global scope.
+type PasswordPolicy struct {
+	ID                  string
+	Name                string
+	MinLength           int
+	MaxLength           int
+	MaxAgeDays          int
+	HistoryCount        int
+	RequireMFA          bool
+	IsDefault           bool
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+	DeletedAt           *time.Time
+}

--- a/internal/storage/password_policy_repository.go
+++ b/internal/storage/password_policy_repository.go
@@ -1,0 +1,247 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// PasswordPolicyRepository defines persistence operations for password policies.
+type PasswordPolicyRepository interface {
+	List(ctx context.Context, limit, offset int) ([]*domain.PasswordPolicy, int, error)
+	FindByID(ctx context.Context, id string) (*domain.PasswordPolicy, error)
+	Create(ctx context.Context, policy *domain.PasswordPolicy) (*domain.PasswordPolicy, error)
+	Update(ctx context.Context, policy *domain.PasswordPolicy) (*domain.PasswordPolicy, error)
+	SoftDelete(ctx context.Context, id string) error
+	// ComplianceReport returns users with expired passwords, users flagged for
+	// forced password change, and a count of policy violations.
+	ComplianceReport(ctx context.Context) (*ComplianceData, error)
+}
+
+// ComplianceData holds the raw data for the compliance report.
+type ComplianceData struct {
+	ExpiredPasswordCount    int
+	ForceChangeCount        int
+	PolicyViolationCount    int
+	ExpiredPasswordUserIDs  []string
+	ForceChangeUserIDs      []string
+}
+
+// ErrDuplicatePolicyName indicates a policy with the given name already exists.
+var ErrDuplicatePolicyName = errors.New("duplicate policy name")
+
+// PostgresPasswordPolicyRepository implements PasswordPolicyRepository using PostgreSQL.
+type PostgresPasswordPolicyRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresPasswordPolicyRepository creates a new PostgreSQL-backed password policy repository.
+func NewPostgresPasswordPolicyRepository(pool *pgxpool.Pool) *PostgresPasswordPolicyRepository {
+	return &PostgresPasswordPolicyRepository{pool: pool}
+}
+
+const policyColumns = `id, name, min_length, max_length, max_age_days, history_count, require_mfa, is_default, created_at, updated_at, deleted_at`
+
+func scanPolicy(row pgx.Row) (*domain.PasswordPolicy, error) {
+	p := &domain.PasswordPolicy{}
+	err := row.Scan(
+		&p.ID, &p.Name, &p.MinLength, &p.MaxLength, &p.MaxAgeDays,
+		&p.HistoryCount, &p.RequireMFA, &p.IsDefault,
+		&p.CreatedAt, &p.UpdatedAt, &p.DeletedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return p, nil
+}
+
+// List returns a paginated list of non-deleted password policies.
+func (r *PostgresPasswordPolicyRepository) List(ctx context.Context, limit, offset int) ([]*domain.PasswordPolicy, int, error) {
+	var total int
+	if err := r.pool.QueryRow(ctx, `SELECT COUNT(*) FROM password_policies WHERE deleted_at IS NULL`).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count password policies: %w", err)
+	}
+
+	query := fmt.Sprintf(`SELECT %s FROM password_policies WHERE deleted_at IS NULL ORDER BY created_at DESC LIMIT $1 OFFSET $2`, policyColumns)
+	rows, err := r.pool.Query(ctx, query, limit, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list password policies: %w", err)
+	}
+	defer rows.Close()
+
+	var policies []*domain.PasswordPolicy
+	for rows.Next() {
+		p := &domain.PasswordPolicy{}
+		if err := rows.Scan(
+			&p.ID, &p.Name, &p.MinLength, &p.MaxLength, &p.MaxAgeDays,
+			&p.HistoryCount, &p.RequireMFA, &p.IsDefault,
+			&p.CreatedAt, &p.UpdatedAt, &p.DeletedAt,
+		); err != nil {
+			return nil, 0, fmt.Errorf("scan password policy: %w", err)
+		}
+		policies = append(policies, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate password policies: %w", err)
+	}
+
+	return policies, total, nil
+}
+
+// FindByID retrieves a password policy by ID.
+func (r *PostgresPasswordPolicyRepository) FindByID(ctx context.Context, id string) (*domain.PasswordPolicy, error) {
+	query := fmt.Sprintf(`SELECT %s FROM password_policies WHERE id = $1 AND deleted_at IS NULL`, policyColumns)
+	p, err := scanPolicy(r.pool.QueryRow(ctx, query, id))
+	if err != nil {
+		return nil, fmt.Errorf("find password policy %s: %w", id, err)
+	}
+	return p, nil
+}
+
+// Create inserts a new password policy.
+func (r *PostgresPasswordPolicyRepository) Create(ctx context.Context, policy *domain.PasswordPolicy) (*domain.PasswordPolicy, error) {
+	query := fmt.Sprintf(`
+		INSERT INTO password_policies (id, name, min_length, max_length, max_age_days, history_count, require_mfa, is_default, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		RETURNING %s`, policyColumns)
+
+	p, err := scanPolicy(r.pool.QueryRow(ctx, query,
+		policy.ID, policy.Name, policy.MinLength, policy.MaxLength,
+		policy.MaxAgeDays, policy.HistoryCount, policy.RequireMFA, policy.IsDefault,
+		policy.CreatedAt, policy.UpdatedAt,
+	))
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return nil, fmt.Errorf("policy name %s: %w", policy.Name, ErrDuplicatePolicyName)
+		}
+		return nil, fmt.Errorf("insert password policy: %w", err)
+	}
+	return p, nil
+}
+
+// Update modifies mutable fields of a password policy.
+func (r *PostgresPasswordPolicyRepository) Update(ctx context.Context, policy *domain.PasswordPolicy) (*domain.PasswordPolicy, error) {
+	query := fmt.Sprintf(`
+		UPDATE password_policies
+		SET name = $1, min_length = $2, max_length = $3, max_age_days = $4,
+		    history_count = $5, require_mfa = $6, is_default = $7, updated_at = $8
+		WHERE id = $9 AND deleted_at IS NULL
+		RETURNING %s`, policyColumns)
+
+	p, err := scanPolicy(r.pool.QueryRow(ctx, query,
+		policy.Name, policy.MinLength, policy.MaxLength, policy.MaxAgeDays,
+		policy.HistoryCount, policy.RequireMFA, policy.IsDefault, time.Now().UTC(),
+		policy.ID,
+	))
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return nil, fmt.Errorf("policy name %s: %w", policy.Name, ErrDuplicatePolicyName)
+		}
+		if errors.Is(err, ErrNotFound) {
+			return nil, fmt.Errorf("password policy %s: %w", policy.ID, ErrNotFound)
+		}
+		return nil, fmt.Errorf("update password policy: %w", err)
+	}
+	return p, nil
+}
+
+// SoftDelete sets deleted_at on the password policy record.
+func (r *PostgresPasswordPolicyRepository) SoftDelete(ctx context.Context, id string) error {
+	now := time.Now().UTC()
+	query := `UPDATE password_policies SET deleted_at = $1, updated_at = $1 WHERE id = $2 AND deleted_at IS NULL`
+
+	tag, err := r.pool.Exec(ctx, query, now, id)
+	if err != nil {
+		return fmt.Errorf("soft delete password policy %s: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		var exists bool
+		_ = r.pool.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM password_policies WHERE id = $1)`, id).Scan(&exists)
+		if exists {
+			return fmt.Errorf("password policy %s already deleted: %w", id, ErrAlreadyDeleted)
+		}
+		return fmt.Errorf("password policy %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
+// ComplianceReport queries users table for password compliance data.
+// It checks: users with expired passwords (based on default policy max_age_days),
+// users flagged for forced password change, and total violation count.
+func (r *PostgresPasswordPolicyRepository) ComplianceReport(ctx context.Context) (*ComplianceData, error) {
+	data := &ComplianceData{}
+
+	// Get default policy max_age_days (0 means no expiry).
+	var maxAgeDays int
+	err := r.pool.QueryRow(ctx,
+		`SELECT COALESCE((SELECT max_age_days FROM password_policies WHERE is_default = true AND deleted_at IS NULL LIMIT 1), 0)`,
+	).Scan(&maxAgeDays)
+	if err != nil {
+		return nil, fmt.Errorf("get default policy: %w", err)
+	}
+
+	// Users with expired passwords (only if max_age_days > 0).
+	if maxAgeDays > 0 {
+		expiredRows, err := r.pool.Query(ctx,
+			`SELECT id FROM users
+			 WHERE deleted_at IS NULL
+			   AND password_changed_at IS NOT NULL
+			   AND password_changed_at < now() - ($1 || ' days')::interval`,
+			fmt.Sprintf("%d", maxAgeDays),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("query expired passwords: %w", err)
+		}
+		defer expiredRows.Close()
+
+		for expiredRows.Next() {
+			var uid string
+			if err := expiredRows.Scan(&uid); err != nil {
+				return nil, fmt.Errorf("scan expired user: %w", err)
+			}
+			data.ExpiredPasswordUserIDs = append(data.ExpiredPasswordUserIDs, uid)
+		}
+		if err := expiredRows.Err(); err != nil {
+			return nil, fmt.Errorf("iterate expired users: %w", err)
+		}
+		data.ExpiredPasswordCount = len(data.ExpiredPasswordUserIDs)
+	}
+
+	// Users flagged for forced password change.
+	forceRows, err := r.pool.Query(ctx,
+		`SELECT id FROM users WHERE deleted_at IS NULL AND force_password_change = true`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query force change users: %w", err)
+	}
+	defer forceRows.Close()
+
+	for forceRows.Next() {
+		var uid string
+		if err := forceRows.Scan(&uid); err != nil {
+			return nil, fmt.Errorf("scan force change user: %w", err)
+		}
+		data.ForceChangeUserIDs = append(data.ForceChangeUserIDs, uid)
+	}
+	if err := forceRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate force change users: %w", err)
+	}
+	data.ForceChangeCount = len(data.ForceChangeUserIDs)
+
+	// Total violations = expired + forced.
+	data.PolicyViolationCount = data.ExpiredPasswordCount + data.ForceChangeCount
+
+	return data, nil
+}

--- a/migrations/000009_create_password_policies_table.down.sql
+++ b/migrations/000009_create_password_policies_table.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE users DROP COLUMN IF EXISTS force_password_change;
+ALTER TABLE users DROP COLUMN IF EXISTS password_changed_at;
+
+DROP TABLE IF EXISTS password_policies;

--- a/migrations/000009_create_password_policies_table.up.sql
+++ b/migrations/000009_create_password_policies_table.up.sql
@@ -1,0 +1,22 @@
+CREATE TABLE password_policies (
+    id            TEXT        PRIMARY KEY,
+    name          TEXT        NOT NULL,
+    min_length    INT         NOT NULL DEFAULT 15,
+    max_length    INT         NOT NULL DEFAULT 128,
+    max_age_days  INT         NOT NULL DEFAULT 0,
+    history_count INT         NOT NULL DEFAULT 0,
+    require_mfa   BOOLEAN     NOT NULL DEFAULT FALSE,
+    is_default    BOOLEAN     NOT NULL DEFAULT FALSE,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at    TIMESTAMPTZ,
+
+    CONSTRAINT password_policies_name_unique UNIQUE (name)
+);
+
+CREATE INDEX idx_password_policies_is_default ON password_policies (is_default) WHERE deleted_at IS NULL;
+CREATE INDEX idx_password_policies_deleted_at ON password_policies (deleted_at) WHERE deleted_at IS NOT NULL;
+
+-- Add password tracking columns to users table for compliance reporting.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS password_changed_at TIMESTAMPTZ;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS force_password_change BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-309.

Closes #309

## Changes

Build CRUD endpoints for managing password policies. Add `PasswordPolicyService` in `internal/admin/` with methods: `GetPolicy`, `CreatePolicy`, `UpdatePolicy`, `DeletePolicy`, `ListPolicies`. Add `AdminPasswordPolicyHandlers` in `internal/api/` with handlers mapped to `GET/POST/PUT/DELETE /admin/password-policies`. Register routes in the admin router. Include an admin compliance endpoint (`GET /admin/password-policies/compliance`) that reports users with expired passwords, users flagged for forced change, and policy violation counts. Touches: `internal/admin/`, `internal/api/`.