### PR TITLE
GH-316: Storage repositories and GDPR service package

### DIFF
--- a/internal/domain/gdpr.go
+++ b/internal/domain/gdpr.go
@@ -1,0 +1,81 @@
+package domain
+
+import "time"
+
+// ConsentType represents the type of GDPR consent.
+const (
+	ConsentTypeDataProcessing = "data_processing"
+	ConsentTypeMarketing      = "marketing"
+	ConsentTypeAnalytics      = "analytics"
+	ConsentTypeThirdParty     = "third_party"
+)
+
+// DeletionStatus represents the state of a GDPR deletion request.
+const (
+	DeletionStatusPending   = "pending"
+	DeletionStatusApproved  = "approved"
+	DeletionStatusCompleted = "completed"
+	DeletionStatusCancelled = "cancelled"
+)
+
+// DeletionGracePeriodDays is the number of days before a deletion request is executed.
+const DeletionGracePeriodDays = 30
+
+// ConsentRecord tracks a user's GDPR consent grant or revocation.
+type ConsentRecord struct {
+	ID          string
+	UserID      string
+	ConsentType string
+	Granted     bool
+	IPAddress   string
+	UserAgent   string
+	GrantedAt   *time.Time
+	RevokedAt   *time.Time
+	CreatedAt   time.Time
+}
+
+// DeletionRequest tracks a GDPR account deletion request with grace period.
+type DeletionRequest struct {
+	ID          string
+	UserID      string
+	Status      string
+	Reason      string
+	RequestedAt time.Time
+	ScheduledAt time.Time
+	CompletedAt *time.Time
+	CancelledAt *time.Time
+	CancelledBy *string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// IsPending returns true if the deletion request is still pending.
+func (d *DeletionRequest) IsPending() bool {
+	return d.Status == DeletionStatusPending
+}
+
+// IsCompleted returns true if the deletion request has been executed.
+func (d *DeletionRequest) IsCompleted() bool {
+	return d.Status == DeletionStatusCompleted
+}
+
+// IsCancelled returns true if the deletion request was cancelled.
+func (d *DeletionRequest) IsCancelled() bool {
+	return d.Status == DeletionStatusCancelled
+}
+
+// UserDataExport represents the aggregated data export for a user.
+type UserDataExport struct {
+	User           *User                `json:"user"`
+	OAuthAccounts  []OAuthAccount       `json:"oauth_accounts"`
+	RefreshTokens  []RefreshTokenRecord `json:"refresh_tokens"`
+	ConsentRecords []ConsentRecord      `json:"consent_records"`
+	ExportedAt     time.Time            `json:"exported_at"`
+}
+
+// DataRetentionPolicy defines how long different types of data are retained.
+type DataRetentionPolicy struct {
+	Name          string
+	RetentionDays int
+	Description   string
+}

--- a/internal/domain/sentinel_errors.go
+++ b/internal/domain/sentinel_errors.go
@@ -33,4 +33,11 @@ var (
 	ErrOAuthAccountNotFound      = errors.New("oauth account not found")
 	ErrOAuthStateMismatch        = errors.New("oauth state mismatch")
 	ErrOAuthCodeExchangeFailed   = errors.New("oauth code exchange failed")
+
+	// GDPR errors.
+	ErrConsentNotFound          = errors.New("consent record not found")
+	ErrDeletionRequestNotFound  = errors.New("deletion request not found")
+	ErrDeletionAlreadyRequested = errors.New("deletion already requested")
+	ErrDeletionAlreadyCompleted = errors.New("deletion already completed")
+	ErrDeletionNotCancellable   = errors.New("deletion request not cancellable")
 )

--- a/internal/gdpr/service.go
+++ b/internal/gdpr/service.go
@@ -1,0 +1,299 @@
+package gdpr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+// Service handles GDPR-related business logic: data export, account deletion,
+// consent tracking, and data retention.
+type Service struct {
+	consentRepo  storage.GDPRConsentRepository
+	deletionRepo storage.GDPRDeletionRepository
+	exportRepo   storage.GDPRExportRepository
+	nowFunc      func() time.Time
+}
+
+// NewService creates a new GDPR service.
+func NewService(
+	consentRepo storage.GDPRConsentRepository,
+	deletionRepo storage.GDPRDeletionRepository,
+	exportRepo storage.GDPRExportRepository,
+) *Service {
+	return &Service{
+		consentRepo:  consentRepo,
+		deletionRepo: deletionRepo,
+		exportRepo:   exportRepo,
+		nowFunc:      func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// SetNowFunc overrides the time source (used in tests for deterministic timestamps).
+func (s *Service) SetNowFunc(fn func() time.Time) {
+	s.nowFunc = fn
+}
+
+// --- Consent Tracking ---
+
+// GrantConsent records a user's consent for a specific type.
+func (s *Service) GrantConsent(ctx context.Context, userID, consentType, ipAddress, userAgent string) (*domain.ConsentRecord, error) {
+	now := s.nowFunc()
+	record := &domain.ConsentRecord{
+		ID:          uuid.New().String(),
+		UserID:      userID,
+		ConsentType: consentType,
+		Granted:     true,
+		IPAddress:   ipAddress,
+		UserAgent:   userAgent,
+		GrantedAt:   &now,
+		CreatedAt:   now,
+	}
+
+	created, err := s.consentRepo.Create(ctx, record)
+	if err != nil {
+		return nil, fmt.Errorf("grant consent: %w", err)
+	}
+	return created, nil
+}
+
+// RevokeConsent revokes a previously granted consent by ID.
+func (s *Service) RevokeConsent(ctx context.Context, consentID string) error {
+	now := s.nowFunc()
+	if err := s.consentRepo.Revoke(ctx, consentID, now); err != nil {
+		return fmt.Errorf("revoke consent: %w", err)
+	}
+	return nil
+}
+
+// GetUserConsents returns all consent records for a user.
+func (s *Service) GetUserConsents(ctx context.Context, userID string) ([]domain.ConsentRecord, error) {
+	records, err := s.consentRepo.FindByUserID(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get user consents: %w", err)
+	}
+	return records, nil
+}
+
+// GetConsentByType returns the consent record for a user and consent type.
+func (s *Service) GetConsentByType(ctx context.Context, userID, consentType string) (*domain.ConsentRecord, error) {
+	record, err := s.consentRepo.FindByUserIDAndType(ctx, userID, consentType)
+	if err != nil {
+		return nil, fmt.Errorf("get consent by type: %w", err)
+	}
+	return record, nil
+}
+
+// --- Data Export ---
+
+// ExportUserData collects all user data across tables and serializes it as JSON.
+func (s *Service) ExportUserData(ctx context.Context, userID string) ([]byte, error) {
+	user, err := s.exportRepo.GetUserData(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("export user data: %w", err)
+	}
+
+	// Redact sensitive fields for the export.
+	user.PasswordHash = "[REDACTED]"
+
+	oauthAccounts, err := s.exportRepo.GetOAuthAccounts(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("export oauth accounts: %w", err)
+	}
+
+	refreshTokens, err := s.exportRepo.GetRefreshTokens(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("export refresh tokens: %w", err)
+	}
+
+	consentRecords, err := s.exportRepo.GetConsentRecords(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("export consent records: %w", err)
+	}
+
+	export := &domain.UserDataExport{
+		User:           user,
+		OAuthAccounts:  oauthAccounts,
+		RefreshTokens:  refreshTokens,
+		ConsentRecords: consentRecords,
+		ExportedAt:     s.nowFunc(),
+	}
+
+	data, err := json.MarshalIndent(export, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal user data export: %w", err)
+	}
+	return data, nil
+}
+
+// --- Account Deletion ---
+
+// RequestDeletion initiates a GDPR account deletion request with a 30-day grace period.
+func (s *Service) RequestDeletion(ctx context.Context, userID, reason string) (*domain.DeletionRequest, error) {
+	// Check for existing pending request.
+	existing, err := s.deletionRepo.FindPendingByUserID(ctx, userID)
+	if err == nil && existing != nil {
+		return nil, fmt.Errorf("user %s: %w", userID, domain.ErrDeletionAlreadyRequested)
+	}
+
+	now := s.nowFunc()
+	scheduledAt := now.AddDate(0, 0, domain.DeletionGracePeriodDays)
+
+	req := &domain.DeletionRequest{
+		ID:          uuid.New().String(),
+		UserID:      userID,
+		Status:      domain.DeletionStatusPending,
+		Reason:      reason,
+		RequestedAt: now,
+		ScheduledAt: scheduledAt,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	created, err := s.deletionRepo.Create(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("request deletion: %w", err)
+	}
+	return created, nil
+}
+
+// CancelDeletion cancels a pending deletion request.
+func (s *Service) CancelDeletion(ctx context.Context, requestID, cancelledBy string) error {
+	req, err := s.deletionRepo.FindByID(ctx, requestID)
+	if err != nil {
+		return fmt.Errorf("cancel deletion: %w", err)
+	}
+
+	if req.Status == domain.DeletionStatusCompleted {
+		return domain.ErrDeletionAlreadyCompleted
+	}
+	if req.Status == domain.DeletionStatusCancelled {
+		return domain.ErrDeletionNotCancellable
+	}
+
+	now := s.nowFunc()
+	if err := s.deletionRepo.Cancel(ctx, requestID, cancelledBy, now); err != nil {
+		return fmt.Errorf("cancel deletion: %w", err)
+	}
+	return nil
+}
+
+// GetDeletionRequest returns the most recent deletion request for a user.
+func (s *Service) GetDeletionRequest(ctx context.Context, userID string) (*domain.DeletionRequest, error) {
+	req, err := s.deletionRepo.FindByUserID(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get deletion request: %w", err)
+	}
+	return req, nil
+}
+
+// ExecutePendingDeletions processes all approved deletion requests that are past their grace period.
+// It performs cascading cleanup: revoke tokens, delete sessions, anonymize audit logs,
+// remove OAuth links, delete consent records, and soft-delete the user.
+func (s *Service) ExecutePendingDeletions(ctx context.Context) (int, error) {
+	now := s.nowFunc()
+	requests, err := s.deletionRepo.FindDueForExecution(ctx, now)
+	if err != nil {
+		return 0, fmt.Errorf("find due deletions: %w", err)
+	}
+
+	executed := 0
+	for _, req := range requests {
+		if err := s.executeUserDeletion(ctx, req.UserID); err != nil {
+			return executed, fmt.Errorf("execute deletion for user %s: %w", req.UserID, err)
+		}
+
+		if err := s.deletionRepo.UpdateStatus(ctx, req.ID, domain.DeletionStatusCompleted, now); err != nil {
+			return executed, fmt.Errorf("update deletion status for %s: %w", req.ID, err)
+		}
+		executed++
+	}
+
+	return executed, nil
+}
+
+// ApprovePendingDeletion approves a pending deletion request so it can be executed after the grace period.
+func (s *Service) ApprovePendingDeletion(ctx context.Context, requestID string) error {
+	now := s.nowFunc()
+	if err := s.deletionRepo.UpdateStatus(ctx, requestID, domain.DeletionStatusApproved, now); err != nil {
+		return fmt.Errorf("approve deletion: %w", err)
+	}
+	return nil
+}
+
+// executeUserDeletion performs the cascading cleanup for a single user.
+func (s *Service) executeUserDeletion(ctx context.Context, userID string) error {
+	// 1. Delete refresh tokens (revoke all sessions).
+	if err := s.exportRepo.DeleteRefreshTokens(ctx, userID); err != nil {
+		return fmt.Errorf("delete refresh tokens: %w", err)
+	}
+
+	// 2. Delete OAuth account links.
+	if err := s.exportRepo.DeleteOAuthAccounts(ctx, userID); err != nil {
+		return fmt.Errorf("delete oauth accounts: %w", err)
+	}
+
+	// 3. Delete consent records.
+	if err := s.consentRepo.DeleteByUserID(ctx, userID); err != nil {
+		return fmt.Errorf("delete consent records: %w", err)
+	}
+
+	// 4. Anonymize audit logs (preserve events but remove PII).
+	if err := s.exportRepo.AnonymizeAuditLogs(ctx, userID); err != nil {
+		return fmt.Errorf("anonymize audit logs: %w", err)
+	}
+
+	// 5. Soft-delete the user record (30-day retention before permanent deletion).
+	if err := s.exportRepo.SoftDeleteUser(ctx, userID); err != nil {
+		return fmt.Errorf("soft delete user: %w", err)
+	}
+
+	return nil
+}
+
+// --- Data Retention ---
+
+// RetentionConfig holds configurable data retention policies.
+type RetentionConfig struct {
+	SoftDeletedUserRetentionDays int
+	ExpiredTokenRetentionDays    int
+}
+
+// DefaultRetentionConfig returns the default retention configuration.
+func DefaultRetentionConfig() RetentionConfig {
+	return RetentionConfig{
+		SoftDeletedUserRetentionDays: 90,
+		ExpiredTokenRetentionDays:    30,
+	}
+}
+
+// CleanupExpiredData enforces data retention policies by removing data past its retention period.
+func (s *Service) CleanupExpiredData(ctx context.Context, config RetentionConfig) (*RetentionResult, error) {
+	result := &RetentionResult{}
+
+	usersDeleted, err := s.exportRepo.DeleteExpiredSoftDeletedUsers(ctx, config.SoftDeletedUserRetentionDays)
+	if err != nil {
+		return nil, fmt.Errorf("cleanup expired users: %w", err)
+	}
+	result.UsersDeleted = usersDeleted
+
+	tokensDeleted, err := s.exportRepo.DeleteExpiredRefreshTokens(ctx, config.ExpiredTokenRetentionDays)
+	if err != nil {
+		return nil, fmt.Errorf("cleanup expired tokens: %w", err)
+	}
+	result.TokensDeleted = tokensDeleted
+
+	return result, nil
+}
+
+// RetentionResult holds the results of a data retention cleanup run.
+type RetentionResult struct {
+	UsersDeleted  int64
+	TokensDeleted int64
+}

--- a/internal/gdpr/service_test.go
+++ b/internal/gdpr/service_test.go
@@ -1,0 +1,542 @@
+package gdpr_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/gdpr"
+	"github.com/qf-studio/auth-service/internal/storage"
+	"github.com/qf-studio/auth-service/internal/storage/mocks"
+)
+
+// testNow is a fixed timestamp for deterministic tests.
+var testNow = time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+
+func newTestService(
+	consentRepo *mocks.MockGDPRConsentRepository,
+	deletionRepo *mocks.MockGDPRDeletionRepository,
+	exportRepo *mocks.MockGDPRExportRepository,
+) *gdpr.Service {
+	svc := gdpr.NewService(consentRepo, deletionRepo, exportRepo)
+	svc.SetNowFunc(func() time.Time { return testNow })
+	return svc
+}
+
+// --- Consent Tracking Tests ---
+
+func TestGrantConsent_Success(t *testing.T) {
+	consentRepo := &mocks.MockGDPRConsentRepository{
+		CreateFn: func(_ context.Context, record *domain.ConsentRecord) (*domain.ConsentRecord, error) {
+			assert.Equal(t, "user-1", record.UserID)
+			assert.Equal(t, domain.ConsentTypeMarketing, record.ConsentType)
+			assert.True(t, record.Granted)
+			assert.Equal(t, "192.168.1.1", record.IPAddress)
+			assert.Equal(t, "TestAgent", record.UserAgent)
+			assert.NotEmpty(t, record.ID)
+			return record, nil
+		},
+	}
+
+	svc := newTestService(consentRepo, &mocks.MockGDPRDeletionRepository{}, &mocks.MockGDPRExportRepository{})
+
+	rec, err := svc.GrantConsent(context.Background(), "user-1", domain.ConsentTypeMarketing, "192.168.1.1", "TestAgent")
+	require.NoError(t, err)
+	assert.Equal(t, "user-1", rec.UserID)
+	assert.True(t, rec.Granted)
+}
+
+func TestGrantConsent_DuplicateError(t *testing.T) {
+	consentRepo := &mocks.MockGDPRConsentRepository{
+		CreateFn: func(_ context.Context, _ *domain.ConsentRecord) (*domain.ConsentRecord, error) {
+			return nil, storage.ErrDuplicateConsent
+		},
+	}
+
+	svc := newTestService(consentRepo, &mocks.MockGDPRDeletionRepository{}, &mocks.MockGDPRExportRepository{})
+
+	_, err := svc.GrantConsent(context.Background(), "user-1", domain.ConsentTypeMarketing, "192.168.1.1", "TestAgent")
+	assert.ErrorIs(t, err, storage.ErrDuplicateConsent)
+}
+
+func TestRevokeConsent_Success(t *testing.T) {
+	consentRepo := &mocks.MockGDPRConsentRepository{
+		RevokeFn: func(_ context.Context, id string, revokedAt time.Time) error {
+			assert.Equal(t, "consent-1", id)
+			assert.Equal(t, testNow, revokedAt)
+			return nil
+		},
+	}
+
+	svc := newTestService(consentRepo, &mocks.MockGDPRDeletionRepository{}, &mocks.MockGDPRExportRepository{})
+
+	err := svc.RevokeConsent(context.Background(), "consent-1")
+	require.NoError(t, err)
+}
+
+func TestRevokeConsent_NotFound(t *testing.T) {
+	consentRepo := &mocks.MockGDPRConsentRepository{
+		RevokeFn: func(_ context.Context, _ string, _ time.Time) error {
+			return storage.ErrNotFound
+		},
+	}
+
+	svc := newTestService(consentRepo, &mocks.MockGDPRDeletionRepository{}, &mocks.MockGDPRExportRepository{})
+
+	err := svc.RevokeConsent(context.Background(), "nonexistent")
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestGetUserConsents_Success(t *testing.T) {
+	now := testNow
+	records := []domain.ConsentRecord{
+		{ID: "c1", UserID: "user-1", ConsentType: domain.ConsentTypeMarketing, Granted: true, GrantedAt: &now},
+		{ID: "c2", UserID: "user-1", ConsentType: domain.ConsentTypeAnalytics, Granted: false, RevokedAt: &now},
+	}
+
+	consentRepo := &mocks.MockGDPRConsentRepository{
+		FindByUserIDFn: func(_ context.Context, userID string) ([]domain.ConsentRecord, error) {
+			assert.Equal(t, "user-1", userID)
+			return records, nil
+		},
+	}
+
+	svc := newTestService(consentRepo, &mocks.MockGDPRDeletionRepository{}, &mocks.MockGDPRExportRepository{})
+
+	result, err := svc.GetUserConsents(context.Background(), "user-1")
+	require.NoError(t, err)
+	assert.Len(t, result, 2)
+}
+
+func TestGetUserConsents_Empty(t *testing.T) {
+	consentRepo := &mocks.MockGDPRConsentRepository{
+		FindByUserIDFn: func(_ context.Context, _ string) ([]domain.ConsentRecord, error) {
+			return nil, nil
+		},
+	}
+
+	svc := newTestService(consentRepo, &mocks.MockGDPRDeletionRepository{}, &mocks.MockGDPRExportRepository{})
+
+	result, err := svc.GetUserConsents(context.Background(), "user-1")
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestGetConsentByType_Success(t *testing.T) {
+	now := testNow
+	record := &domain.ConsentRecord{
+		ID: "c1", UserID: "user-1", ConsentType: domain.ConsentTypeMarketing, Granted: true, GrantedAt: &now,
+	}
+
+	consentRepo := &mocks.MockGDPRConsentRepository{
+		FindByUserIDAndTypeFn: func(_ context.Context, userID, consentType string) (*domain.ConsentRecord, error) {
+			assert.Equal(t, "user-1", userID)
+			assert.Equal(t, domain.ConsentTypeMarketing, consentType)
+			return record, nil
+		},
+	}
+
+	svc := newTestService(consentRepo, &mocks.MockGDPRDeletionRepository{}, &mocks.MockGDPRExportRepository{})
+
+	result, err := svc.GetConsentByType(context.Background(), "user-1", domain.ConsentTypeMarketing)
+	require.NoError(t, err)
+	assert.Equal(t, "c1", result.ID)
+}
+
+func TestGetConsentByType_NotFound(t *testing.T) {
+	consentRepo := &mocks.MockGDPRConsentRepository{
+		FindByUserIDAndTypeFn: func(_ context.Context, _ string, _ string) (*domain.ConsentRecord, error) {
+			return nil, storage.ErrNotFound
+		},
+	}
+
+	svc := newTestService(consentRepo, &mocks.MockGDPRDeletionRepository{}, &mocks.MockGDPRExportRepository{})
+
+	_, err := svc.GetConsentByType(context.Background(), "user-1", domain.ConsentTypeMarketing)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+// --- Data Export Tests ---
+
+func TestExportUserData_Success(t *testing.T) {
+	user := &domain.User{
+		ID:           "user-1",
+		Email:        "test@example.com",
+		PasswordHash: "secret-hash",
+		Name:         "Test User",
+		CreatedAt:    testNow,
+		UpdatedAt:    testNow,
+	}
+	oauthAccounts := []domain.OAuthAccount{
+		{ID: "oa1", UserID: "user-1", Provider: "google", ProviderUserID: "g123"},
+	}
+	refreshTokens := []domain.RefreshTokenRecord{
+		{Signature: "sig1", UserID: "user-1", ExpiresAt: testNow.Add(24 * time.Hour)},
+	}
+	consentRecords := []domain.ConsentRecord{
+		{ID: "c1", UserID: "user-1", ConsentType: domain.ConsentTypeMarketing, Granted: true},
+	}
+
+	exportRepo := &mocks.MockGDPRExportRepository{
+		GetUserDataFn: func(_ context.Context, _ string) (*domain.User, error) {
+			return user, nil
+		},
+		GetOAuthAccountsFn: func(_ context.Context, _ string) ([]domain.OAuthAccount, error) {
+			return oauthAccounts, nil
+		},
+		GetRefreshTokensFn: func(_ context.Context, _ string) ([]domain.RefreshTokenRecord, error) {
+			return refreshTokens, nil
+		},
+		GetConsentRecordsFn: func(_ context.Context, _ string) ([]domain.ConsentRecord, error) {
+			return consentRecords, nil
+		},
+	}
+
+	svc := newTestService(&mocks.MockGDPRConsentRepository{}, &mocks.MockGDPRDeletionRepository{}, exportRepo)
+
+	data, err := svc.ExportUserData(context.Background(), "user-1")
+	require.NoError(t, err)
+
+	var export domain.UserDataExport
+	require.NoError(t, json.Unmarshal(data, &export))
+
+	assert.Equal(t, "user-1", export.User.ID)
+	assert.Equal(t, "[REDACTED]", export.User.PasswordHash)
+	assert.Len(t, export.OAuthAccounts, 1)
+	assert.Len(t, export.RefreshTokens, 1)
+	assert.Len(t, export.ConsentRecords, 1)
+	assert.Equal(t, testNow, export.ExportedAt)
+}
+
+func TestExportUserData_UserNotFound(t *testing.T) {
+	exportRepo := &mocks.MockGDPRExportRepository{
+		GetUserDataFn: func(_ context.Context, _ string) (*domain.User, error) {
+			return nil, storage.ErrNotFound
+		},
+	}
+
+	svc := newTestService(&mocks.MockGDPRConsentRepository{}, &mocks.MockGDPRDeletionRepository{}, exportRepo)
+
+	_, err := svc.ExportUserData(context.Background(), "nonexistent")
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestExportUserData_OAuthError(t *testing.T) {
+	exportRepo := &mocks.MockGDPRExportRepository{
+		GetUserDataFn: func(_ context.Context, _ string) (*domain.User, error) {
+			return &domain.User{ID: "user-1"}, nil
+		},
+		GetOAuthAccountsFn: func(_ context.Context, _ string) ([]domain.OAuthAccount, error) {
+			return nil, errors.New("db connection failed")
+		},
+	}
+
+	svc := newTestService(&mocks.MockGDPRConsentRepository{}, &mocks.MockGDPRDeletionRepository{}, exportRepo)
+
+	_, err := svc.ExportUserData(context.Background(), "user-1")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "export oauth accounts")
+}
+
+// --- Account Deletion Tests ---
+
+func TestRequestDeletion_Success(t *testing.T) {
+	deletionRepo := &mocks.MockGDPRDeletionRepository{
+		FindPendingByUserIDFn: func(_ context.Context, _ string) (*domain.DeletionRequest, error) {
+			return nil, storage.ErrNotFound
+		},
+		CreateFn: func(_ context.Context, req *domain.DeletionRequest) (*domain.DeletionRequest, error) {
+			assert.Equal(t, "user-1", req.UserID)
+			assert.Equal(t, domain.DeletionStatusPending, req.Status)
+			assert.Equal(t, "privacy concerns", req.Reason)
+			expectedSchedule := testNow.AddDate(0, 0, domain.DeletionGracePeriodDays)
+			assert.Equal(t, expectedSchedule, req.ScheduledAt)
+			return req, nil
+		},
+	}
+
+	svc := newTestService(&mocks.MockGDPRConsentRepository{}, deletionRepo, &mocks.MockGDPRExportRepository{})
+
+	req, err := svc.RequestDeletion(context.Background(), "user-1", "privacy concerns")
+	require.NoError(t, err)
+	assert.Equal(t, "user-1", req.UserID)
+	assert.Equal(t, domain.DeletionStatusPending, req.Status)
+}
+
+func TestRequestDeletion_AlreadyRequested(t *testing.T) {
+	deletionRepo := &mocks.MockGDPRDeletionRepository{
+		FindPendingByUserIDFn: func(_ context.Context, _ string) (*domain.DeletionRequest, error) {
+			return &domain.DeletionRequest{ID: "existing", Status: domain.DeletionStatusPending}, nil
+		},
+	}
+
+	svc := newTestService(&mocks.MockGDPRConsentRepository{}, deletionRepo, &mocks.MockGDPRExportRepository{})
+
+	_, err := svc.RequestDeletion(context.Background(), "user-1", "privacy concerns")
+	assert.ErrorIs(t, err, domain.ErrDeletionAlreadyRequested)
+}
+
+func TestCancelDeletion_Success(t *testing.T) {
+	deletionRepo := &mocks.MockGDPRDeletionRepository{
+		FindByIDFn: func(_ context.Context, id string) (*domain.DeletionRequest, error) {
+			return &domain.DeletionRequest{ID: id, Status: domain.DeletionStatusPending}, nil
+		},
+		CancelFn: func(_ context.Context, id, cancelledBy string, cancelledAt time.Time) error {
+			assert.Equal(t, "req-1", id)
+			assert.Equal(t, "admin-1", cancelledBy)
+			assert.Equal(t, testNow, cancelledAt)
+			return nil
+		},
+	}
+
+	svc := newTestService(&mocks.MockGDPRConsentRepository{}, deletionRepo, &mocks.MockGDPRExportRepository{})
+
+	err := svc.CancelDeletion(context.Background(), "req-1", "admin-1")
+	require.NoError(t, err)
+}
+
+func TestCancelDeletion_AlreadyCompleted(t *testing.T) {
+	deletionRepo := &mocks.MockGDPRDeletionRepository{
+		FindByIDFn: func(_ context.Context, _ string) (*domain.DeletionRequest, error) {
+			return &domain.DeletionRequest{Status: domain.DeletionStatusCompleted}, nil
+		},
+	}
+
+	svc := newTestService(&mocks.MockGDPRConsentRepository{}, deletionRepo, &mocks.MockGDPRExportRepository{})
+
+	err := svc.CancelDeletion(context.Background(), "req-1", "admin-1")
+	assert.ErrorIs(t, err, domain.ErrDeletionAlreadyCompleted)
+}
+
+func TestCancelDeletion_AlreadyCancelled(t *testing.T) {
+	deletionRepo := &mocks.MockGDPRDeletionRepository{
+		FindByIDFn: func(_ context.Context, _ string) (*domain.DeletionRequest, error) {
+			return &domain.DeletionRequest{Status: domain.DeletionStatusCancelled}, nil
+		},
+	}
+
+	svc := newTestService(&mocks.MockGDPRConsentRepository{}, deletionRepo, &mocks.MockGDPRExportRepository{})
+
+	err := svc.CancelDeletion(context.Background(), "req-1", "admin-1")
+	assert.ErrorIs(t, err, domain.ErrDeletionNotCancellable)
+}
+
+func TestCancelDeletion_NotFound(t *testing.T) {
+	deletionRepo := &mocks.MockGDPRDeletionRepository{
+		FindByIDFn: func(_ context.Context, _ string) (*domain.DeletionRequest, error) {
+			return nil, storage.ErrNotFound
+		},
+	}
+
+	svc := newTestService(&mocks.MockGDPRConsentRepository{}, deletionRepo, &mocks.MockGDPRExportRepository{})
+
+	err := svc.CancelDeletion(context.Background(), "nonexistent", "admin-1")
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestGetDeletionRequest_Success(t *testing.T) {
+	deletionRepo := &mocks.MockGDPRDeletionRepository{
+		FindByUserIDFn: func(_ context.Context, userID string) (*domain.DeletionRequest, error) {
+			return &domain.DeletionRequest{ID: "req-1", UserID: userID, Status: domain.DeletionStatusPending}, nil
+		},
+	}
+
+	svc := newTestService(&mocks.MockGDPRConsentRepository{}, deletionRepo, &mocks.MockGDPRExportRepository{})
+
+	req, err := svc.GetDeletionRequest(context.Background(), "user-1")
+	require.NoError(t, err)
+	assert.Equal(t, "req-1", req.ID)
+}
+
+func TestExecutePendingDeletions_Success(t *testing.T) {
+	deletionCalls := make(map[string]bool)
+
+	deletionRepo := &mocks.MockGDPRDeletionRepository{
+		FindDueForExecutionFn: func(_ context.Context, _ time.Time) ([]domain.DeletionRequest, error) {
+			return []domain.DeletionRequest{
+				{ID: "req-1", UserID: "user-1", Status: domain.DeletionStatusApproved},
+				{ID: "req-2", UserID: "user-2", Status: domain.DeletionStatusApproved},
+			}, nil
+		},
+		UpdateStatusFn: func(_ context.Context, id, status string, _ time.Time) error {
+			assert.Equal(t, domain.DeletionStatusCompleted, status)
+			deletionCalls[id] = true
+			return nil
+		},
+	}
+
+	consentRepo := &mocks.MockGDPRConsentRepository{
+		DeleteByUserIDFn: func(_ context.Context, _ string) error { return nil },
+	}
+
+	exportRepo := &mocks.MockGDPRExportRepository{
+		DeleteRefreshTokensFn: func(_ context.Context, _ string) error { return nil },
+		DeleteOAuthAccountsFn: func(_ context.Context, _ string) error { return nil },
+		AnonymizeAuditLogsFn:  func(_ context.Context, _ string) error { return nil },
+		SoftDeleteUserFn:      func(_ context.Context, _ string) error { return nil },
+	}
+
+	svc := newTestService(consentRepo, deletionRepo, exportRepo)
+
+	count, err := svc.ExecutePendingDeletions(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+	assert.True(t, deletionCalls["req-1"])
+	assert.True(t, deletionCalls["req-2"])
+}
+
+func TestExecutePendingDeletions_NoDueRequests(t *testing.T) {
+	deletionRepo := &mocks.MockGDPRDeletionRepository{
+		FindDueForExecutionFn: func(_ context.Context, _ time.Time) ([]domain.DeletionRequest, error) {
+			return nil, nil
+		},
+	}
+
+	svc := newTestService(&mocks.MockGDPRConsentRepository{}, deletionRepo, &mocks.MockGDPRExportRepository{})
+
+	count, err := svc.ExecutePendingDeletions(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestExecutePendingDeletions_PartialFailure(t *testing.T) {
+	callCount := 0
+	deletionRepo := &mocks.MockGDPRDeletionRepository{
+		FindDueForExecutionFn: func(_ context.Context, _ time.Time) ([]domain.DeletionRequest, error) {
+			return []domain.DeletionRequest{
+				{ID: "req-1", UserID: "user-1", Status: domain.DeletionStatusApproved},
+				{ID: "req-2", UserID: "user-2", Status: domain.DeletionStatusApproved},
+			}, nil
+		},
+		UpdateStatusFn: func(_ context.Context, _ string, _ string, _ time.Time) error {
+			return nil
+		},
+	}
+
+	consentRepo := &mocks.MockGDPRConsentRepository{
+		DeleteByUserIDFn: func(_ context.Context, _ string) error { return nil },
+	}
+
+	exportRepo := &mocks.MockGDPRExportRepository{
+		DeleteRefreshTokensFn: func(_ context.Context, userID string) error {
+			callCount++
+			if callCount == 2 {
+				return errors.New("db connection lost")
+			}
+			return nil
+		},
+		DeleteOAuthAccountsFn: func(_ context.Context, _ string) error { return nil },
+		AnonymizeAuditLogsFn:  func(_ context.Context, _ string) error { return nil },
+		SoftDeleteUserFn:      func(_ context.Context, _ string) error { return nil },
+	}
+
+	svc := newTestService(consentRepo, deletionRepo, exportRepo)
+
+	count, err := svc.ExecutePendingDeletions(context.Background())
+	assert.Error(t, err)
+	assert.Equal(t, 1, count) // First succeeded, second failed.
+}
+
+func TestApprovePendingDeletion_Success(t *testing.T) {
+	deletionRepo := &mocks.MockGDPRDeletionRepository{
+		UpdateStatusFn: func(_ context.Context, id, status string, _ time.Time) error {
+			assert.Equal(t, "req-1", id)
+			assert.Equal(t, domain.DeletionStatusApproved, status)
+			return nil
+		},
+	}
+
+	svc := newTestService(&mocks.MockGDPRConsentRepository{}, deletionRepo, &mocks.MockGDPRExportRepository{})
+
+	err := svc.ApprovePendingDeletion(context.Background(), "req-1")
+	require.NoError(t, err)
+}
+
+// --- Data Retention Tests ---
+
+func TestCleanupExpiredData_Success(t *testing.T) {
+	exportRepo := &mocks.MockGDPRExportRepository{
+		DeleteExpiredSoftDeletedUsersFn: func(_ context.Context, days int) (int64, error) {
+			assert.Equal(t, 90, days)
+			return 5, nil
+		},
+		DeleteExpiredRefreshTokensFn: func(_ context.Context, days int) (int64, error) {
+			assert.Equal(t, 30, days)
+			return 100, nil
+		},
+	}
+
+	svc := newTestService(&mocks.MockGDPRConsentRepository{}, &mocks.MockGDPRDeletionRepository{}, exportRepo)
+
+	result, err := svc.CleanupExpiredData(context.Background(), gdpr.DefaultRetentionConfig())
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), result.UsersDeleted)
+	assert.Equal(t, int64(100), result.TokensDeleted)
+}
+
+func TestCleanupExpiredData_CustomConfig(t *testing.T) {
+	exportRepo := &mocks.MockGDPRExportRepository{
+		DeleteExpiredSoftDeletedUsersFn: func(_ context.Context, days int) (int64, error) {
+			assert.Equal(t, 180, days)
+			return 2, nil
+		},
+		DeleteExpiredRefreshTokensFn: func(_ context.Context, days int) (int64, error) {
+			assert.Equal(t, 7, days)
+			return 50, nil
+		},
+	}
+
+	svc := newTestService(&mocks.MockGDPRConsentRepository{}, &mocks.MockGDPRDeletionRepository{}, exportRepo)
+
+	config := gdpr.RetentionConfig{
+		SoftDeletedUserRetentionDays: 180,
+		ExpiredTokenRetentionDays:    7,
+	}
+	result, err := svc.CleanupExpiredData(context.Background(), config)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), result.UsersDeleted)
+	assert.Equal(t, int64(50), result.TokensDeleted)
+}
+
+func TestCleanupExpiredData_UserDeletionError(t *testing.T) {
+	exportRepo := &mocks.MockGDPRExportRepository{
+		DeleteExpiredSoftDeletedUsersFn: func(_ context.Context, _ int) (int64, error) {
+			return 0, errors.New("permission denied")
+		},
+	}
+
+	svc := newTestService(&mocks.MockGDPRConsentRepository{}, &mocks.MockGDPRDeletionRepository{}, exportRepo)
+
+	_, err := svc.CleanupExpiredData(context.Background(), gdpr.DefaultRetentionConfig())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cleanup expired users")
+}
+
+func TestCleanupExpiredData_TokenDeletionError(t *testing.T) {
+	exportRepo := &mocks.MockGDPRExportRepository{
+		DeleteExpiredSoftDeletedUsersFn: func(_ context.Context, _ int) (int64, error) {
+			return 3, nil
+		},
+		DeleteExpiredRefreshTokensFn: func(_ context.Context, _ int) (int64, error) {
+			return 0, errors.New("timeout")
+		},
+	}
+
+	svc := newTestService(&mocks.MockGDPRConsentRepository{}, &mocks.MockGDPRDeletionRepository{}, exportRepo)
+
+	_, err := svc.CleanupExpiredData(context.Background(), gdpr.DefaultRetentionConfig())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cleanup expired tokens")
+}
+
+func TestDefaultRetentionConfig(t *testing.T) {
+	config := gdpr.DefaultRetentionConfig()
+	assert.Equal(t, 90, config.SoftDeletedUserRetentionDays)
+	assert.Equal(t, 30, config.ExpiredTokenRetentionDays)
+}

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -44,4 +44,10 @@ var (
 
 	// ErrDuplicateOAuthAccount indicates an OAuth account with the same provider and provider user ID already exists.
 	ErrDuplicateOAuthAccount = errors.New("duplicate oauth account")
+
+	// ErrDuplicateConsent indicates a consent record of this type already exists for the user.
+	ErrDuplicateConsent = errors.New("duplicate consent record")
+
+	// ErrDeletionAlreadyRequested indicates a pending deletion request already exists for this user.
+	ErrDeletionAlreadyRequested = errors.New("deletion already requested")
 )

--- a/internal/storage/gdpr_consent_repository.go
+++ b/internal/storage/gdpr_consent_repository.go
@@ -1,0 +1,167 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// GDPRConsentRepository defines the persistence operations for GDPR consent records.
+type GDPRConsentRepository interface {
+	// Create stores a new consent record. Returns ErrDuplicateConsent if a record
+	// of this consent type already exists for the user.
+	Create(ctx context.Context, record *domain.ConsentRecord) (*domain.ConsentRecord, error)
+
+	// FindByID retrieves a consent record by primary key. Returns ErrNotFound if absent.
+	FindByID(ctx context.Context, id string) (*domain.ConsentRecord, error)
+
+	// FindByUserID returns all consent records for a user.
+	FindByUserID(ctx context.Context, userID string) ([]domain.ConsentRecord, error)
+
+	// FindByUserIDAndType returns the consent record for a specific user and consent type.
+	// Returns ErrNotFound if absent.
+	FindByUserIDAndType(ctx context.Context, userID, consentType string) (*domain.ConsentRecord, error)
+
+	// Revoke marks a consent record as revoked. Returns ErrNotFound if absent.
+	Revoke(ctx context.Context, id string, revokedAt time.Time) error
+
+	// DeleteByUserID removes all consent records for a user (used during account deletion).
+	DeleteByUserID(ctx context.Context, userID string) error
+}
+
+// PostgresGDPRConsentRepository implements GDPRConsentRepository using pgx.
+type PostgresGDPRConsentRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresGDPRConsentRepository creates a new PostgreSQL-backed GDPR consent repository.
+func NewPostgresGDPRConsentRepository(pool *pgxpool.Pool) *PostgresGDPRConsentRepository {
+	return &PostgresGDPRConsentRepository{pool: pool}
+}
+
+const consentColumns = `id, user_id, consent_type, granted, ip_address, user_agent, granted_at, revoked_at, created_at`
+
+func scanConsent(row pgx.Row) (*domain.ConsentRecord, error) {
+	rec := &domain.ConsentRecord{}
+	err := row.Scan(
+		&rec.ID, &rec.UserID, &rec.ConsentType, &rec.Granted,
+		&rec.IPAddress, &rec.UserAgent, &rec.GrantedAt, &rec.RevokedAt, &rec.CreatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return rec, nil
+}
+
+// Create inserts a new consent record.
+func (r *PostgresGDPRConsentRepository) Create(ctx context.Context, record *domain.ConsentRecord) (*domain.ConsentRecord, error) {
+	query := fmt.Sprintf(`
+		INSERT INTO consent_records (id, user_id, consent_type, granted, ip_address, user_agent, granted_at, revoked_at, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		RETURNING %s`, consentColumns)
+
+	out, err := scanConsent(r.pool.QueryRow(ctx, query,
+		record.ID, record.UserID, record.ConsentType, record.Granted,
+		record.IPAddress, record.UserAgent, record.GrantedAt, record.RevokedAt, record.CreatedAt,
+	))
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return nil, fmt.Errorf("consent %s for user %s: %w", record.ConsentType, record.UserID, ErrDuplicateConsent)
+		}
+		return nil, fmt.Errorf("insert consent record: %w", err)
+	}
+	return out, nil
+}
+
+// FindByID retrieves a consent record by ID.
+func (r *PostgresGDPRConsentRepository) FindByID(ctx context.Context, id string) (*domain.ConsentRecord, error) {
+	query := fmt.Sprintf(`SELECT %s FROM consent_records WHERE id = $1`, consentColumns)
+
+	rec, err := scanConsent(r.pool.QueryRow(ctx, query, id))
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, fmt.Errorf("consent %s: %w", id, ErrNotFound)
+		}
+		return nil, fmt.Errorf("find consent by id: %w", err)
+	}
+	return rec, nil
+}
+
+// FindByUserID returns all consent records for a user.
+func (r *PostgresGDPRConsentRepository) FindByUserID(ctx context.Context, userID string) ([]domain.ConsentRecord, error) {
+	query := fmt.Sprintf(`SELECT %s FROM consent_records WHERE user_id = $1 ORDER BY created_at DESC`, consentColumns)
+
+	rows, err := r.pool.Query(ctx, query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("find consents by user: %w", err)
+	}
+	defer rows.Close()
+
+	var records []domain.ConsentRecord
+	for rows.Next() {
+		var rec domain.ConsentRecord
+		err := rows.Scan(
+			&rec.ID, &rec.UserID, &rec.ConsentType, &rec.Granted,
+			&rec.IPAddress, &rec.UserAgent, &rec.GrantedAt, &rec.RevokedAt, &rec.CreatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("scan consent record: %w", err)
+		}
+		records = append(records, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate consent records: %w", err)
+	}
+
+	return records, nil
+}
+
+// FindByUserIDAndType returns the consent record for a specific user and type.
+func (r *PostgresGDPRConsentRepository) FindByUserIDAndType(ctx context.Context, userID, consentType string) (*domain.ConsentRecord, error) {
+	query := fmt.Sprintf(`SELECT %s FROM consent_records WHERE user_id = $1 AND consent_type = $2`, consentColumns)
+
+	rec, err := scanConsent(r.pool.QueryRow(ctx, query, userID, consentType))
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, fmt.Errorf("consent %s for user %s: %w", consentType, userID, ErrNotFound)
+		}
+		return nil, fmt.Errorf("find consent by user and type: %w", err)
+	}
+	return rec, nil
+}
+
+// Revoke marks a consent record as revoked.
+func (r *PostgresGDPRConsentRepository) Revoke(ctx context.Context, id string, revokedAt time.Time) error {
+	query := `UPDATE consent_records SET granted = FALSE, revoked_at = $1 WHERE id = $2 AND granted = TRUE`
+
+	tag, err := r.pool.Exec(ctx, query, revokedAt, id)
+	if err != nil {
+		return fmt.Errorf("revoke consent: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("consent %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
+// DeleteByUserID removes all consent records for a user.
+func (r *PostgresGDPRConsentRepository) DeleteByUserID(ctx context.Context, userID string) error {
+	query := `DELETE FROM consent_records WHERE user_id = $1`
+
+	_, err := r.pool.Exec(ctx, query, userID)
+	if err != nil {
+		return fmt.Errorf("delete consent records for user %s: %w", userID, err)
+	}
+	return nil
+}

--- a/internal/storage/gdpr_deletion_repository.go
+++ b/internal/storage/gdpr_deletion_repository.go
@@ -1,0 +1,191 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// GDPRDeletionRepository defines the persistence operations for GDPR deletion requests.
+type GDPRDeletionRepository interface {
+	// Create stores a new deletion request. Returns ErrDeletionAlreadyRequested
+	// if a pending request already exists for this user.
+	Create(ctx context.Context, req *domain.DeletionRequest) (*domain.DeletionRequest, error)
+
+	// FindByID retrieves a deletion request by primary key. Returns ErrNotFound if absent.
+	FindByID(ctx context.Context, id string) (*domain.DeletionRequest, error)
+
+	// FindByUserID retrieves the most recent deletion request for a user.
+	// Returns ErrNotFound if absent.
+	FindByUserID(ctx context.Context, userID string) (*domain.DeletionRequest, error)
+
+	// FindPendingByUserID retrieves the pending deletion request for a user.
+	// Returns ErrNotFound if no pending request exists.
+	FindPendingByUserID(ctx context.Context, userID string) (*domain.DeletionRequest, error)
+
+	// FindDueForExecution returns all approved requests whose scheduled_at is in the past.
+	FindDueForExecution(ctx context.Context, now time.Time) ([]domain.DeletionRequest, error)
+
+	// UpdateStatus updates the status and relevant timestamps of a deletion request.
+	UpdateStatus(ctx context.Context, id, status string, now time.Time) error
+
+	// Cancel marks a deletion request as cancelled.
+	Cancel(ctx context.Context, id, cancelledBy string, cancelledAt time.Time) error
+}
+
+// PostgresGDPRDeletionRepository implements GDPRDeletionRepository using pgx.
+type PostgresGDPRDeletionRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresGDPRDeletionRepository creates a new PostgreSQL-backed GDPR deletion repository.
+func NewPostgresGDPRDeletionRepository(pool *pgxpool.Pool) *PostgresGDPRDeletionRepository {
+	return &PostgresGDPRDeletionRepository{pool: pool}
+}
+
+const deletionColumns = `id, user_id, status, reason, requested_at, scheduled_at, completed_at, cancelled_at, cancelled_by, created_at, updated_at`
+
+func scanDeletion(row pgx.Row) (*domain.DeletionRequest, error) {
+	rec := &domain.DeletionRequest{}
+	err := row.Scan(
+		&rec.ID, &rec.UserID, &rec.Status, &rec.Reason,
+		&rec.RequestedAt, &rec.ScheduledAt, &rec.CompletedAt,
+		&rec.CancelledAt, &rec.CancelledBy, &rec.CreatedAt, &rec.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return rec, nil
+}
+
+// Create inserts a new deletion request.
+func (r *PostgresGDPRDeletionRepository) Create(ctx context.Context, req *domain.DeletionRequest) (*domain.DeletionRequest, error) {
+	query := fmt.Sprintf(`
+		INSERT INTO gdpr_deletion_requests (id, user_id, status, reason, requested_at, scheduled_at, completed_at, cancelled_at, cancelled_by, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		RETURNING %s`, deletionColumns)
+
+	out, err := scanDeletion(r.pool.QueryRow(ctx, query,
+		req.ID, req.UserID, req.Status, req.Reason,
+		req.RequestedAt, req.ScheduledAt, req.CompletedAt,
+		req.CancelledAt, req.CancelledBy, req.CreatedAt, req.UpdatedAt,
+	))
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return nil, fmt.Errorf("deletion for user %s: %w", req.UserID, ErrDeletionAlreadyRequested)
+		}
+		return nil, fmt.Errorf("insert deletion request: %w", err)
+	}
+	return out, nil
+}
+
+// FindByID retrieves a deletion request by ID.
+func (r *PostgresGDPRDeletionRepository) FindByID(ctx context.Context, id string) (*domain.DeletionRequest, error) {
+	query := fmt.Sprintf(`SELECT %s FROM gdpr_deletion_requests WHERE id = $1`, deletionColumns)
+
+	rec, err := scanDeletion(r.pool.QueryRow(ctx, query, id))
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, fmt.Errorf("deletion request %s: %w", id, ErrNotFound)
+		}
+		return nil, fmt.Errorf("find deletion request by id: %w", err)
+	}
+	return rec, nil
+}
+
+// FindByUserID retrieves the most recent deletion request for a user.
+func (r *PostgresGDPRDeletionRepository) FindByUserID(ctx context.Context, userID string) (*domain.DeletionRequest, error) {
+	query := fmt.Sprintf(`SELECT %s FROM gdpr_deletion_requests WHERE user_id = $1 ORDER BY created_at DESC LIMIT 1`, deletionColumns)
+
+	rec, err := scanDeletion(r.pool.QueryRow(ctx, query, userID))
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, fmt.Errorf("deletion request for user %s: %w", userID, ErrNotFound)
+		}
+		return nil, fmt.Errorf("find deletion request by user: %w", err)
+	}
+	return rec, nil
+}
+
+// FindPendingByUserID retrieves the pending deletion request for a user.
+func (r *PostgresGDPRDeletionRepository) FindPendingByUserID(ctx context.Context, userID string) (*domain.DeletionRequest, error) {
+	query := fmt.Sprintf(`SELECT %s FROM gdpr_deletion_requests WHERE user_id = $1 AND status = $2`, deletionColumns)
+
+	rec, err := scanDeletion(r.pool.QueryRow(ctx, query, userID, domain.DeletionStatusPending))
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, fmt.Errorf("pending deletion for user %s: %w", userID, ErrNotFound)
+		}
+		return nil, fmt.Errorf("find pending deletion by user: %w", err)
+	}
+	return rec, nil
+}
+
+// FindDueForExecution returns all approved requests whose scheduled_at is in the past.
+func (r *PostgresGDPRDeletionRepository) FindDueForExecution(ctx context.Context, now time.Time) ([]domain.DeletionRequest, error) {
+	query := fmt.Sprintf(`SELECT %s FROM gdpr_deletion_requests WHERE status = $1 AND scheduled_at <= $2 ORDER BY scheduled_at ASC`, deletionColumns)
+
+	rows, err := r.pool.Query(ctx, query, domain.DeletionStatusApproved, now)
+	if err != nil {
+		return nil, fmt.Errorf("find due deletion requests: %w", err)
+	}
+	defer rows.Close()
+
+	var requests []domain.DeletionRequest
+	for rows.Next() {
+		var req domain.DeletionRequest
+		err := rows.Scan(
+			&req.ID, &req.UserID, &req.Status, &req.Reason,
+			&req.RequestedAt, &req.ScheduledAt, &req.CompletedAt,
+			&req.CancelledAt, &req.CancelledBy, &req.CreatedAt, &req.UpdatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("scan deletion request: %w", err)
+		}
+		requests = append(requests, req)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate deletion requests: %w", err)
+	}
+
+	return requests, nil
+}
+
+// UpdateStatus updates the status and timestamps of a deletion request.
+func (r *PostgresGDPRDeletionRepository) UpdateStatus(ctx context.Context, id, status string, now time.Time) error {
+	query := `UPDATE gdpr_deletion_requests SET status = $1, updated_at = $2, completed_at = CASE WHEN $1 = 'completed' THEN $2 ELSE completed_at END WHERE id = $3`
+
+	tag, err := r.pool.Exec(ctx, query, status, now, id)
+	if err != nil {
+		return fmt.Errorf("update deletion status: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("deletion request %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
+// Cancel marks a deletion request as cancelled.
+func (r *PostgresGDPRDeletionRepository) Cancel(ctx context.Context, id, cancelledBy string, cancelledAt time.Time) error {
+	query := `UPDATE gdpr_deletion_requests SET status = $1, cancelled_at = $2, cancelled_by = $3, updated_at = $2 WHERE id = $4 AND status IN ('pending', 'approved')`
+
+	tag, err := r.pool.Exec(ctx, query, domain.DeletionStatusCancelled, cancelledAt, cancelledBy, id)
+	if err != nil {
+		return fmt.Errorf("cancel deletion request: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("deletion request %s: %w", id, ErrNotFound)
+	}
+	return nil
+}

--- a/internal/storage/gdpr_export_repository.go
+++ b/internal/storage/gdpr_export_repository.go
@@ -1,0 +1,220 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// GDPRExportRepository defines read-only queries for aggregating user data across tables.
+type GDPRExportRepository interface {
+	// GetUserData retrieves the user record. Returns ErrNotFound if absent.
+	GetUserData(ctx context.Context, userID string) (*domain.User, error)
+
+	// GetOAuthAccounts retrieves all OAuth accounts linked to the user.
+	GetOAuthAccounts(ctx context.Context, userID string) ([]domain.OAuthAccount, error)
+
+	// GetRefreshTokens retrieves all refresh token records for the user.
+	GetRefreshTokens(ctx context.Context, userID string) ([]domain.RefreshTokenRecord, error)
+
+	// GetConsentRecords retrieves all consent records for the user.
+	GetConsentRecords(ctx context.Context, userID string) ([]domain.ConsentRecord, error)
+
+	// SoftDeleteUser sets the deleted_at timestamp on the user record.
+	SoftDeleteUser(ctx context.Context, userID string) error
+
+	// DeleteOAuthAccounts removes all OAuth account links for a user.
+	DeleteOAuthAccounts(ctx context.Context, userID string) error
+
+	// DeleteRefreshTokens removes all refresh tokens for a user.
+	DeleteRefreshTokens(ctx context.Context, userID string) error
+
+	// AnonymizeAuditLogs replaces user-identifiable information in audit logs with anonymized values.
+	AnonymizeAuditLogs(ctx context.Context, userID string) error
+
+	// DeleteExpiredSoftDeletedUsers permanently deletes users whose deleted_at is older than the given days.
+	DeleteExpiredSoftDeletedUsers(ctx context.Context, retentionDays int) (int64, error)
+
+	// DeleteExpiredRefreshTokens removes refresh tokens that expired before the given days.
+	DeleteExpiredRefreshTokens(ctx context.Context, retentionDays int) (int64, error)
+}
+
+// PostgresGDPRExportRepository implements GDPRExportRepository using pgx.
+type PostgresGDPRExportRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresGDPRExportRepository creates a new PostgreSQL-backed GDPR export repository.
+func NewPostgresGDPRExportRepository(pool *pgxpool.Pool) *PostgresGDPRExportRepository {
+	return &PostgresGDPRExportRepository{pool: pool}
+}
+
+// GetUserData retrieves the user record by ID.
+func (r *PostgresGDPRExportRepository) GetUserData(ctx context.Context, userID string) (*domain.User, error) {
+	query := `SELECT id, email, password_hash, name, roles, locked, locked_at, locked_reason,
+		email_verified, email_verify_token, email_verify_token_expires_at,
+		last_login_at, created_at, updated_at, deleted_at
+		FROM users WHERE id = $1`
+
+	user := &domain.User{}
+	err := r.pool.QueryRow(ctx, query, userID).Scan(
+		&user.ID, &user.Email, &user.PasswordHash, &user.Name, &user.Roles,
+		&user.Locked, &user.LockedAt, &user.LockedReason,
+		&user.EmailVerified, &user.EmailVerifyToken, &user.EmailVerifyTokenExpiresAt,
+		&user.LastLoginAt, &user.CreatedAt, &user.UpdatedAt, &user.DeletedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get user data: %w", mapNoRows(err))
+	}
+	return user, nil
+}
+
+// GetOAuthAccounts retrieves all OAuth accounts linked to the user.
+func (r *PostgresGDPRExportRepository) GetOAuthAccounts(ctx context.Context, userID string) ([]domain.OAuthAccount, error) {
+	query := `SELECT id, user_id, provider, provider_user_id, email, created_at
+		FROM oauth_accounts WHERE user_id = $1 ORDER BY created_at`
+
+	rows, err := r.pool.Query(ctx, query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get oauth accounts: %w", err)
+	}
+	defer rows.Close()
+
+	var accounts []domain.OAuthAccount
+	for rows.Next() {
+		var a domain.OAuthAccount
+		if err := rows.Scan(&a.ID, &a.UserID, &a.Provider, &a.ProviderUserID, &a.Email, &a.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan oauth account: %w", err)
+		}
+		accounts = append(accounts, a)
+	}
+	return accounts, rows.Err()
+}
+
+// GetRefreshTokens retrieves all refresh token records for the user.
+func (r *PostgresGDPRExportRepository) GetRefreshTokens(ctx context.Context, userID string) ([]domain.RefreshTokenRecord, error) {
+	query := `SELECT signature, user_id, expires_at, created_at, revoked_at
+		FROM refresh_tokens WHERE user_id = $1 ORDER BY created_at`
+
+	rows, err := r.pool.Query(ctx, query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get refresh tokens: %w", err)
+	}
+	defer rows.Close()
+
+	var tokens []domain.RefreshTokenRecord
+	for rows.Next() {
+		var t domain.RefreshTokenRecord
+		if err := rows.Scan(&t.Signature, &t.UserID, &t.ExpiresAt, &t.CreatedAt, &t.RevokedAt); err != nil {
+			return nil, fmt.Errorf("scan refresh token: %w", err)
+		}
+		tokens = append(tokens, t)
+	}
+	return tokens, rows.Err()
+}
+
+// GetConsentRecords retrieves all consent records for the user.
+func (r *PostgresGDPRExportRepository) GetConsentRecords(ctx context.Context, userID string) ([]domain.ConsentRecord, error) {
+	query := fmt.Sprintf(`SELECT %s FROM consent_records WHERE user_id = $1 ORDER BY created_at`, consentColumns)
+
+	rows, err := r.pool.Query(ctx, query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get consent records: %w", err)
+	}
+	defer rows.Close()
+
+	var records []domain.ConsentRecord
+	for rows.Next() {
+		var rec domain.ConsentRecord
+		if err := rows.Scan(
+			&rec.ID, &rec.UserID, &rec.ConsentType, &rec.Granted,
+			&rec.IPAddress, &rec.UserAgent, &rec.GrantedAt, &rec.RevokedAt, &rec.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan consent record: %w", err)
+		}
+		records = append(records, rec)
+	}
+	return records, rows.Err()
+}
+
+// SoftDeleteUser sets the deleted_at timestamp on the user record.
+func (r *PostgresGDPRExportRepository) SoftDeleteUser(ctx context.Context, userID string) error {
+	query := `UPDATE users SET deleted_at = NOW(), updated_at = NOW() WHERE id = $1 AND deleted_at IS NULL`
+
+	tag, err := r.pool.Exec(ctx, query, userID)
+	if err != nil {
+		return fmt.Errorf("soft delete user: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("user %s: %w", userID, ErrNotFound)
+	}
+	return nil
+}
+
+// DeleteOAuthAccounts removes all OAuth account links for a user.
+func (r *PostgresGDPRExportRepository) DeleteOAuthAccounts(ctx context.Context, userID string) error {
+	query := `DELETE FROM oauth_accounts WHERE user_id = $1`
+
+	_, err := r.pool.Exec(ctx, query, userID)
+	if err != nil {
+		return fmt.Errorf("delete oauth accounts for user %s: %w", userID, err)
+	}
+	return nil
+}
+
+// DeleteRefreshTokens removes all refresh tokens for a user.
+func (r *PostgresGDPRExportRepository) DeleteRefreshTokens(ctx context.Context, userID string) error {
+	query := `DELETE FROM refresh_tokens WHERE user_id = $1`
+
+	_, err := r.pool.Exec(ctx, query, userID)
+	if err != nil {
+		return fmt.Errorf("delete refresh tokens for user %s: %w", userID, err)
+	}
+	return nil
+}
+
+// AnonymizeAuditLogs replaces user-identifiable info in audit logs with anonymized placeholders.
+func (r *PostgresGDPRExportRepository) AnonymizeAuditLogs(ctx context.Context, userID string) error {
+	query := `UPDATE audit_logs SET user_id = 'anonymized', ip_address = '0.0.0.0', user_agent = 'anonymized', updated_at = NOW() WHERE user_id = $1`
+
+	_, err := r.pool.Exec(ctx, query, userID)
+	if err != nil {
+		return fmt.Errorf("anonymize audit logs for user %s: %w", userID, err)
+	}
+	return nil
+}
+
+// DeleteExpiredSoftDeletedUsers permanently deletes users whose deleted_at is older than retentionDays.
+func (r *PostgresGDPRExportRepository) DeleteExpiredSoftDeletedUsers(ctx context.Context, retentionDays int) (int64, error) {
+	query := `DELETE FROM users WHERE deleted_at IS NOT NULL AND deleted_at < NOW() - make_interval(days => $1)`
+
+	tag, err := r.pool.Exec(ctx, query, retentionDays)
+	if err != nil {
+		return 0, fmt.Errorf("delete expired soft-deleted users: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+// DeleteExpiredRefreshTokens removes refresh tokens that expired more than retentionDays ago.
+func (r *PostgresGDPRExportRepository) DeleteExpiredRefreshTokens(ctx context.Context, retentionDays int) (int64, error) {
+	query := `DELETE FROM refresh_tokens WHERE expires_at < NOW() - make_interval(days => $1)`
+
+	tag, err := r.pool.Exec(ctx, query, retentionDays)
+	if err != nil {
+		return 0, fmt.Errorf("delete expired refresh tokens: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+// mapNoRows converts pgx.ErrNoRows to ErrNotFound.
+func mapNoRows(err error) error {
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrNotFound
+	}
+	return err
+}

--- a/internal/storage/mocks/gdpr_consent_repository.go
+++ b/internal/storage/mocks/gdpr_consent_repository.go
@@ -1,0 +1,48 @@
+package mocks
+
+import (
+	"context"
+	"time"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// MockGDPRConsentRepository is a configurable mock for storage.GDPRConsentRepository.
+type MockGDPRConsentRepository struct {
+	CreateFn              func(ctx context.Context, record *domain.ConsentRecord) (*domain.ConsentRecord, error)
+	FindByIDFn            func(ctx context.Context, id string) (*domain.ConsentRecord, error)
+	FindByUserIDFn        func(ctx context.Context, userID string) ([]domain.ConsentRecord, error)
+	FindByUserIDAndTypeFn func(ctx context.Context, userID, consentType string) (*domain.ConsentRecord, error)
+	RevokeFn              func(ctx context.Context, id string, revokedAt time.Time) error
+	DeleteByUserIDFn      func(ctx context.Context, userID string) error
+}
+
+// Create delegates to CreateFn.
+func (m *MockGDPRConsentRepository) Create(ctx context.Context, record *domain.ConsentRecord) (*domain.ConsentRecord, error) {
+	return m.CreateFn(ctx, record)
+}
+
+// FindByID delegates to FindByIDFn.
+func (m *MockGDPRConsentRepository) FindByID(ctx context.Context, id string) (*domain.ConsentRecord, error) {
+	return m.FindByIDFn(ctx, id)
+}
+
+// FindByUserID delegates to FindByUserIDFn.
+func (m *MockGDPRConsentRepository) FindByUserID(ctx context.Context, userID string) ([]domain.ConsentRecord, error) {
+	return m.FindByUserIDFn(ctx, userID)
+}
+
+// FindByUserIDAndType delegates to FindByUserIDAndTypeFn.
+func (m *MockGDPRConsentRepository) FindByUserIDAndType(ctx context.Context, userID, consentType string) (*domain.ConsentRecord, error) {
+	return m.FindByUserIDAndTypeFn(ctx, userID, consentType)
+}
+
+// Revoke delegates to RevokeFn.
+func (m *MockGDPRConsentRepository) Revoke(ctx context.Context, id string, revokedAt time.Time) error {
+	return m.RevokeFn(ctx, id, revokedAt)
+}
+
+// DeleteByUserID delegates to DeleteByUserIDFn.
+func (m *MockGDPRConsentRepository) DeleteByUserID(ctx context.Context, userID string) error {
+	return m.DeleteByUserIDFn(ctx, userID)
+}

--- a/internal/storage/mocks/gdpr_deletion_repository.go
+++ b/internal/storage/mocks/gdpr_deletion_repository.go
@@ -1,0 +1,54 @@
+package mocks
+
+import (
+	"context"
+	"time"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// MockGDPRDeletionRepository is a configurable mock for storage.GDPRDeletionRepository.
+type MockGDPRDeletionRepository struct {
+	CreateFn              func(ctx context.Context, req *domain.DeletionRequest) (*domain.DeletionRequest, error)
+	FindByIDFn            func(ctx context.Context, id string) (*domain.DeletionRequest, error)
+	FindByUserIDFn        func(ctx context.Context, userID string) (*domain.DeletionRequest, error)
+	FindPendingByUserIDFn func(ctx context.Context, userID string) (*domain.DeletionRequest, error)
+	FindDueForExecutionFn func(ctx context.Context, now time.Time) ([]domain.DeletionRequest, error)
+	UpdateStatusFn        func(ctx context.Context, id, status string, now time.Time) error
+	CancelFn              func(ctx context.Context, id, cancelledBy string, cancelledAt time.Time) error
+}
+
+// Create delegates to CreateFn.
+func (m *MockGDPRDeletionRepository) Create(ctx context.Context, req *domain.DeletionRequest) (*domain.DeletionRequest, error) {
+	return m.CreateFn(ctx, req)
+}
+
+// FindByID delegates to FindByIDFn.
+func (m *MockGDPRDeletionRepository) FindByID(ctx context.Context, id string) (*domain.DeletionRequest, error) {
+	return m.FindByIDFn(ctx, id)
+}
+
+// FindByUserID delegates to FindByUserIDFn.
+func (m *MockGDPRDeletionRepository) FindByUserID(ctx context.Context, userID string) (*domain.DeletionRequest, error) {
+	return m.FindByUserIDFn(ctx, userID)
+}
+
+// FindPendingByUserID delegates to FindPendingByUserIDFn.
+func (m *MockGDPRDeletionRepository) FindPendingByUserID(ctx context.Context, userID string) (*domain.DeletionRequest, error) {
+	return m.FindPendingByUserIDFn(ctx, userID)
+}
+
+// FindDueForExecution delegates to FindDueForExecutionFn.
+func (m *MockGDPRDeletionRepository) FindDueForExecution(ctx context.Context, now time.Time) ([]domain.DeletionRequest, error) {
+	return m.FindDueForExecutionFn(ctx, now)
+}
+
+// UpdateStatus delegates to UpdateStatusFn.
+func (m *MockGDPRDeletionRepository) UpdateStatus(ctx context.Context, id, status string, now time.Time) error {
+	return m.UpdateStatusFn(ctx, id, status, now)
+}
+
+// Cancel delegates to CancelFn.
+func (m *MockGDPRDeletionRepository) Cancel(ctx context.Context, id, cancelledBy string, cancelledAt time.Time) error {
+	return m.CancelFn(ctx, id, cancelledBy, cancelledAt)
+}

--- a/internal/storage/mocks/gdpr_export_repository.go
+++ b/internal/storage/mocks/gdpr_export_repository.go
@@ -1,0 +1,71 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// MockGDPRExportRepository is a configurable mock for storage.GDPRExportRepository.
+type MockGDPRExportRepository struct {
+	GetUserDataFn                   func(ctx context.Context, userID string) (*domain.User, error)
+	GetOAuthAccountsFn              func(ctx context.Context, userID string) ([]domain.OAuthAccount, error)
+	GetRefreshTokensFn              func(ctx context.Context, userID string) ([]domain.RefreshTokenRecord, error)
+	GetConsentRecordsFn             func(ctx context.Context, userID string) ([]domain.ConsentRecord, error)
+	SoftDeleteUserFn                func(ctx context.Context, userID string) error
+	DeleteOAuthAccountsFn           func(ctx context.Context, userID string) error
+	DeleteRefreshTokensFn           func(ctx context.Context, userID string) error
+	AnonymizeAuditLogsFn            func(ctx context.Context, userID string) error
+	DeleteExpiredSoftDeletedUsersFn func(ctx context.Context, retentionDays int) (int64, error)
+	DeleteExpiredRefreshTokensFn    func(ctx context.Context, retentionDays int) (int64, error)
+}
+
+// GetUserData delegates to GetUserDataFn.
+func (m *MockGDPRExportRepository) GetUserData(ctx context.Context, userID string) (*domain.User, error) {
+	return m.GetUserDataFn(ctx, userID)
+}
+
+// GetOAuthAccounts delegates to GetOAuthAccountsFn.
+func (m *MockGDPRExportRepository) GetOAuthAccounts(ctx context.Context, userID string) ([]domain.OAuthAccount, error) {
+	return m.GetOAuthAccountsFn(ctx, userID)
+}
+
+// GetRefreshTokens delegates to GetRefreshTokensFn.
+func (m *MockGDPRExportRepository) GetRefreshTokens(ctx context.Context, userID string) ([]domain.RefreshTokenRecord, error) {
+	return m.GetRefreshTokensFn(ctx, userID)
+}
+
+// GetConsentRecords delegates to GetConsentRecordsFn.
+func (m *MockGDPRExportRepository) GetConsentRecords(ctx context.Context, userID string) ([]domain.ConsentRecord, error) {
+	return m.GetConsentRecordsFn(ctx, userID)
+}
+
+// SoftDeleteUser delegates to SoftDeleteUserFn.
+func (m *MockGDPRExportRepository) SoftDeleteUser(ctx context.Context, userID string) error {
+	return m.SoftDeleteUserFn(ctx, userID)
+}
+
+// DeleteOAuthAccounts delegates to DeleteOAuthAccountsFn.
+func (m *MockGDPRExportRepository) DeleteOAuthAccounts(ctx context.Context, userID string) error {
+	return m.DeleteOAuthAccountsFn(ctx, userID)
+}
+
+// DeleteRefreshTokens delegates to DeleteRefreshTokensFn.
+func (m *MockGDPRExportRepository) DeleteRefreshTokens(ctx context.Context, userID string) error {
+	return m.DeleteRefreshTokensFn(ctx, userID)
+}
+
+// AnonymizeAuditLogs delegates to AnonymizeAuditLogsFn.
+func (m *MockGDPRExportRepository) AnonymizeAuditLogs(ctx context.Context, userID string) error {
+	return m.AnonymizeAuditLogsFn(ctx, userID)
+}
+
+// DeleteExpiredSoftDeletedUsers delegates to DeleteExpiredSoftDeletedUsersFn.
+func (m *MockGDPRExportRepository) DeleteExpiredSoftDeletedUsers(ctx context.Context, retentionDays int) (int64, error) {
+	return m.DeleteExpiredSoftDeletedUsersFn(ctx, retentionDays)
+}
+
+// DeleteExpiredRefreshTokens delegates to DeleteExpiredRefreshTokensFn.
+func (m *MockGDPRExportRepository) DeleteExpiredRefreshTokens(ctx context.Context, retentionDays int) (int64, error) {
+	return m.DeleteExpiredRefreshTokensFn(ctx, retentionDays)
+}

--- a/internal/storage/mocks/mocks_test.go
+++ b/internal/storage/mocks/mocks_test.go
@@ -14,4 +14,7 @@ func TestInterfaceCompliance(t *testing.T) {
 	var _ storage.ClientRepository = (*mocks.MockClientRepository)(nil)
 	var _ storage.RefreshTokenRepository = (*mocks.MockRefreshTokenRepository)(nil)
 	var _ storage.OAuthAccountRepository = (*mocks.MockOAuthAccountRepository)(nil)
+	var _ storage.GDPRConsentRepository = (*mocks.MockGDPRConsentRepository)(nil)
+	var _ storage.GDPRDeletionRepository = (*mocks.MockGDPRDeletionRepository)(nil)
+	var _ storage.GDPRExportRepository = (*mocks.MockGDPRExportRepository)(nil)
 }

--- a/migrations/000009_create_consent_records_table.down.sql
+++ b/migrations/000009_create_consent_records_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS consent_records;

--- a/migrations/000009_create_consent_records_table.up.sql
+++ b/migrations/000009_create_consent_records_table.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS consent_records (
+    id          TEXT PRIMARY KEY,
+    user_id     TEXT NOT NULL REFERENCES users(id),
+    consent_type TEXT NOT NULL,
+    granted     BOOLEAN NOT NULL DEFAULT TRUE,
+    ip_address  TEXT NOT NULL DEFAULT '',
+    user_agent  TEXT NOT NULL DEFAULT '',
+    granted_at  TIMESTAMPTZ,
+    revoked_at  TIMESTAMPTZ,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, consent_type)
+);
+
+CREATE INDEX idx_consent_records_user_id ON consent_records(user_id);
+CREATE INDEX idx_consent_records_consent_type ON consent_records(consent_type);

--- a/migrations/000010_create_gdpr_deletion_requests_table.down.sql
+++ b/migrations/000010_create_gdpr_deletion_requests_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS gdpr_deletion_requests;

--- a/migrations/000010_create_gdpr_deletion_requests_table.up.sql
+++ b/migrations/000010_create_gdpr_deletion_requests_table.up.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS gdpr_deletion_requests (
+    id            TEXT PRIMARY KEY,
+    user_id       TEXT NOT NULL REFERENCES users(id),
+    status        TEXT NOT NULL DEFAULT 'pending',
+    reason        TEXT NOT NULL DEFAULT '',
+    requested_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    scheduled_at  TIMESTAMPTZ NOT NULL,
+    completed_at  TIMESTAMPTZ,
+    cancelled_at  TIMESTAMPTZ,
+    cancelled_by  TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_gdpr_deletion_requests_user_id ON gdpr_deletion_requests(user_id);
+CREATE INDEX idx_gdpr_deletion_requests_status ON gdpr_deletion_requests(status);
+CREATE INDEX idx_gdpr_deletion_requests_scheduled_at ON gdpr_deletion_requests(scheduled_at);
+
+-- Ensure only one pending/approved deletion request per user.
+CREATE UNIQUE INDEX idx_gdpr_deletion_requests_user_pending
+    ON gdpr_deletion_requests(user_id)
+    WHERE status IN ('pending', 'approved');


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-316.

Closes #316

## Changes

Create new repository interfaces and Postgres implementations in `internal/storage/` for consent records (`gdpr_consent_repository.go`) and deletion requests, plus data-export query methods that aggregate user data across tables (users, sessions, oauth_accounts, refresh_tokens, audit logs). Create the new `internal/gdpr/` package with all business logic: data export (collect + serialize user data as JSON), account deletion (cascading cleanup — revoke tokens, delete sessions, anonymize audit logs, remove OAuth links, soft-delete with 30-day grace period), consent tracking (grant/revoke with audit trail), and data retention (configurable policies, cleanup for expired data). Include comprehensive unit tests with mocked repositories. Touches: `internal/storage/` (new files), `internal/gdpr/` (new package).