### PR TITLE
GH-315: Database migrations and domain types

### DIFF
--- a/internal/domain/gdpr.go
+++ b/internal/domain/gdpr.go
@@ -1,0 +1,102 @@
+package domain
+
+import "time"
+
+// ConsentType represents the kind of consent being tracked.
+type ConsentType string
+
+const (
+	ConsentTypeTermsOfService ConsentType = "terms_of_service"
+	ConsentTypePrivacyPolicy  ConsentType = "privacy_policy"
+	ConsentTypeMarketing      ConsentType = "marketing"
+	ConsentTypeAnalytics      ConsentType = "analytics"
+	ConsentTypeDataProcessing ConsentType = "data_processing"
+)
+
+// validConsentTypes is the authoritative set of recognised consent types.
+var validConsentTypes = map[ConsentType]bool{
+	ConsentTypeTermsOfService: true,
+	ConsentTypePrivacyPolicy:  true,
+	ConsentTypeMarketing:      true,
+	ConsentTypeAnalytics:      true,
+	ConsentTypeDataProcessing: true,
+}
+
+// IsValid returns true if the ConsentType is a recognised value.
+func (ct ConsentType) IsValid() bool {
+	return validConsentTypes[ct]
+}
+
+// String returns the string representation of the ConsentType.
+func (ct ConsentType) String() string {
+	return string(ct)
+}
+
+// DeletionStatus represents the lifecycle state of a GDPR deletion request.
+type DeletionStatus string
+
+const (
+	DeletionStatusPending   DeletionStatus = "pending"
+	DeletionStatusCompleted DeletionStatus = "completed"
+	DeletionStatusCancelled DeletionStatus = "cancelled"
+)
+
+// validDeletionStatuses is the authoritative set of recognised deletion statuses.
+var validDeletionStatuses = map[DeletionStatus]bool{
+	DeletionStatusPending:   true,
+	DeletionStatusCompleted: true,
+	DeletionStatusCancelled: true,
+}
+
+// IsValid returns true if the DeletionStatus is a recognised value.
+func (ds DeletionStatus) IsValid() bool {
+	return validDeletionStatuses[ds]
+}
+
+// String returns the string representation of the DeletionStatus.
+func (ds DeletionStatus) String() string {
+	return string(ds)
+}
+
+// ConsentRecord tracks a user's consent grant or revocation for a specific type.
+type ConsentRecord struct {
+	ID          string      `json:"id"`
+	UserID      string      `json:"user_id"`
+	ConsentType ConsentType `json:"consent_type"`
+	Granted     bool        `json:"granted"`
+	GrantedAt   *time.Time  `json:"granted_at,omitempty"`
+	RevokedAt   *time.Time  `json:"revoked_at,omitempty"`
+	IPAddress   string      `json:"ip_address,omitempty"`
+	UserAgent   string      `json:"user_agent,omitempty"`
+	CreatedAt   time.Time   `json:"created_at"`
+	UpdatedAt   time.Time   `json:"updated_at"`
+}
+
+// IsGranted returns true if the consent is currently active (granted and not revoked).
+func (cr *ConsentRecord) IsGranted() bool {
+	return cr.Granted && cr.RevokedAt == nil
+}
+
+// DeletionRequest represents a GDPR right-to-erasure request with grace-period workflow.
+type DeletionRequest struct {
+	ID           string         `json:"id"`
+	UserID       string         `json:"user_id"`
+	Status       DeletionStatus `json:"status"`
+	Reason       string         `json:"reason,omitempty"`
+	RequestedAt  time.Time      `json:"requested_at"`
+	ScheduledAt  time.Time      `json:"scheduled_at"`
+	CompletedAt  *time.Time     `json:"completed_at,omitempty"`
+	CancelledAt  *time.Time     `json:"cancelled_at,omitempty"`
+	CreatedAt    time.Time      `json:"created_at"`
+	UpdatedAt    time.Time      `json:"updated_at"`
+}
+
+// IsPending returns true if the deletion request is still pending execution.
+func (dr *DeletionRequest) IsPending() bool {
+	return dr.Status == DeletionStatusPending
+}
+
+// IsCancellable returns true if the deletion request can still be cancelled.
+func (dr *DeletionRequest) IsCancellable() bool {
+	return dr.Status == DeletionStatusPending && time.Now().Before(dr.ScheduledAt)
+}

--- a/internal/domain/gdpr_test.go
+++ b/internal/domain/gdpr_test.go
@@ -1,0 +1,127 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConsentType_IsValid(t *testing.T) {
+	tests := []struct {
+		name  string
+		ct    ConsentType
+		valid bool
+	}{
+		{"terms_of_service", ConsentTypeTermsOfService, true},
+		{"privacy_policy", ConsentTypePrivacyPolicy, true},
+		{"marketing", ConsentTypeMarketing, true},
+		{"analytics", ConsentTypeAnalytics, true},
+		{"data_processing", ConsentTypeDataProcessing, true},
+		{"empty", ConsentType(""), false},
+		{"unknown", ConsentType("unknown"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.valid, tt.ct.IsValid())
+		})
+	}
+}
+
+func TestConsentType_String(t *testing.T) {
+	assert.Equal(t, "marketing", ConsentTypeMarketing.String())
+}
+
+func TestDeletionStatus_IsValid(t *testing.T) {
+	tests := []struct {
+		name  string
+		ds    DeletionStatus
+		valid bool
+	}{
+		{"pending", DeletionStatusPending, true},
+		{"completed", DeletionStatusCompleted, true},
+		{"cancelled", DeletionStatusCancelled, true},
+		{"empty", DeletionStatus(""), false},
+		{"unknown", DeletionStatus("rejected"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.valid, tt.ds.IsValid())
+		})
+	}
+}
+
+func TestDeletionStatus_String(t *testing.T) {
+	assert.Equal(t, "pending", DeletionStatusPending.String())
+}
+
+func TestConsentRecord_IsGranted(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name    string
+		record  ConsentRecord
+		granted bool
+	}{
+		{
+			name:    "granted and not revoked",
+			record:  ConsentRecord{Granted: true, GrantedAt: &now},
+			granted: true,
+		},
+		{
+			name:    "granted but revoked",
+			record:  ConsentRecord{Granted: true, GrantedAt: &now, RevokedAt: &now},
+			granted: false,
+		},
+		{
+			name:    "not granted",
+			record:  ConsentRecord{Granted: false},
+			granted: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.granted, tt.record.IsGranted())
+		})
+	}
+}
+
+func TestDeletionRequest_IsPending(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  DeletionStatus
+		pending bool
+	}{
+		{"pending", DeletionStatusPending, true},
+		{"completed", DeletionStatusCompleted, false},
+		{"cancelled", DeletionStatusCancelled, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dr := DeletionRequest{Status: tt.status}
+			assert.Equal(t, tt.pending, dr.IsPending())
+		})
+	}
+}
+
+func TestDeletionRequest_IsCancellable(t *testing.T) {
+	future := time.Now().Add(24 * time.Hour)
+	past := time.Now().Add(-24 * time.Hour)
+
+	tests := []struct {
+		name        string
+		status      DeletionStatus
+		scheduledAt time.Time
+		cancellable bool
+	}{
+		{"pending and future scheduled", DeletionStatusPending, future, true},
+		{"pending but past scheduled", DeletionStatusPending, past, false},
+		{"completed", DeletionStatusCompleted, future, false},
+		{"cancelled", DeletionStatusCancelled, future, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dr := DeletionRequest{Status: tt.status, ScheduledAt: tt.scheduledAt}
+			assert.Equal(t, tt.cancellable, dr.IsCancellable())
+		})
+	}
+}

--- a/internal/domain/sentinel_errors.go
+++ b/internal/domain/sentinel_errors.go
@@ -33,4 +33,11 @@ var (
 	ErrOAuthAccountNotFound      = errors.New("oauth account not found")
 	ErrOAuthStateMismatch        = errors.New("oauth state mismatch")
 	ErrOAuthCodeExchangeFailed   = errors.New("oauth code exchange failed")
+
+	// GDPR / consent errors.
+	ErrConsentNotFound            = errors.New("consent record not found")
+	ErrConsentAlreadyGranted      = errors.New("consent already granted")
+	ErrDeletionRequestNotFound    = errors.New("deletion request not found")
+	ErrDeletionRequestExists      = errors.New("deletion request already exists")
+	ErrDeletionRequestNotCancellable = errors.New("deletion request cannot be cancelled")
 )

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -16,6 +16,7 @@ type User struct {
 	EmailVerifyToken          *string
 	EmailVerifyTokenExpiresAt *time.Time
 	LastLoginAt               *time.Time
+	DeletionRequestedAt       *time.Time
 	CreatedAt                 time.Time
 	UpdatedAt                 time.Time
 	DeletedAt                 *time.Time

--- a/migrations/000009_create_gdpr_tables.down.sql
+++ b/migrations/000009_create_gdpr_tables.down.sql
@@ -1,0 +1,10 @@
+-- 000009_create_gdpr_tables.down.sql
+-- Removes GDPR tables and user-level deletion_requested_at column.
+
+DROP TABLE IF EXISTS gdpr_deletion_requests;
+DROP TABLE IF EXISTS consent_records;
+
+DROP INDEX IF EXISTS idx_users_deletion_requested_at;
+
+ALTER TABLE users
+    DROP COLUMN IF EXISTS deletion_requested_at;

--- a/migrations/000009_create_gdpr_tables.up.sql
+++ b/migrations/000009_create_gdpr_tables.up.sql
@@ -1,0 +1,47 @@
+-- 000009_create_gdpr_tables.up.sql
+-- Adds GDPR consent tracking, deletion requests, and user-level deletion timestamp.
+
+-- Add deletion_requested_at to users table for grace-period tracking.
+ALTER TABLE users
+    ADD COLUMN deletion_requested_at TIMESTAMPTZ;
+
+CREATE INDEX idx_users_deletion_requested_at ON users (deletion_requested_at)
+    WHERE deletion_requested_at IS NOT NULL;
+
+-- Consent records track per-user, per-type consent grants and revocations.
+CREATE TABLE consent_records (
+    id          TEXT        PRIMARY KEY,
+    user_id     TEXT        NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    consent_type TEXT       NOT NULL,
+    granted     BOOLEAN     NOT NULL DEFAULT FALSE,
+    granted_at  TIMESTAMPTZ,
+    revoked_at  TIMESTAMPTZ,
+    ip_address  TEXT        NOT NULL DEFAULT '',
+    user_agent  TEXT        NOT NULL DEFAULT '',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_consent_records_user_id ON consent_records (user_id);
+CREATE INDEX idx_consent_records_user_type ON consent_records (user_id, consent_type);
+
+-- GDPR deletion requests with grace-period workflow.
+CREATE TABLE gdpr_deletion_requests (
+    id              TEXT        PRIMARY KEY,
+    user_id         TEXT        NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    status          TEXT        NOT NULL DEFAULT 'pending',
+    reason          TEXT        NOT NULL DEFAULT '',
+    requested_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    scheduled_at    TIMESTAMPTZ NOT NULL,
+    completed_at    TIMESTAMPTZ,
+    cancelled_at    TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT gdpr_deletion_requests_user_id_unique UNIQUE (user_id)
+);
+
+CREATE INDEX idx_gdpr_deletion_requests_status ON gdpr_deletion_requests (status)
+    WHERE status = 'pending';
+CREATE INDEX idx_gdpr_deletion_requests_scheduled ON gdpr_deletion_requests (scheduled_at)
+    WHERE status = 'pending';


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-315.

Closes #315

## Changes

Create migration `000009` with new tables (`consent_records` for consent tracking, `gdpr_deletion_requests` for grace-period deletion tracking) and any necessary column additions to the `users` table (e.g., `deletion_requested_at`). Add GDPR-related domain types to `internal/domain/` — `ConsentRecord`, `DeletionRequest`, and associated constants/enums for consent types and deletion status. This is the data foundation all other subtasks build on. Touches: `migrations/` (new files only), `internal/domain/` (new file + minor edits to existing).