### PR TITLE
GH-353: Tenant service and repository

### DIFF
--- a/.agent/tasks/gh-353.md
+++ b/.agent/tasks/gh-353.md
@@ -1,0 +1,10 @@
+# GH-353
+
+**Created:** 2026-04-07
+
+## Problem
+
+Create new `internal/tenant/` package containing: a `Repository` interface and PostgreSQL implementation for tenant CRUD (Create, FindByID, FindBySlug, List, Update, Delete), a `Service` layer wrapping the repository with business logic and validation, and an implementation of `middleware.TenantResolver` that queries the tenants table (bridging the existing middleware interface to the new storage). Extend `internal/config/` with any additional tenant-related configuration knobs needed for per-tenant overrides (defaults for new tenants, etc.). Packages: `internal/tenant/` (new), `internal/config/`
+
+## Acceptance Criteria
+

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,9 @@ type TenantConfig struct {
 	ResolutionMode string        // TENANT_RESOLUTION_MODE: "subdomain", "header", or "both" (default "both")
 	BaseDomain     string        // TENANT_BASE_DOMAIN: base domain for subdomain parsing (e.g. "auth.quantflow.studio")
 	CacheTTL       time.Duration // TENANT_CACHE_TTL: how long to cache tenant lookups
+	SlugMinLength  int           // TENANT_SLUG_MIN_LENGTH: minimum slug length for new tenants (default 2)
+	SlugMaxLength  int           // TENANT_SLUG_MAX_LENGTH: maximum slug length for new tenants (default 63)
+	NameMaxLength  int           // TENANT_NAME_MAX_LENGTH: maximum display name length (default 128)
 }
 
 // SAMLConfig holds SAML Service Provider settings.
@@ -736,11 +739,27 @@ func loadTenant(l *loader) (TenantConfig, error) {
 		return TenantConfig{}, fmt.Errorf("TENANT_CACHE_TTL: %w", err)
 	}
 
+	slugMinLen, err := l.optInt("TENANT_SLUG_MIN_LENGTH", 2)
+	if err != nil {
+		return TenantConfig{}, err
+	}
+	slugMaxLen, err := l.optInt("TENANT_SLUG_MAX_LENGTH", 63)
+	if err != nil {
+		return TenantConfig{}, err
+	}
+	nameMaxLen, err := l.optInt("TENANT_NAME_MAX_LENGTH", 128)
+	if err != nil {
+		return TenantConfig{}, err
+	}
+
 	return TenantConfig{
 		DefaultID:      defaultID,
 		ResolutionMode: mode,
 		BaseDomain:     baseDomain,
 		CacheTTL:       cacheTTL,
+		SlugMinLength:  slugMinLen,
+		SlugMaxLength:  slugMaxLen,
+		NameMaxLength:  nameMaxLen,
 	}, nil
 }
 

--- a/internal/domain/sentinel_errors.go
+++ b/internal/domain/sentinel_errors.go
@@ -41,6 +41,10 @@ var (
 	ErrRARTooManyActions   = errors.New("too many actions in authorization detail")
 	ErrRARTooManyDataTypes = errors.New("too many datatypes in authorization detail")
 
+	// Tenant errors.
+	ErrTenantNotFound = errors.New("tenant not found")
+	ErrTenantInactive = errors.New("tenant inactive")
+
 	// OAuth errors.
 	ErrOAuthProviderNotSupported = errors.New("oauth provider not supported")
 	ErrOAuthAccountAlreadyLinked = errors.New("oauth account already linked")

--- a/internal/domain/tenant.go
+++ b/internal/domain/tenant.go
@@ -1,0 +1,19 @@
+package domain
+
+import "time"
+
+// Tenant represents a tenant in the multi-tenant auth service.
+type Tenant struct {
+	ID        string     `json:"id"         db:"id"`
+	Slug      string     `json:"slug"       db:"slug"`
+	Name      string     `json:"name"       db:"name"`
+	Active    bool       `json:"active"     db:"active"`
+	CreatedAt time.Time  `json:"created_at" db:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at" db:"updated_at"`
+	DeletedAt *time.Time `json:"deleted_at" db:"deleted_at"`
+}
+
+// IsActive returns true if the tenant is active and not soft-deleted.
+func (t *Tenant) IsActive() bool {
+	return t.Active && t.DeletedAt == nil
+}

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -56,4 +56,7 @@ var (
 
 	// ErrDuplicateSAMLAccount indicates a SAML account with the same IdP + NameID already exists.
 	ErrDuplicateSAMLAccount = errors.New("duplicate saml account")
+
+	// ErrDuplicateTenantSlug indicates a tenant with the given slug already exists.
+	ErrDuplicateTenantSlug = errors.New("duplicate tenant slug")
 )

--- a/internal/storage/mocks/mocks_test.go
+++ b/internal/storage/mocks/mocks_test.go
@@ -14,4 +14,5 @@ func TestInterfaceCompliance(t *testing.T) {
 	var _ storage.ClientRepository = (*mocks.MockClientRepository)(nil)
 	var _ storage.RefreshTokenRepository = (*mocks.MockRefreshTokenRepository)(nil)
 	var _ storage.OAuthAccountRepository = (*mocks.MockOAuthAccountRepository)(nil)
+	var _ storage.TenantRepository = (*mocks.MockTenantRepository)(nil)
 }

--- a/internal/storage/mocks/tenant_repository.go
+++ b/internal/storage/mocks/tenant_repository.go
@@ -1,0 +1,47 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// MockTenantRepository is a configurable mock for storage.TenantRepository.
+type MockTenantRepository struct {
+	CreateFn     func(ctx context.Context, tenant *domain.Tenant) (*domain.Tenant, error)
+	FindByIDFn   func(ctx context.Context, id string) (*domain.Tenant, error)
+	FindBySlugFn func(ctx context.Context, slug string) (*domain.Tenant, error)
+	ListFn       func(ctx context.Context, limit, offset int, includeDeleted bool) ([]*domain.Tenant, int, error)
+	UpdateFn     func(ctx context.Context, tenant *domain.Tenant) (*domain.Tenant, error)
+	DeleteFn     func(ctx context.Context, id string) error
+}
+
+// Create delegates to CreateFn.
+func (m *MockTenantRepository) Create(ctx context.Context, tenant *domain.Tenant) (*domain.Tenant, error) {
+	return m.CreateFn(ctx, tenant)
+}
+
+// FindByID delegates to FindByIDFn.
+func (m *MockTenantRepository) FindByID(ctx context.Context, id string) (*domain.Tenant, error) {
+	return m.FindByIDFn(ctx, id)
+}
+
+// FindBySlug delegates to FindBySlugFn.
+func (m *MockTenantRepository) FindBySlug(ctx context.Context, slug string) (*domain.Tenant, error) {
+	return m.FindBySlugFn(ctx, slug)
+}
+
+// List delegates to ListFn.
+func (m *MockTenantRepository) List(ctx context.Context, limit, offset int, includeDeleted bool) ([]*domain.Tenant, int, error) {
+	return m.ListFn(ctx, limit, offset, includeDeleted)
+}
+
+// Update delegates to UpdateFn.
+func (m *MockTenantRepository) Update(ctx context.Context, tenant *domain.Tenant) (*domain.Tenant, error) {
+	return m.UpdateFn(ctx, tenant)
+}
+
+// Delete delegates to DeleteFn.
+func (m *MockTenantRepository) Delete(ctx context.Context, id string) error {
+	return m.DeleteFn(ctx, id)
+}

--- a/internal/storage/tenant_repository.go
+++ b/internal/storage/tenant_repository.go
@@ -1,0 +1,169 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// TenantRepository defines persistence operations for tenant management.
+type TenantRepository interface {
+	Create(ctx context.Context, tenant *domain.Tenant) (*domain.Tenant, error)
+	FindByID(ctx context.Context, id string) (*domain.Tenant, error)
+	FindBySlug(ctx context.Context, slug string) (*domain.Tenant, error)
+	List(ctx context.Context, limit, offset int, includeDeleted bool) ([]*domain.Tenant, int, error)
+	Update(ctx context.Context, tenant *domain.Tenant) (*domain.Tenant, error)
+	Delete(ctx context.Context, id string) error
+}
+
+// PostgresTenantRepository implements TenantRepository using PostgreSQL.
+type PostgresTenantRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresTenantRepository creates a new PostgreSQL-backed tenant repository.
+func NewPostgresTenantRepository(pool *pgxpool.Pool) *PostgresTenantRepository {
+	return &PostgresTenantRepository{pool: pool}
+}
+
+const tenantColumns = `id, slug, name, active, created_at, updated_at, deleted_at`
+
+func scanTenant(row pgx.Row) (*domain.Tenant, error) {
+	t := &domain.Tenant{}
+	err := row.Scan(&t.ID, &t.Slug, &t.Name, &t.Active, &t.CreatedAt, &t.UpdatedAt, &t.DeletedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return t, nil
+}
+
+// Create inserts a new tenant. Returns ErrDuplicateTenantSlug on slug conflict.
+func (r *PostgresTenantRepository) Create(ctx context.Context, tenant *domain.Tenant) (*domain.Tenant, error) {
+	query := fmt.Sprintf(`
+		INSERT INTO tenants (id, slug, name, active, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING %s`, tenantColumns)
+
+	t, err := scanTenant(r.pool.QueryRow(ctx, query,
+		tenant.ID, tenant.Slug, tenant.Name, tenant.Active,
+		tenant.CreatedAt, tenant.UpdatedAt,
+	))
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return nil, fmt.Errorf("tenant slug %s: %w", tenant.Slug, ErrDuplicateTenantSlug)
+		}
+		return nil, fmt.Errorf("insert tenant: %w", err)
+	}
+	return t, nil
+}
+
+// FindByID retrieves a tenant by primary key (excludes soft-deleted).
+func (r *PostgresTenantRepository) FindByID(ctx context.Context, id string) (*domain.Tenant, error) {
+	query := fmt.Sprintf(`SELECT %s FROM tenants WHERE id = $1 AND deleted_at IS NULL`, tenantColumns)
+	t, err := scanTenant(r.pool.QueryRow(ctx, query, id))
+	if err != nil {
+		return nil, fmt.Errorf("find tenant %s: %w", id, err)
+	}
+	return t, nil
+}
+
+// FindBySlug retrieves a tenant by slug (excludes soft-deleted).
+func (r *PostgresTenantRepository) FindBySlug(ctx context.Context, slug string) (*domain.Tenant, error) {
+	query := fmt.Sprintf(`SELECT %s FROM tenants WHERE slug = $1 AND deleted_at IS NULL`, tenantColumns)
+	t, err := scanTenant(r.pool.QueryRow(ctx, query, slug))
+	if err != nil {
+		return nil, fmt.Errorf("find tenant %s: %w", slug, err)
+	}
+	return t, nil
+}
+
+// List returns a paginated list of tenants. When includeDeleted is false,
+// soft-deleted tenants are excluded.
+func (r *PostgresTenantRepository) List(ctx context.Context, limit, offset int, includeDeleted bool) ([]*domain.Tenant, int, error) {
+	whereClause := ""
+	if !includeDeleted {
+		whereClause = "WHERE deleted_at IS NULL"
+	}
+
+	countQuery := fmt.Sprintf(`SELECT COUNT(*) FROM tenants %s`, whereClause)
+	var total int
+	if err := r.pool.QueryRow(ctx, countQuery).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count tenants: %w", err)
+	}
+
+	query := fmt.Sprintf(`SELECT %s FROM tenants %s ORDER BY created_at DESC LIMIT $1 OFFSET $2`,
+		tenantColumns, whereClause)
+	rows, err := r.pool.Query(ctx, query, limit, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list tenants: %w", err)
+	}
+	defer rows.Close()
+
+	var tenants []*domain.Tenant
+	for rows.Next() {
+		t := &domain.Tenant{}
+		if err := rows.Scan(&t.ID, &t.Slug, &t.Name, &t.Active, &t.CreatedAt, &t.UpdatedAt, &t.DeletedAt); err != nil {
+			return nil, 0, fmt.Errorf("scan tenant: %w", err)
+		}
+		tenants = append(tenants, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate tenants: %w", err)
+	}
+
+	return tenants, total, nil
+}
+
+// Update modifies mutable fields of a tenant (name, slug, active).
+func (r *PostgresTenantRepository) Update(ctx context.Context, tenant *domain.Tenant) (*domain.Tenant, error) {
+	query := fmt.Sprintf(`
+		UPDATE tenants SET name = $1, slug = $2, active = $3, updated_at = $4
+		WHERE id = $5 AND deleted_at IS NULL
+		RETURNING %s`, tenantColumns)
+
+	t, err := scanTenant(r.pool.QueryRow(ctx, query,
+		tenant.Name, tenant.Slug, tenant.Active, time.Now().UTC(), tenant.ID,
+	))
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return nil, fmt.Errorf("tenant slug %s: %w", tenant.Slug, ErrDuplicateTenantSlug)
+		}
+		if errors.Is(err, ErrNotFound) {
+			return nil, fmt.Errorf("tenant %s: %w", tenant.ID, ErrNotFound)
+		}
+		return nil, fmt.Errorf("update tenant: %w", err)
+	}
+	return t, nil
+}
+
+// Delete soft-deletes a tenant by setting deleted_at.
+func (r *PostgresTenantRepository) Delete(ctx context.Context, id string) error {
+	query := `UPDATE tenants SET deleted_at = $1, updated_at = $1 WHERE id = $2 AND deleted_at IS NULL`
+	now := time.Now().UTC()
+
+	tag, err := r.pool.Exec(ctx, query, now, id)
+	if err != nil {
+		return fmt.Errorf("soft delete tenant %s: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		var exists bool
+		_ = r.pool.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM tenants WHERE id = $1)`, id).Scan(&exists)
+		if exists {
+			return fmt.Errorf("tenant %s already deleted: %w", id, ErrAlreadyDeleted)
+		}
+		return fmt.Errorf("tenant %s: %w", id, ErrNotFound)
+	}
+	return nil
+}

--- a/internal/tenant/service.go
+++ b/internal/tenant/service.go
@@ -1,0 +1,224 @@
+// Package tenant provides tenant management and resolution for the multi-tenant auth service.
+package tenant
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/config"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/middleware"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+// slugPattern enforces DNS-safe tenant slugs: lowercase alphanumeric with hyphens,
+// must start and end with alphanumeric.
+var slugPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
+// Service wraps the tenant repository with business logic, validation,
+// and implements middleware.TenantResolver.
+type Service struct {
+	repo   storage.TenantRepository
+	logger *zap.Logger
+	cfg    config.TenantConfig
+}
+
+// NewService creates a new tenant Service.
+func NewService(repo storage.TenantRepository, logger *zap.Logger, cfg config.TenantConfig) *Service {
+	return &Service{repo: repo, logger: logger, cfg: cfg}
+}
+
+// Create validates and persists a new tenant.
+func (s *Service) Create(ctx context.Context, slug, name string) (*domain.Tenant, error) {
+	slug = strings.ToLower(strings.TrimSpace(slug))
+	name = strings.TrimSpace(name)
+
+	if err := s.validateSlug(slug); err != nil {
+		return nil, err
+	}
+	if err := s.validateName(name); err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	tenant := &domain.Tenant{
+		ID:        "tnt_" + generateID(),
+		Slug:      slug,
+		Name:      name,
+		Active:    true,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	created, err := s.repo.Create(ctx, tenant)
+	if err != nil {
+		if errors.Is(err, storage.ErrDuplicateTenantSlug) {
+			return nil, fmt.Errorf("slug %q: %w", slug, storage.ErrDuplicateTenantSlug)
+		}
+		return nil, fmt.Errorf("create tenant: %w", err)
+	}
+
+	s.logger.Info("tenant created", zap.String("tenant_id", created.ID), zap.String("slug", created.Slug))
+	return created, nil
+}
+
+// FindByID returns a tenant by its ID.
+func (s *Service) FindByID(ctx context.Context, id string) (*domain.Tenant, error) {
+	t, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("tenant %s: %w", id, domain.ErrTenantNotFound)
+		}
+		return nil, fmt.Errorf("find tenant: %w", err)
+	}
+	return t, nil
+}
+
+// FindBySlug returns a tenant by its slug.
+func (s *Service) FindBySlug(ctx context.Context, slug string) (*domain.Tenant, error) {
+	t, err := s.repo.FindBySlug(ctx, slug)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("tenant %s: %w", slug, domain.ErrTenantNotFound)
+		}
+		return nil, fmt.Errorf("find tenant: %w", err)
+	}
+	return t, nil
+}
+
+// List returns a paginated list of tenants.
+func (s *Service) List(ctx context.Context, limit, offset int, includeDeleted bool) ([]*domain.Tenant, int, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	return s.repo.List(ctx, limit, offset, includeDeleted)
+}
+
+// Update modifies a tenant's mutable fields.
+func (s *Service) Update(ctx context.Context, id, slug, name string, active *bool) (*domain.Tenant, error) {
+	existing, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("tenant %s: %w", id, domain.ErrTenantNotFound)
+		}
+		return nil, fmt.Errorf("find tenant: %w", err)
+	}
+
+	if slug != "" {
+		slug = strings.ToLower(strings.TrimSpace(slug))
+		if err := s.validateSlug(slug); err != nil {
+			return nil, err
+		}
+		existing.Slug = slug
+	}
+	if name != "" {
+		name = strings.TrimSpace(name)
+		if err := s.validateName(name); err != nil {
+			return nil, err
+		}
+		existing.Name = name
+	}
+	if active != nil {
+		existing.Active = *active
+	}
+
+	updated, err := s.repo.Update(ctx, existing)
+	if err != nil {
+		if errors.Is(err, storage.ErrDuplicateTenantSlug) {
+			return nil, fmt.Errorf("slug %q: %w", existing.Slug, storage.ErrDuplicateTenantSlug)
+		}
+		return nil, fmt.Errorf("update tenant: %w", err)
+	}
+
+	s.logger.Info("tenant updated", zap.String("tenant_id", updated.ID), zap.String("slug", updated.Slug))
+	return updated, nil
+}
+
+// Delete soft-deletes a tenant.
+func (s *Service) Delete(ctx context.Context, id string) error {
+	if err := s.repo.Delete(ctx, id); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return fmt.Errorf("tenant %s: %w", id, domain.ErrTenantNotFound)
+		}
+		if errors.Is(err, storage.ErrAlreadyDeleted) {
+			return fmt.Errorf("tenant %s: %w", id, storage.ErrAlreadyDeleted)
+		}
+		return fmt.Errorf("delete tenant: %w", err)
+	}
+
+	s.logger.Info("tenant deleted", zap.String("tenant_id", id))
+	return nil
+}
+
+// ResolveTenant implements middleware.TenantResolver. It looks up a tenant
+// by ID or slug and returns the middleware-level TenantConfig.
+func (s *Service) ResolveTenant(ctx context.Context, identifier string) (*middleware.TenantConfig, error) {
+	// Try by ID first (IDs have the "tnt_" prefix), then by slug.
+	var t *domain.Tenant
+	var err error
+
+	if strings.HasPrefix(identifier, "tnt_") {
+		t, err = s.repo.FindByID(ctx, identifier)
+	} else {
+		t, err = s.repo.FindBySlug(ctx, identifier)
+	}
+
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("tenant %s: %w", identifier, domain.ErrTenantNotFound)
+		}
+		return nil, fmt.Errorf("resolve tenant: %w", err)
+	}
+
+	return &middleware.TenantConfig{
+		TenantID: t.ID,
+		Name:     t.Name,
+		Active:   t.IsActive(),
+	}, nil
+}
+
+func (s *Service) validateSlug(slug string) error {
+	if len(slug) < s.cfg.SlugMinLength {
+		return fmt.Errorf("slug must be at least %d characters", s.cfg.SlugMinLength)
+	}
+	if len(slug) > s.cfg.SlugMaxLength {
+		return fmt.Errorf("slug must be at most %d characters", s.cfg.SlugMaxLength)
+	}
+	if !slugPattern.MatchString(slug) {
+		return fmt.Errorf("slug must be lowercase alphanumeric with hyphens, starting and ending with alphanumeric")
+	}
+	return nil
+}
+
+func (s *Service) validateName(name string) error {
+	if name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if len(name) > s.cfg.NameMaxLength {
+		return fmt.Errorf("name must be at most %d characters", s.cfg.NameMaxLength)
+	}
+	return nil
+}
+
+func generateID() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// Compile-time assertion that Service implements middleware.TenantResolver.
+var _ middleware.TenantResolver = (*Service)(nil)

--- a/internal/tenant/service_test.go
+++ b/internal/tenant/service_test.go
@@ -1,0 +1,518 @@
+package tenant
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/config"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+// mockTenantRepo is a package-private mock for testing.
+type mockTenantRepo struct {
+	createFn     func(ctx context.Context, tenant *domain.Tenant) (*domain.Tenant, error)
+	findByIDFn   func(ctx context.Context, id string) (*domain.Tenant, error)
+	findBySlugFn func(ctx context.Context, slug string) (*domain.Tenant, error)
+	listFn       func(ctx context.Context, limit, offset int, includeDeleted bool) ([]*domain.Tenant, int, error)
+	updateFn     func(ctx context.Context, tenant *domain.Tenant) (*domain.Tenant, error)
+	deleteFn     func(ctx context.Context, id string) error
+}
+
+func (m *mockTenantRepo) Create(ctx context.Context, tenant *domain.Tenant) (*domain.Tenant, error) {
+	if m.createFn != nil {
+		return m.createFn(ctx, tenant)
+	}
+	return tenant, nil
+}
+
+func (m *mockTenantRepo) FindByID(ctx context.Context, id string) (*domain.Tenant, error) {
+	if m.findByIDFn != nil {
+		return m.findByIDFn(ctx, id)
+	}
+	return nil, storage.ErrNotFound
+}
+
+func (m *mockTenantRepo) FindBySlug(ctx context.Context, slug string) (*domain.Tenant, error) {
+	if m.findBySlugFn != nil {
+		return m.findBySlugFn(ctx, slug)
+	}
+	return nil, storage.ErrNotFound
+}
+
+func (m *mockTenantRepo) List(ctx context.Context, limit, offset int, includeDeleted bool) ([]*domain.Tenant, int, error) {
+	if m.listFn != nil {
+		return m.listFn(ctx, limit, offset, includeDeleted)
+	}
+	return nil, 0, nil
+}
+
+func (m *mockTenantRepo) Update(ctx context.Context, tenant *domain.Tenant) (*domain.Tenant, error) {
+	if m.updateFn != nil {
+		return m.updateFn(ctx, tenant)
+	}
+	return tenant, nil
+}
+
+func (m *mockTenantRepo) Delete(ctx context.Context, id string) error {
+	if m.deleteFn != nil {
+		return m.deleteFn(ctx, id)
+	}
+	return nil
+}
+
+func testCfg() config.TenantConfig {
+	return config.TenantConfig{
+		SlugMinLength: 2,
+		SlugMaxLength: 63,
+		NameMaxLength: 128,
+	}
+}
+
+func testService(repo *mockTenantRepo) *Service {
+	return NewService(repo, zap.NewNop(), testCfg())
+}
+
+func TestCreate(t *testing.T) {
+	tests := []struct {
+		name    string
+		slug    string
+		tName   string
+		setup   func(repo *mockTenantRepo)
+		wantErr string
+	}{
+		{
+			name:  "success",
+			slug:  "acme",
+			tName: "Acme Corp",
+			setup: func(repo *mockTenantRepo) {
+				repo.createFn = func(_ context.Context, tenant *domain.Tenant) (*domain.Tenant, error) {
+					return tenant, nil
+				}
+			},
+		},
+		{
+			name:    "slug too short",
+			slug:    "a",
+			tName:   "Acme Corp",
+			wantErr: "slug must be at least 2 characters",
+		},
+		{
+			name:    "slug invalid characters",
+			slug:    "ACME_Corp",
+			tName:   "Acme Corp",
+			wantErr: "slug must be lowercase alphanumeric",
+		},
+		{
+			name:    "slug starts with hyphen",
+			slug:    "-acme",
+			tName:   "Acme Corp",
+			wantErr: "slug must be lowercase alphanumeric",
+		},
+		{
+			name:    "slug ends with hyphen",
+			slug:    "acme-",
+			tName:   "Acme Corp",
+			wantErr: "slug must be lowercase alphanumeric",
+		},
+		{
+			name:    "empty name",
+			slug:    "acme",
+			tName:   "",
+			wantErr: "name is required",
+		},
+		{
+			name:  "duplicate slug",
+			slug:  "acme",
+			tName: "Acme Corp",
+			setup: func(repo *mockTenantRepo) {
+				repo.createFn = func(_ context.Context, _ *domain.Tenant) (*domain.Tenant, error) {
+					return nil, fmt.Errorf("tenant slug acme: %w", storage.ErrDuplicateTenantSlug)
+				}
+			},
+			wantErr: "duplicate tenant slug",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockTenantRepo{}
+			if tt.setup != nil {
+				tt.setup(repo)
+			}
+			svc := testService(repo)
+
+			result, err := svc.Create(context.Background(), tt.slug, tt.tName)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				assert.Equal(t, tt.slug, result.Slug)
+				assert.Equal(t, tt.tName, result.Name)
+				assert.True(t, result.Active)
+				assert.Contains(t, result.ID, "tnt_")
+			}
+		})
+	}
+}
+
+func TestFindByID(t *testing.T) {
+	now := time.Now().UTC()
+	tenant := &domain.Tenant{ID: "tnt_abc123", Slug: "acme", Name: "Acme", Active: true, CreatedAt: now, UpdatedAt: now}
+
+	tests := []struct {
+		name    string
+		id      string
+		setup   func(repo *mockTenantRepo)
+		wantErr string
+	}{
+		{
+			name: "found",
+			id:   "tnt_abc123",
+			setup: func(repo *mockTenantRepo) {
+				repo.findByIDFn = func(_ context.Context, _ string) (*domain.Tenant, error) {
+					return tenant, nil
+				}
+			},
+		},
+		{
+			name:    "not found",
+			id:      "tnt_nonexistent",
+			wantErr: "tenant not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockTenantRepo{}
+			if tt.setup != nil {
+				tt.setup(repo)
+			}
+			svc := testService(repo)
+
+			result, err := svc.FindByID(context.Background(), tt.id)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tenant.ID, result.ID)
+			}
+		})
+	}
+}
+
+func TestFindBySlug(t *testing.T) {
+	now := time.Now().UTC()
+	tenant := &domain.Tenant{ID: "tnt_abc123", Slug: "acme", Name: "Acme", Active: true, CreatedAt: now, UpdatedAt: now}
+
+	tests := []struct {
+		name    string
+		slug    string
+		setup   func(repo *mockTenantRepo)
+		wantErr string
+	}{
+		{
+			name: "found",
+			slug: "acme",
+			setup: func(repo *mockTenantRepo) {
+				repo.findBySlugFn = func(_ context.Context, _ string) (*domain.Tenant, error) {
+					return tenant, nil
+				}
+			},
+		},
+		{
+			name:    "not found",
+			slug:    "nonexistent",
+			wantErr: "tenant not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockTenantRepo{}
+			if tt.setup != nil {
+				tt.setup(repo)
+			}
+			svc := testService(repo)
+
+			result, err := svc.FindBySlug(context.Background(), tt.slug)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tenant.ID, result.ID)
+			}
+		})
+	}
+}
+
+func TestList(t *testing.T) {
+	tests := []struct {
+		name       string
+		limit      int
+		offset     int
+		wantLimit  int
+		wantOffset int
+	}{
+		{name: "defaults", limit: 0, offset: -1, wantLimit: 20, wantOffset: 0},
+		{name: "clamped max", limit: 200, offset: 0, wantLimit: 100, wantOffset: 0},
+		{name: "normal", limit: 10, offset: 5, wantLimit: 10, wantOffset: 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockTenantRepo{
+				listFn: func(_ context.Context, limit, offset int, _ bool) ([]*domain.Tenant, int, error) {
+					assert.Equal(t, tt.wantLimit, limit)
+					assert.Equal(t, tt.wantOffset, offset)
+					return nil, 0, nil
+				},
+			}
+			svc := testService(repo)
+			_, _, err := svc.List(context.Background(), tt.limit, tt.offset, false)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	now := time.Now().UTC()
+	existing := &domain.Tenant{ID: "tnt_abc", Slug: "acme", Name: "Acme", Active: true, CreatedAt: now, UpdatedAt: now}
+	active := true
+
+	tests := []struct {
+		name    string
+		id      string
+		slug    string
+		tName   string
+		active  *bool
+		setup   func(repo *mockTenantRepo)
+		wantErr string
+	}{
+		{
+			name:   "success",
+			id:     "tnt_abc",
+			slug:   "new-slug",
+			tName:  "New Name",
+			active: &active,
+			setup: func(repo *mockTenantRepo) {
+				repo.findByIDFn = func(_ context.Context, _ string) (*domain.Tenant, error) {
+					cp := *existing
+					return &cp, nil
+				}
+				repo.updateFn = func(_ context.Context, tenant *domain.Tenant) (*domain.Tenant, error) {
+					return tenant, nil
+				}
+			},
+		},
+		{
+			name:    "not found",
+			id:      "tnt_nope",
+			slug:    "slug",
+			wantErr: "tenant not found",
+		},
+		{
+			name:  "invalid slug",
+			id:    "tnt_abc",
+			slug:  "has_underscore",
+			tName: "Name",
+			setup: func(repo *mockTenantRepo) {
+				repo.findByIDFn = func(_ context.Context, _ string) (*domain.Tenant, error) {
+					cp := *existing
+					return &cp, nil
+				}
+			},
+			wantErr: "slug must be lowercase alphanumeric",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockTenantRepo{}
+			if tt.setup != nil {
+				tt.setup(repo)
+			}
+			svc := testService(repo)
+
+			result, err := svc.Update(context.Background(), tt.id, tt.slug, tt.tName, tt.active)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+			}
+		})
+	}
+}
+
+func TestDelete(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      string
+		setup   func(repo *mockTenantRepo)
+		wantErr string
+	}{
+		{
+			name: "success",
+			id:   "tnt_abc",
+		},
+		{
+			name: "not found",
+			id:   "tnt_nope",
+			setup: func(repo *mockTenantRepo) {
+				repo.deleteFn = func(_ context.Context, _ string) error {
+					return fmt.Errorf("tenant tnt_nope: %w", storage.ErrNotFound)
+				}
+			},
+			wantErr: "tenant not found",
+		},
+		{
+			name: "already deleted",
+			id:   "tnt_old",
+			setup: func(repo *mockTenantRepo) {
+				repo.deleteFn = func(_ context.Context, _ string) error {
+					return fmt.Errorf("tenant tnt_old: %w", storage.ErrAlreadyDeleted)
+				}
+			},
+			wantErr: "already deleted",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockTenantRepo{}
+			if tt.setup != nil {
+				tt.setup(repo)
+			}
+			svc := testService(repo)
+
+			err := svc.Delete(context.Background(), tt.id)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestResolveTenant(t *testing.T) {
+	now := time.Now().UTC()
+	activeTenant := &domain.Tenant{ID: "tnt_abc", Slug: "acme", Name: "Acme", Active: true, CreatedAt: now, UpdatedAt: now}
+	inactiveTenant := &domain.Tenant{ID: "tnt_def", Slug: "dead", Name: "Dead Co", Active: false, CreatedAt: now, UpdatedAt: now}
+
+	tests := []struct {
+		name       string
+		identifier string
+		setup      func(repo *mockTenantRepo)
+		wantActive bool
+		wantErr    string
+	}{
+		{
+			name:       "resolve by ID",
+			identifier: "tnt_abc",
+			setup: func(repo *mockTenantRepo) {
+				repo.findByIDFn = func(_ context.Context, id string) (*domain.Tenant, error) {
+					if id == "tnt_abc" {
+						return activeTenant, nil
+					}
+					return nil, storage.ErrNotFound
+				}
+			},
+			wantActive: true,
+		},
+		{
+			name:       "resolve by slug",
+			identifier: "acme",
+			setup: func(repo *mockTenantRepo) {
+				repo.findBySlugFn = func(_ context.Context, slug string) (*domain.Tenant, error) {
+					if slug == "acme" {
+						return activeTenant, nil
+					}
+					return nil, storage.ErrNotFound
+				}
+			},
+			wantActive: true,
+		},
+		{
+			name:       "resolve inactive tenant",
+			identifier: "tnt_def",
+			setup: func(repo *mockTenantRepo) {
+				repo.findByIDFn = func(_ context.Context, _ string) (*domain.Tenant, error) {
+					return inactiveTenant, nil
+				}
+			},
+			wantActive: false,
+		},
+		{
+			name:       "tenant not found",
+			identifier: "nonexistent",
+			wantErr:    "tenant not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockTenantRepo{}
+			if tt.setup != nil {
+				tt.setup(repo)
+			}
+			svc := testService(repo)
+
+			cfg, err := svc.ResolveTenant(context.Background(), tt.identifier)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, cfg)
+				assert.Equal(t, tt.wantActive, cfg.Active)
+			}
+		})
+	}
+}
+
+func TestValidateSlug(t *testing.T) {
+	svc := testService(&mockTenantRepo{})
+
+	tests := []struct {
+		slug    string
+		wantErr bool
+	}{
+		{"ab", false},
+		{"a", true},                    // too short
+		{"my-tenant", false},           // valid with hyphen
+		{"my--tenant", false},          // double hyphen is valid
+		{"-tenant", true},              // starts with hyphen
+		{"tenant-", true},              // ends with hyphen
+		{"UPPER", true},                // uppercase
+		{"has_underscore", true},       // underscore
+		{"has space", true},            // space
+		{"a2", false},                  // min length
+		{"x", true},                    // below min
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.slug, func(t *testing.T) {
+			err := svc.validateSlug(tt.slug)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/migrations/000015_create_tenants_table.down.sql
+++ b/migrations/000015_create_tenants_table.down.sql
@@ -1,0 +1,3 @@
+-- 000015_create_tenants_table.down.sql
+
+DROP TABLE IF EXISTS tenants;

--- a/migrations/000015_create_tenants_table.up.sql
+++ b/migrations/000015_create_tenants_table.up.sql
@@ -1,0 +1,18 @@
+-- 000015_create_tenants_table.up.sql
+-- Multi-tenancy: stores tenant records for tenant resolution middleware.
+
+CREATE TABLE IF NOT EXISTS tenants (
+    id         TEXT        PRIMARY KEY,
+    slug       TEXT        NOT NULL UNIQUE,
+    name       TEXT        NOT NULL,
+    active     BOOLEAN     NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at TIMESTAMPTZ
+);
+
+-- Fast lookup by slug (used by tenant resolution middleware).
+CREATE INDEX IF NOT EXISTS idx_tenants_slug ON tenants (slug) WHERE deleted_at IS NULL;
+
+-- List active tenants sorted by creation time.
+CREATE INDEX IF NOT EXISTS idx_tenants_active ON tenants (active, created_at DESC) WHERE deleted_at IS NULL;


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-353.

Closes #353

## Changes

Create new `internal/tenant/` package containing: a `Repository` interface and PostgreSQL implementation for tenant CRUD (Create, FindByID, FindBySlug, List, Update, Delete), a `Service` layer wrapping the repository with business logic and validation, and an implementation of `middleware.TenantResolver` that queries the tenants table (bridging the existing middleware interface to the new storage). Extend `internal/config/` with any additional tenant-related configuration knobs needed for per-tenant overrides (defaults for new tenants, etc.). Packages: `internal/tenant/` (new), `internal/config/`