### PR TITLE
GH-352: Database migration and domain types

### DIFF
--- a/.agent/tasks/gh-352.md
+++ b/.agent/tasks/gh-352.md
@@ -1,0 +1,10 @@
+# GH-352
+
+**Created:** 2026-04-07
+
+## Problem
+
+Create migration `000015_multi_tenancy.up.sql` that adds the `tenants` table (with per-tenant config columns: password policy overrides, MFA enforcement, allowed OAuth providers, custom token TTLs), adds `tenant_id UUID NOT NULL` column to all existing tables (users, clients, refresh_tokens, oauth_accounts, mfa_tables, webhooks, casbin_policies, audit_logs, saml tables, rar tables, password_history, credential_vault), creates composite indexes including tenant_id, sets up PostgreSQL Row-Level Security policies for tenant isolation, and updates unique constraints (e.g., users.email becomes unique per tenant, not globally). In `internal/domain/`, add the `Tenant` model (ID, slug, name, active status, per-tenant config fields) and add `TenantID string` field to `User`, `Client`, and other relevant domain structs. Packages: `migrations/`, `internal/domain/`
+
+## Acceptance Criteria
+

--- a/internal/domain/agent_credential.go
+++ b/internal/domain/agent_credential.go
@@ -44,6 +44,7 @@ var ValidCredentialStatuses = map[string]bool{
 // on behalf of an agent or service client.
 type AgentCredential struct {
 	ID             uuid.UUID      `json:"id"               db:"id"`
+	TenantID       string         `json:"tenant_id"        db:"tenant_id"`
 	OwnerClientID  uuid.UUID      `json:"owner_client_id"  db:"owner_client_id"`
 	TargetName     string         `json:"target_name"      db:"target_name"`
 	CredentialType CredentialType `json:"credential_type"  db:"credential_type"`

--- a/internal/domain/client.go
+++ b/internal/domain/client.go
@@ -31,6 +31,7 @@ const (
 // Client represents an OAuth2 client (service or AI agent) in the system.
 type Client struct {
 	ID                      uuid.UUID  `json:"id"                          db:"id"`
+	TenantID                string     `json:"tenant_id"                   db:"tenant_id"`
 	Name                    string     `json:"name"                        db:"name"`
 	ClientType              ClientType `json:"client_type"                 db:"client_type"`
 	SecretHash              string     `json:"-"                           db:"secret_hash"`

--- a/internal/domain/mfa.go
+++ b/internal/domain/mfa.go
@@ -5,6 +5,7 @@ import "time"
 // MFASecret represents a user's MFA enrollment (e.g. TOTP secret).
 type MFASecret struct {
 	ID          string
+	TenantID    string
 	UserID      string
 	Type        string // "totp", "webauthn" (Phase 2)
 	Secret      string // encrypted TOTP secret
@@ -18,6 +19,7 @@ type MFASecret struct {
 // BackupCode represents a single hashed MFA backup code.
 type BackupCode struct {
 	ID        string
+	TenantID  string
 	UserID    string
 	CodeHash  string
 	Used      bool

--- a/internal/domain/oauth.go
+++ b/internal/domain/oauth.go
@@ -5,6 +5,7 @@ import "time"
 // OAuthAccount represents a linked OAuth provider account for a user.
 type OAuthAccount struct {
 	ID             string    `json:"id"`
+	TenantID       string    `json:"tenant_id"`
 	UserID         string    `json:"user_id"`
 	Provider       string    `json:"provider"`
 	ProviderUserID string    `json:"provider_user_id"`

--- a/internal/domain/rar.go
+++ b/internal/domain/rar.go
@@ -96,6 +96,9 @@ type RARResourceType struct {
 	// ID is the primary key.
 	ID uuid.UUID `json:"id"`
 
+	// TenantID scopes this resource type to a tenant.
+	TenantID string `json:"tenant_id"`
+
 	// Type is the unique authorization type identifier (e.g., "payment_initiation").
 	Type string `json:"type"`
 
@@ -120,6 +123,9 @@ type RARResourceType struct {
 type ClientRARAllowedType struct {
 	// ClientID references the OAuth2 client.
 	ClientID uuid.UUID `json:"client_id"`
+
+	// TenantID scopes this association to a tenant.
+	TenantID string `json:"tenant_id"`
 
 	// ResourceTypeID references the RAR resource type.
 	ResourceTypeID uuid.UUID `json:"resource_type_id"`

--- a/internal/domain/saml.go
+++ b/internal/domain/saml.go
@@ -5,6 +5,7 @@ import "time"
 // SAMLIdPConfig represents a SAML Identity Provider configuration.
 type SAMLIdPConfig struct {
 	ID                string
+	TenantID          string
 	EntityID          string
 	MetadataURL       string
 	MetadataXML       string
@@ -21,6 +22,7 @@ type SAMLIdPConfig struct {
 // SAMLAccount links a SAML NameID to an internal user account.
 type SAMLAccount struct {
 	ID               string
+	TenantID         string
 	UserID           string
 	IdPID            string
 	NameID           string

--- a/internal/domain/tenant.go
+++ b/internal/domain/tenant.go
@@ -1,0 +1,65 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Tenant status constants.
+const (
+	TenantStatusActive   = "active"
+	TenantStatusInactive = "inactive"
+)
+
+// Tenant represents a tenant in the multi-tenant auth system.
+// Each tenant has its own isolated set of users, clients, and configuration.
+type Tenant struct {
+	ID     uuid.UUID `json:"id"     db:"id"`
+	Slug   string    `json:"slug"   db:"slug"`
+	Name   string    `json:"name"   db:"name"`
+	Active bool      `json:"active" db:"active"`
+
+	// Per-tenant password policy overrides (nil = use system defaults).
+	PasswordMinLength    *int `json:"password_min_length,omitempty"    db:"password_min_length"`
+	PasswordMaxLength    *int `json:"password_max_length,omitempty"    db:"password_max_length"`
+	PasswordMaxAgeDays   *int `json:"password_max_age_days,omitempty"  db:"password_max_age_days"`
+	PasswordHistoryCount *int `json:"password_history_count,omitempty" db:"password_history_count"`
+
+	// MFA enforcement for the tenant.
+	MFAEnforced bool `json:"mfa_enforced" db:"mfa_enforced"`
+
+	// Allowed OAuth providers (nil = all allowed).
+	AllowedOAuthProviders []string `json:"allowed_oauth_providers,omitempty" db:"allowed_oauth_providers"`
+
+	// Custom token TTLs in seconds (nil = use system defaults).
+	AccessTokenTTL  *int `json:"access_token_ttl,omitempty"  db:"access_token_ttl"`
+	RefreshTokenTTL *int `json:"refresh_token_ttl,omitempty" db:"refresh_token_ttl"`
+
+	CreatedAt time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
+}
+
+// IsActive returns true if the tenant is active.
+func (t *Tenant) IsActive() bool {
+	return t.Active
+}
+
+// EffectivePasswordPolicy returns the tenant's password policy, falling back
+// to the provided system defaults for any fields not overridden.
+func (t *Tenant) EffectivePasswordPolicy(defaults PasswordPolicy) PasswordPolicy {
+	p := defaults
+	if t.PasswordMinLength != nil {
+		p.MinLength = *t.PasswordMinLength
+	}
+	if t.PasswordMaxLength != nil {
+		p.MaxLength = *t.PasswordMaxLength
+	}
+	if t.PasswordMaxAgeDays != nil {
+		p.MaxAgeDays = *t.PasswordMaxAgeDays
+	}
+	if t.PasswordHistoryCount != nil {
+		p.HistoryCount = *t.PasswordHistoryCount
+	}
+	return p
+}

--- a/internal/domain/tenant_test.go
+++ b/internal/domain/tenant_test.go
@@ -1,0 +1,73 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTenant_IsActive(t *testing.T) {
+	tests := []struct {
+		name   string
+		active bool
+		want   bool
+	}{
+		{"active tenant", true, true},
+		{"inactive tenant", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tenant := &Tenant{Active: tt.active}
+			assert.Equal(t, tt.want, tenant.IsActive())
+		})
+	}
+}
+
+func TestTenant_EffectivePasswordPolicy(t *testing.T) {
+	defaults := PasswordPolicy{
+		MinLength:    15,
+		MaxLength:    128,
+		MaxAgeDays:   0,
+		HistoryCount: 5,
+	}
+
+	t.Run("no overrides returns defaults", func(t *testing.T) {
+		tenant := &Tenant{}
+		got := tenant.EffectivePasswordPolicy(defaults)
+		assert.Equal(t, defaults, got)
+	})
+
+	t.Run("partial overrides", func(t *testing.T) {
+		minLen := 20
+		histCount := 10
+		tenant := &Tenant{
+			PasswordMinLength:    &minLen,
+			PasswordHistoryCount: &histCount,
+		}
+		got := tenant.EffectivePasswordPolicy(defaults)
+		assert.Equal(t, 20, got.MinLength)
+		assert.Equal(t, 128, got.MaxLength)    // default
+		assert.Equal(t, 0, got.MaxAgeDays)     // default
+		assert.Equal(t, 10, got.HistoryCount)
+	})
+
+	t.Run("all overrides", func(t *testing.T) {
+		minLen := 8
+		maxLen := 64
+		maxAge := 90
+		histCount := 3
+		tenant := &Tenant{
+			PasswordMinLength:    &minLen,
+			PasswordMaxLength:    &maxLen,
+			PasswordMaxAgeDays:   &maxAge,
+			PasswordHistoryCount: &histCount,
+		}
+		got := tenant.EffectivePasswordPolicy(defaults)
+		assert.Equal(t, PasswordPolicy{
+			MinLength:    8,
+			MaxLength:    64,
+			MaxAgeDays:   90,
+			HistoryCount: 3,
+		}, got)
+	})
+}

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -5,6 +5,7 @@ import "time"
 // User represents a user account in the system.
 type User struct {
 	ID                        string
+	TenantID                  string
 	Email                     string
 	PasswordHash              string
 	Name                      string
@@ -39,6 +40,7 @@ type PasswordPolicy struct {
 // PasswordHistoryEntry represents a historical password hash for reuse detection.
 type PasswordHistoryEntry struct {
 	ID           string
+	TenantID     string
 	UserID       string
 	PasswordHash string
 	CreatedAt    time.Time
@@ -47,6 +49,7 @@ type PasswordHistoryEntry struct {
 // RefreshTokenRecord represents a stored refresh token signature in the database.
 type RefreshTokenRecord struct {
 	Signature string
+	TenantID  string
 	UserID    string
 	ExpiresAt time.Time
 	CreatedAt time.Time

--- a/internal/domain/webhook.go
+++ b/internal/domain/webhook.go
@@ -25,6 +25,7 @@ const MaxWebhookFailures = 10
 // Webhook represents a webhook subscription that receives event notifications via HTTP POST.
 type Webhook struct {
 	ID           uuid.UUID `json:"id"            db:"id"`
+	TenantID     string    `json:"tenant_id"     db:"tenant_id"`
 	URL          string    `json:"url"           db:"url"`
 	SecretHash   string    `json:"-"             db:"secret_hash"`
 	EventTypes   []string  `json:"event_types"   db:"event_types"`
@@ -37,6 +38,7 @@ type Webhook struct {
 // WebhookDelivery represents a single delivery attempt for a webhook event.
 type WebhookDelivery struct {
 	ID           uuid.UUID  `json:"id"                      db:"id"`
+	TenantID     string     `json:"tenant_id"               db:"tenant_id"`
 	WebhookID    uuid.UUID  `json:"webhook_id"              db:"webhook_id"`
 	EventType    string     `json:"event_type"              db:"event_type"`
 	Payload      string     `json:"payload"                 db:"payload"`

--- a/migrations/000015_multi_tenancy.down.sql
+++ b/migrations/000015_multi_tenancy.down.sql
@@ -1,0 +1,160 @@
+-- 000015_multi_tenancy.down.sql
+-- Reverts multi-tenancy: drops RLS policies, tenant_id columns, and tenants table.
+
+BEGIN;
+
+-- ============================================================================
+-- 1. Drop RLS policies and disable RLS
+-- ============================================================================
+DROP POLICY IF EXISTS tenant_isolation_password_history ON password_history;
+ALTER TABLE password_history DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation_agent_credentials ON agent_credentials;
+ALTER TABLE agent_credentials DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation_client_rar_allowed_types ON client_rar_allowed_types;
+ALTER TABLE client_rar_allowed_types DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation_rar_resource_types ON rar_resource_types;
+ALTER TABLE rar_resource_types DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation_saml_accounts ON saml_accounts;
+ALTER TABLE saml_accounts DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation_saml_idp_configs ON saml_idp_configs;
+ALTER TABLE saml_idp_configs DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation_audit_logs ON audit_logs;
+ALTER TABLE audit_logs DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation_casbin_policies ON casbin_policies;
+ALTER TABLE casbin_policies DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation_webhook_deliveries ON webhook_deliveries;
+ALTER TABLE webhook_deliveries DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation_webhooks ON webhooks;
+ALTER TABLE webhooks DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation_mfa_backup_codes ON mfa_backup_codes;
+ALTER TABLE mfa_backup_codes DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation_mfa_secrets ON mfa_secrets;
+ALTER TABLE mfa_secrets DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation_oauth_accounts ON oauth_accounts;
+ALTER TABLE oauth_accounts DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation_refresh_tokens ON refresh_tokens;
+ALTER TABLE refresh_tokens DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation_clients ON clients;
+ALTER TABLE clients DISABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation_users ON users;
+ALTER TABLE users DISABLE ROW LEVEL SECURITY;
+
+-- ============================================================================
+-- 2. Drop tenant_id columns (cascades indexes and FK constraints)
+-- ============================================================================
+
+-- password_history
+ALTER TABLE password_history DROP CONSTRAINT IF EXISTS fk_password_history_tenant;
+DROP INDEX IF EXISTS idx_password_history_tenant_id;
+ALTER TABLE password_history DROP COLUMN IF EXISTS tenant_id;
+
+-- agent_credentials
+ALTER TABLE agent_credentials DROP CONSTRAINT IF EXISTS fk_agent_credentials_tenant;
+DROP INDEX IF EXISTS idx_agent_credentials_tenant_id;
+ALTER TABLE agent_credentials DROP COLUMN IF EXISTS tenant_id;
+
+-- client_rar_allowed_types
+ALTER TABLE client_rar_allowed_types DROP CONSTRAINT IF EXISTS fk_client_rar_allowed_types_tenant;
+DROP INDEX IF EXISTS idx_client_rar_allowed_types_tenant_id;
+ALTER TABLE client_rar_allowed_types DROP COLUMN IF EXISTS tenant_id;
+
+-- rar_resource_types
+ALTER TABLE rar_resource_types DROP CONSTRAINT IF EXISTS fk_rar_resource_types_tenant;
+DROP INDEX IF EXISTS idx_rar_resource_types_tenant_id;
+ALTER TABLE rar_resource_types DROP CONSTRAINT IF EXISTS rar_resource_types_type_tenant_unique;
+ALTER TABLE rar_resource_types DROP COLUMN IF EXISTS tenant_id;
+ALTER TABLE rar_resource_types ADD CONSTRAINT rar_resource_types_type_key UNIQUE (type);
+
+-- saml_accounts
+ALTER TABLE saml_accounts DROP CONSTRAINT IF EXISTS fk_saml_accounts_tenant;
+DROP INDEX IF EXISTS idx_saml_accounts_tenant_id;
+ALTER TABLE saml_accounts DROP CONSTRAINT IF EXISTS saml_accounts_idp_name_tenant_unique;
+ALTER TABLE saml_accounts DROP COLUMN IF EXISTS tenant_id;
+ALTER TABLE saml_accounts ADD CONSTRAINT saml_accounts_idp_id_name_id_key UNIQUE (idp_id, name_id);
+
+-- saml_idp_configs
+ALTER TABLE saml_idp_configs DROP CONSTRAINT IF EXISTS fk_saml_idp_configs_tenant;
+DROP INDEX IF EXISTS idx_saml_idp_configs_tenant_id;
+ALTER TABLE saml_idp_configs DROP CONSTRAINT IF EXISTS saml_idp_configs_entity_tenant_unique;
+ALTER TABLE saml_idp_configs DROP COLUMN IF EXISTS tenant_id;
+ALTER TABLE saml_idp_configs ADD CONSTRAINT saml_idp_configs_entity_id_key UNIQUE (entity_id);
+
+-- audit_logs
+ALTER TABLE audit_logs DROP CONSTRAINT IF EXISTS fk_audit_logs_tenant;
+DROP INDEX IF EXISTS idx_audit_logs_tenant_id;
+DROP INDEX IF EXISTS idx_audit_logs_tenant_event;
+ALTER TABLE audit_logs DROP COLUMN IF EXISTS tenant_id;
+
+-- casbin_policies
+ALTER TABLE casbin_policies DROP CONSTRAINT IF EXISTS fk_casbin_policies_tenant;
+DROP INDEX IF EXISTS idx_casbin_policies_tenant_id;
+ALTER TABLE casbin_policies DROP COLUMN IF EXISTS tenant_id;
+
+-- webhook_deliveries
+ALTER TABLE webhook_deliveries DROP CONSTRAINT IF EXISTS fk_webhook_deliveries_tenant;
+DROP INDEX IF EXISTS idx_webhook_deliveries_tenant_id;
+ALTER TABLE webhook_deliveries DROP COLUMN IF EXISTS tenant_id;
+
+-- webhooks
+ALTER TABLE webhooks DROP CONSTRAINT IF EXISTS fk_webhooks_tenant;
+DROP INDEX IF EXISTS idx_webhooks_tenant_id;
+ALTER TABLE webhooks DROP COLUMN IF EXISTS tenant_id;
+
+-- mfa_backup_codes
+ALTER TABLE mfa_backup_codes DROP CONSTRAINT IF EXISTS fk_mfa_backup_codes_tenant;
+DROP INDEX IF EXISTS idx_mfa_backup_codes_tenant_id;
+ALTER TABLE mfa_backup_codes DROP COLUMN IF EXISTS tenant_id;
+
+-- mfa_secrets
+ALTER TABLE mfa_secrets DROP CONSTRAINT IF EXISTS fk_mfa_secrets_tenant;
+DROP INDEX IF EXISTS idx_mfa_secrets_tenant_id;
+ALTER TABLE mfa_secrets DROP COLUMN IF EXISTS tenant_id;
+
+-- oauth_accounts
+ALTER TABLE oauth_accounts DROP CONSTRAINT IF EXISTS fk_oauth_accounts_tenant;
+DROP INDEX IF EXISTS idx_oauth_accounts_tenant_id;
+ALTER TABLE oauth_accounts DROP CONSTRAINT IF EXISTS oauth_accounts_provider_tenant_unique;
+ALTER TABLE oauth_accounts DROP COLUMN IF EXISTS tenant_id;
+ALTER TABLE oauth_accounts ADD CONSTRAINT oauth_accounts_provider_provider_user_id_key UNIQUE (provider, provider_user_id);
+
+-- refresh_tokens
+ALTER TABLE refresh_tokens DROP CONSTRAINT IF EXISTS fk_refresh_tokens_tenant;
+DROP INDEX IF EXISTS idx_refresh_tokens_tenant_id;
+ALTER TABLE refresh_tokens DROP COLUMN IF EXISTS tenant_id;
+
+-- clients
+ALTER TABLE clients DROP CONSTRAINT IF EXISTS fk_clients_tenant;
+DROP INDEX IF EXISTS idx_clients_tenant_id;
+ALTER TABLE clients DROP CONSTRAINT IF EXISTS clients_name_tenant_unique;
+ALTER TABLE clients DROP COLUMN IF EXISTS tenant_id;
+ALTER TABLE clients ADD CONSTRAINT clients_name_key UNIQUE (name);
+
+-- users
+ALTER TABLE users DROP CONSTRAINT IF EXISTS fk_users_tenant;
+DROP INDEX IF EXISTS idx_users_tenant_id;
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_email_tenant_unique;
+ALTER TABLE users DROP COLUMN IF EXISTS tenant_id;
+ALTER TABLE users ADD CONSTRAINT users_email_key UNIQUE (email);
+
+-- ============================================================================
+-- 3. Drop the tenants table
+-- ============================================================================
+DROP INDEX IF EXISTS idx_tenants_active;
+DROP TABLE IF EXISTS tenants;
+
+COMMIT;

--- a/migrations/000015_multi_tenancy.up.sql
+++ b/migrations/000015_multi_tenancy.up.sql
@@ -1,0 +1,328 @@
+-- 000015_multi_tenancy.up.sql
+-- Adds multi-tenancy support: tenants table, tenant_id columns, RLS policies,
+-- composite indexes, and per-tenant unique constraints.
+
+BEGIN;
+
+-- ============================================================================
+-- 1. Create the tenants table
+-- ============================================================================
+CREATE TABLE tenants (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    slug            TEXT NOT NULL,
+    name            TEXT NOT NULL,
+    active          BOOLEAN NOT NULL DEFAULT true,
+
+    -- Per-tenant password policy overrides (NULL = use system defaults)
+    password_min_length    INTEGER,
+    password_max_length    INTEGER,
+    password_max_age_days  INTEGER,
+    password_history_count INTEGER,
+
+    -- MFA enforcement
+    mfa_enforced    BOOLEAN NOT NULL DEFAULT false,
+
+    -- Allowed OAuth providers (NULL = all allowed)
+    allowed_oauth_providers TEXT[],
+
+    -- Custom token TTLs in seconds (NULL = use system defaults)
+    access_token_ttl  INTEGER,
+    refresh_token_ttl INTEGER,
+
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT tenants_slug_unique UNIQUE (slug)
+);
+
+CREATE INDEX idx_tenants_active ON tenants (active) WHERE active = true;
+
+-- ============================================================================
+-- 2. Add tenant_id to all existing tables
+-- ============================================================================
+
+-- A default tenant is required so existing rows can reference it.
+-- The application must create a real default tenant during bootstrap;
+-- this UUID is a deterministic placeholder used only during migration.
+INSERT INTO tenants (id, slug, name, active)
+VALUES ('00000000-0000-0000-0000-000000000001', 'default', 'Default Tenant', true)
+ON CONFLICT (slug) DO NOTHING;
+
+-- -- users ------------------------------------------------------------------
+ALTER TABLE users
+    ADD COLUMN tenant_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001';
+
+ALTER TABLE users ALTER COLUMN tenant_id DROP DEFAULT;
+
+-- Replace global email uniqueness with per-tenant uniqueness.
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_email_key;
+ALTER TABLE users ADD CONSTRAINT users_email_tenant_unique UNIQUE (tenant_id, email);
+
+ALTER TABLE users
+    ADD CONSTRAINT fk_users_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+
+CREATE INDEX idx_users_tenant_id ON users (tenant_id);
+
+-- -- clients ----------------------------------------------------------------
+ALTER TABLE clients
+    ADD COLUMN tenant_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001';
+
+ALTER TABLE clients ALTER COLUMN tenant_id DROP DEFAULT;
+
+-- Replace global name uniqueness with per-tenant uniqueness.
+ALTER TABLE clients DROP CONSTRAINT IF EXISTS clients_name_key;
+ALTER TABLE clients ADD CONSTRAINT clients_name_tenant_unique UNIQUE (tenant_id, name);
+
+ALTER TABLE clients
+    ADD CONSTRAINT fk_clients_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+
+CREATE INDEX idx_clients_tenant_id ON clients (tenant_id);
+
+-- -- refresh_tokens ---------------------------------------------------------
+ALTER TABLE refresh_tokens
+    ADD COLUMN tenant_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001';
+
+ALTER TABLE refresh_tokens ALTER COLUMN tenant_id DROP DEFAULT;
+
+ALTER TABLE refresh_tokens
+    ADD CONSTRAINT fk_refresh_tokens_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+
+CREATE INDEX idx_refresh_tokens_tenant_id ON refresh_tokens (tenant_id);
+
+-- -- oauth_accounts ---------------------------------------------------------
+ALTER TABLE oauth_accounts
+    ADD COLUMN tenant_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001';
+
+ALTER TABLE oauth_accounts ALTER COLUMN tenant_id DROP DEFAULT;
+
+-- Provider+provider_user_id should be unique per tenant, not globally.
+ALTER TABLE oauth_accounts DROP CONSTRAINT IF EXISTS oauth_accounts_provider_provider_user_id_key;
+ALTER TABLE oauth_accounts ADD CONSTRAINT oauth_accounts_provider_tenant_unique
+    UNIQUE (tenant_id, provider, provider_user_id);
+
+ALTER TABLE oauth_accounts
+    ADD CONSTRAINT fk_oauth_accounts_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+
+CREATE INDEX idx_oauth_accounts_tenant_id ON oauth_accounts (tenant_id);
+
+-- -- mfa_secrets ------------------------------------------------------------
+ALTER TABLE mfa_secrets
+    ADD COLUMN tenant_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001';
+
+ALTER TABLE mfa_secrets ALTER COLUMN tenant_id DROP DEFAULT;
+
+ALTER TABLE mfa_secrets
+    ADD CONSTRAINT fk_mfa_secrets_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+
+CREATE INDEX idx_mfa_secrets_tenant_id ON mfa_secrets (tenant_id);
+
+-- -- mfa_backup_codes -------------------------------------------------------
+ALTER TABLE mfa_backup_codes
+    ADD COLUMN tenant_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001';
+
+ALTER TABLE mfa_backup_codes ALTER COLUMN tenant_id DROP DEFAULT;
+
+ALTER TABLE mfa_backup_codes
+    ADD CONSTRAINT fk_mfa_backup_codes_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+
+CREATE INDEX idx_mfa_backup_codes_tenant_id ON mfa_backup_codes (tenant_id);
+
+-- -- webhooks ---------------------------------------------------------------
+ALTER TABLE webhooks
+    ADD COLUMN tenant_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001';
+
+ALTER TABLE webhooks ALTER COLUMN tenant_id DROP DEFAULT;
+
+ALTER TABLE webhooks
+    ADD CONSTRAINT fk_webhooks_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+
+CREATE INDEX idx_webhooks_tenant_id ON webhooks (tenant_id);
+
+-- -- webhook_deliveries -----------------------------------------------------
+ALTER TABLE webhook_deliveries
+    ADD COLUMN tenant_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001';
+
+ALTER TABLE webhook_deliveries ALTER COLUMN tenant_id DROP DEFAULT;
+
+ALTER TABLE webhook_deliveries
+    ADD CONSTRAINT fk_webhook_deliveries_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+
+CREATE INDEX idx_webhook_deliveries_tenant_id ON webhook_deliveries (tenant_id);
+
+-- -- casbin_policies --------------------------------------------------------
+ALTER TABLE casbin_policies
+    ADD COLUMN tenant_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001';
+
+ALTER TABLE casbin_policies ALTER COLUMN tenant_id DROP DEFAULT;
+
+ALTER TABLE casbin_policies
+    ADD CONSTRAINT fk_casbin_policies_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+
+CREATE INDEX idx_casbin_policies_tenant_id ON casbin_policies (tenant_id);
+
+-- -- audit_logs -------------------------------------------------------------
+ALTER TABLE audit_logs
+    ADD COLUMN tenant_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001';
+
+ALTER TABLE audit_logs ALTER COLUMN tenant_id DROP DEFAULT;
+
+ALTER TABLE audit_logs
+    ADD CONSTRAINT fk_audit_logs_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+
+-- Composite index for tenant-scoped audit queries (replaces or supplements existing).
+CREATE INDEX idx_audit_logs_tenant_id ON audit_logs (tenant_id);
+CREATE INDEX idx_audit_logs_tenant_event ON audit_logs (tenant_id, event_type, created_at DESC);
+
+-- -- saml_idp_configs -------------------------------------------------------
+ALTER TABLE saml_idp_configs
+    ADD COLUMN tenant_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001';
+
+ALTER TABLE saml_idp_configs ALTER COLUMN tenant_id DROP DEFAULT;
+
+-- Entity ID should be unique per tenant, not globally.
+ALTER TABLE saml_idp_configs DROP CONSTRAINT IF EXISTS saml_idp_configs_entity_id_key;
+ALTER TABLE saml_idp_configs ADD CONSTRAINT saml_idp_configs_entity_tenant_unique
+    UNIQUE (tenant_id, entity_id);
+
+ALTER TABLE saml_idp_configs
+    ADD CONSTRAINT fk_saml_idp_configs_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+
+CREATE INDEX idx_saml_idp_configs_tenant_id ON saml_idp_configs (tenant_id);
+
+-- -- saml_accounts ----------------------------------------------------------
+ALTER TABLE saml_accounts
+    ADD COLUMN tenant_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001';
+
+ALTER TABLE saml_accounts ALTER COLUMN tenant_id DROP DEFAULT;
+
+-- IdP+NameID should be unique per tenant.
+ALTER TABLE saml_accounts DROP CONSTRAINT IF EXISTS saml_accounts_idp_id_name_id_key;
+ALTER TABLE saml_accounts ADD CONSTRAINT saml_accounts_idp_name_tenant_unique
+    UNIQUE (tenant_id, idp_id, name_id);
+
+ALTER TABLE saml_accounts
+    ADD CONSTRAINT fk_saml_accounts_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+
+CREATE INDEX idx_saml_accounts_tenant_id ON saml_accounts (tenant_id);
+
+-- -- rar_resource_types -----------------------------------------------------
+ALTER TABLE rar_resource_types
+    ADD COLUMN tenant_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001';
+
+ALTER TABLE rar_resource_types ALTER COLUMN tenant_id DROP DEFAULT;
+
+-- Type should be unique per tenant, not globally.
+ALTER TABLE rar_resource_types DROP CONSTRAINT IF EXISTS rar_resource_types_type_key;
+ALTER TABLE rar_resource_types ADD CONSTRAINT rar_resource_types_type_tenant_unique
+    UNIQUE (tenant_id, type);
+
+ALTER TABLE rar_resource_types
+    ADD CONSTRAINT fk_rar_resource_types_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+
+CREATE INDEX idx_rar_resource_types_tenant_id ON rar_resource_types (tenant_id);
+
+-- -- client_rar_allowed_types -----------------------------------------------
+ALTER TABLE client_rar_allowed_types
+    ADD COLUMN tenant_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001';
+
+ALTER TABLE client_rar_allowed_types ALTER COLUMN tenant_id DROP DEFAULT;
+
+ALTER TABLE client_rar_allowed_types
+    ADD CONSTRAINT fk_client_rar_allowed_types_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+
+CREATE INDEX idx_client_rar_allowed_types_tenant_id ON client_rar_allowed_types (tenant_id);
+
+-- -- agent_credentials (credential_vault) -----------------------------------
+ALTER TABLE agent_credentials
+    ADD COLUMN tenant_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001';
+
+ALTER TABLE agent_credentials ALTER COLUMN tenant_id DROP DEFAULT;
+
+ALTER TABLE agent_credentials
+    ADD CONSTRAINT fk_agent_credentials_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+
+CREATE INDEX idx_agent_credentials_tenant_id ON agent_credentials (tenant_id);
+
+-- -- password_history -------------------------------------------------------
+ALTER TABLE password_history
+    ADD COLUMN tenant_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001';
+
+ALTER TABLE password_history ALTER COLUMN tenant_id DROP DEFAULT;
+
+ALTER TABLE password_history
+    ADD CONSTRAINT fk_password_history_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+
+CREATE INDEX idx_password_history_tenant_id ON password_history (tenant_id);
+
+-- ============================================================================
+-- 3. Row-Level Security (RLS) policies for tenant isolation
+-- ============================================================================
+-- RLS ensures that queries scoped to a tenant cannot access other tenants'
+-- data, even if application-level filtering is bypassed. The application sets
+-- the current tenant via: SET LOCAL app.current_tenant = '<tenant-id>';
+
+ALTER TABLE users ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_users ON users
+    USING (tenant_id = current_setting('app.current_tenant')::UUID);
+
+ALTER TABLE clients ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_clients ON clients
+    USING (tenant_id = current_setting('app.current_tenant')::UUID);
+
+ALTER TABLE refresh_tokens ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_refresh_tokens ON refresh_tokens
+    USING (tenant_id = current_setting('app.current_tenant')::UUID);
+
+ALTER TABLE oauth_accounts ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_oauth_accounts ON oauth_accounts
+    USING (tenant_id = current_setting('app.current_tenant')::UUID);
+
+ALTER TABLE mfa_secrets ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_mfa_secrets ON mfa_secrets
+    USING (tenant_id = current_setting('app.current_tenant')::UUID);
+
+ALTER TABLE mfa_backup_codes ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_mfa_backup_codes ON mfa_backup_codes
+    USING (tenant_id = current_setting('app.current_tenant')::UUID);
+
+ALTER TABLE webhooks ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_webhooks ON webhooks
+    USING (tenant_id = current_setting('app.current_tenant')::UUID);
+
+ALTER TABLE webhook_deliveries ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_webhook_deliveries ON webhook_deliveries
+    USING (tenant_id = current_setting('app.current_tenant')::UUID);
+
+ALTER TABLE casbin_policies ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_casbin_policies ON casbin_policies
+    USING (tenant_id = current_setting('app.current_tenant')::UUID);
+
+ALTER TABLE audit_logs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_audit_logs ON audit_logs
+    USING (tenant_id = current_setting('app.current_tenant')::UUID);
+
+ALTER TABLE saml_idp_configs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_saml_idp_configs ON saml_idp_configs
+    USING (tenant_id = current_setting('app.current_tenant')::UUID);
+
+ALTER TABLE saml_accounts ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_saml_accounts ON saml_accounts
+    USING (tenant_id = current_setting('app.current_tenant')::UUID);
+
+ALTER TABLE rar_resource_types ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_rar_resource_types ON rar_resource_types
+    USING (tenant_id = current_setting('app.current_tenant')::UUID);
+
+ALTER TABLE client_rar_allowed_types ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_client_rar_allowed_types ON client_rar_allowed_types
+    USING (tenant_id = current_setting('app.current_tenant')::UUID);
+
+ALTER TABLE agent_credentials ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_agent_credentials ON agent_credentials
+    USING (tenant_id = current_setting('app.current_tenant')::UUID);
+
+ALTER TABLE password_history ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_password_history ON password_history
+    USING (tenant_id = current_setting('app.current_tenant')::UUID);
+
+COMMIT;


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-352.

Closes #352

## Changes

Create migration `000015_multi_tenancy.up.sql` that adds the `tenants` table (with per-tenant config columns: password policy overrides, MFA enforcement, allowed OAuth providers, custom token TTLs), adds `tenant_id UUID NOT NULL` column to all existing tables (users, clients, refresh_tokens, oauth_accounts, mfa_tables, webhooks, casbin_policies, audit_logs, saml tables, rar tables, password_history, credential_vault), creates composite indexes including tenant_id, sets up PostgreSQL Row-Level Security policies for tenant isolation, and updates unique constraints (e.g., users.email becomes unique per tenant, not globally). In `internal/domain/`, add the `Tenant` model (ID, slug, name, active status, per-tenant config fields) and add `TenantID string` field to `User`, `Client`, and other relevant domain structs. Packages: `migrations/`, `internal/domain/`