### PR TITLE
GH-361: Tenant Admin Service: Interface, Types, and Business Logic

### DIFF
--- a/internal/admin/tenant_service.go
+++ b/internal/admin/tenant_service.go
@@ -1,0 +1,371 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/audit"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+const (
+	// minPasswordLength is the absolute minimum a tenant can set for password min_length.
+	minPasswordLength = 8
+	// maxPasswordLength is the upper bound for password max_length.
+	maxPasswordLength = 128
+	// minTokenTTL is the minimum allowed token TTL in seconds (30 seconds).
+	minTokenTTL = 30
+	// maxTokenTTL is the maximum allowed token TTL in seconds (30 days).
+	maxTokenTTL = 30 * 24 * 3600
+
+	// validMFAMethods lists the recognised MFA method identifiers.
+	mfaMethodTOTP     = "totp"
+	mfaMethodWebAuthn = "webauthn"
+	mfaMethodBackup   = "backup_codes"
+)
+
+var validMFAMethods = map[string]bool{
+	mfaMethodTOTP:     true,
+	mfaMethodWebAuthn: true,
+	mfaMethodBackup:   true,
+}
+
+// TenantService implements api.AdminTenantService.
+type TenantService struct {
+	repo   storage.TenantRepository
+	logger *zap.Logger
+	audit  audit.EventLogger
+}
+
+// NewTenantService creates a new admin tenant service.
+func NewTenantService(repo storage.TenantRepository, logger *zap.Logger, auditor audit.EventLogger) *TenantService {
+	return &TenantService{
+		repo:   repo,
+		logger: logger,
+		audit:  auditor,
+	}
+}
+
+// ListTenants returns a paginated list of tenants.
+func (s *TenantService) ListTenants(ctx context.Context, page, perPage int) (*api.AdminTenantList, error) {
+	offset := (page - 1) * perPage
+
+	tenants, total, err := s.repo.List(ctx, perPage, offset)
+	if err != nil {
+		s.logger.Error("list tenants failed", zap.Error(err))
+		return nil, fmt.Errorf("list tenants: %w", api.ErrInternalError)
+	}
+
+	result := &api.AdminTenantList{
+		Tenants: make([]api.AdminTenant, 0, len(tenants)),
+		Total:   total,
+		Page:    page,
+		PerPage: perPage,
+	}
+
+	for _, t := range tenants {
+		result.Tenants = append(result.Tenants, domainTenantToAdmin(t))
+	}
+
+	return result, nil
+}
+
+// GetTenant retrieves a single tenant by ID.
+func (s *TenantService) GetTenant(ctx context.Context, tenantID string) (*api.AdminTenant, error) {
+	id, err := uuid.Parse(tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid tenant ID: %w", api.ErrNotFound)
+	}
+
+	t, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("tenant %s: %w", tenantID, api.ErrNotFound)
+		}
+		s.logger.Error("get tenant failed", zap.String("tenant_id", tenantID), zap.Error(err))
+		return nil, fmt.Errorf("get tenant: %w", api.ErrInternalError)
+	}
+
+	admin := domainTenantToAdmin(t)
+	return &admin, nil
+}
+
+// CreateTenant creates a new tenant with optional configuration.
+func (s *TenantService) CreateTenant(ctx context.Context, req *api.CreateTenantRequest) (*api.AdminTenant, error) {
+	var cfg domain.TenantConfig
+	if req.Config != nil {
+		if err := validateTenantConfig(req.Config); err != nil {
+			return nil, err
+		}
+		cfg = adminConfigToDomain(req.Config)
+	}
+
+	now := time.Now().UTC()
+	tenant := &domain.Tenant{
+		ID:        uuid.New(),
+		Name:      req.Name,
+		Slug:      req.Slug,
+		Config:    cfg,
+		Status:    domain.TenantStatusActive,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	created, err := s.repo.Create(ctx, tenant)
+	if err != nil {
+		if errors.Is(err, storage.ErrDuplicateTenant) {
+			return nil, fmt.Errorf("tenant slug %s already exists: %w", req.Slug, api.ErrConflict)
+		}
+		s.logger.Error("create tenant failed", zap.Error(err))
+		return nil, fmt.Errorf("create tenant: %w", api.ErrInternalError)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminTenantCreate,
+		TargetID: created.ID.String(),
+		Metadata: map[string]string{"name": created.Name, "slug": created.Slug},
+	})
+
+	admin := domainTenantToAdmin(created)
+	return &admin, nil
+}
+
+// UpdateTenant modifies tenant fields.
+func (s *TenantService) UpdateTenant(ctx context.Context, tenantID string, req *api.UpdateTenantRequest) (*api.AdminTenant, error) {
+	id, err := uuid.Parse(tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid tenant ID: %w", api.ErrNotFound)
+	}
+
+	existing, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("tenant %s: %w", tenantID, api.ErrNotFound)
+		}
+		s.logger.Error("find tenant for update failed", zap.String("tenant_id", tenantID), zap.Error(err))
+		return nil, fmt.Errorf("update tenant: %w", api.ErrInternalError)
+	}
+
+	if req.Name != nil {
+		existing.Name = *req.Name
+	}
+	if req.Status != nil {
+		status := domain.TenantStatus(*req.Status)
+		if !status.IsValid() || status == domain.TenantStatusDeleted {
+			return nil, fmt.Errorf("invalid status %q: %w", *req.Status, api.ErrConflict)
+		}
+		existing.Status = status
+	}
+	if req.Config != nil {
+		if err := validateTenantConfig(req.Config); err != nil {
+			return nil, err
+		}
+		existing.Config = adminConfigToDomain(req.Config)
+	}
+
+	updated, err := s.repo.Update(ctx, existing)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("tenant %s: %w", tenantID, api.ErrNotFound)
+		}
+		s.logger.Error("update tenant failed", zap.String("tenant_id", tenantID), zap.Error(err))
+		return nil, fmt.Errorf("update tenant: %w", api.ErrInternalError)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminTenantUpdate,
+		TargetID: tenantID,
+	})
+
+	admin := domainTenantToAdmin(updated)
+	return &admin, nil
+}
+
+// DeleteTenant removes a tenant by ID.
+func (s *TenantService) DeleteTenant(ctx context.Context, tenantID string) error {
+	id, err := uuid.Parse(tenantID)
+	if err != nil {
+		return fmt.Errorf("invalid tenant ID: %w", api.ErrNotFound)
+	}
+
+	if id == domain.DefaultTenantID {
+		return fmt.Errorf("cannot delete default tenant: %w", api.ErrConflict)
+	}
+
+	err = s.repo.Delete(ctx, id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return fmt.Errorf("tenant %s: %w", tenantID, api.ErrNotFound)
+		}
+		s.logger.Error("delete tenant failed", zap.String("tenant_id", tenantID), zap.Error(err))
+		return fmt.Errorf("delete tenant: %w", api.ErrInternalError)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventAdminTenantDelete,
+		TargetID: tenantID,
+	})
+
+	return nil
+}
+
+// validateTenantConfig validates the tenant configuration fields.
+func validateTenantConfig(cfg *api.AdminTenantConfig) error {
+	if cfg.PasswordPolicy != nil {
+		if err := validatePasswordPolicy(cfg.PasswordPolicy); err != nil {
+			return err
+		}
+	}
+	if cfg.MFA != nil {
+		if err := validateMFAConfig(cfg.MFA); err != nil {
+			return err
+		}
+	}
+	if cfg.AllowedOAuthProviders != nil {
+		if err := validateOAuthProviders(cfg.AllowedOAuthProviders); err != nil {
+			return err
+		}
+	}
+	if cfg.TokenTTLs != nil {
+		if err := validateTokenTTLs(cfg.TokenTTLs); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validatePasswordPolicy(pp *api.AdminTenantPasswordPolicy) error {
+	if pp.MinLength != nil {
+		if *pp.MinLength < minPasswordLength {
+			return fmt.Errorf("password min_length must be at least %d: %w", minPasswordLength, api.ErrConflict)
+		}
+	}
+	if pp.MaxLength != nil {
+		if *pp.MaxLength > maxPasswordLength {
+			return fmt.Errorf("password max_length must not exceed %d: %w", maxPasswordLength, api.ErrConflict)
+		}
+	}
+	if pp.MinLength != nil && pp.MaxLength != nil {
+		if *pp.MaxLength < *pp.MinLength {
+			return fmt.Errorf("password max_length must be >= min_length: %w", api.ErrConflict)
+		}
+	}
+	if pp.MaxAgeDays != nil && *pp.MaxAgeDays < 0 {
+		return fmt.Errorf("password max_age_days must be >= 0: %w", api.ErrConflict)
+	}
+	if pp.HistoryCount != nil && *pp.HistoryCount < 0 {
+		return fmt.Errorf("password history_count must be >= 0: %w", api.ErrConflict)
+	}
+	return nil
+}
+
+func validateMFAConfig(mfa *api.AdminTenantMFAConfig) error {
+	for _, method := range mfa.AllowedMethods {
+		if !validMFAMethods[method] {
+			return fmt.Errorf("invalid MFA method %q: %w", method, api.ErrConflict)
+		}
+	}
+	if mfa.GracePeriodDays < 0 {
+		return fmt.Errorf("MFA grace_period_days must be >= 0: %w", api.ErrConflict)
+	}
+	return nil
+}
+
+func validateOAuthProviders(providers []string) error {
+	for _, p := range providers {
+		if p == "" {
+			return fmt.Errorf("OAuth provider name must not be empty: %w", api.ErrConflict)
+		}
+	}
+	return nil
+}
+
+func validateTokenTTLs(ttls *api.AdminTenantTokenTTLs) error {
+	if ttls.AccessTokenTTL != nil {
+		if *ttls.AccessTokenTTL < minTokenTTL || *ttls.AccessTokenTTL > maxTokenTTL {
+			return fmt.Errorf("access_token_ttl must be between %d and %d seconds: %w", minTokenTTL, maxTokenTTL, api.ErrConflict)
+		}
+	}
+	if ttls.RefreshTokenTTL != nil {
+		if *ttls.RefreshTokenTTL < minTokenTTL || *ttls.RefreshTokenTTL > maxTokenTTL {
+			return fmt.Errorf("refresh_token_ttl must be between %d and %d seconds: %w", minTokenTTL, maxTokenTTL, api.ErrConflict)
+		}
+	}
+	return nil
+}
+
+// domainTenantToAdmin converts a domain.Tenant to an api.AdminTenant response DTO.
+func domainTenantToAdmin(t *domain.Tenant) api.AdminTenant {
+	return api.AdminTenant{
+		ID:        t.ID.String(),
+		Name:      t.Name,
+		Slug:      t.Slug,
+		Config:    domainConfigToAdmin(t.Config),
+		Status:    string(t.Status),
+		CreatedAt: t.CreatedAt,
+		UpdatedAt: t.UpdatedAt,
+	}
+}
+
+func domainConfigToAdmin(cfg domain.TenantConfig) api.AdminTenantConfig {
+	out := api.AdminTenantConfig{
+		AllowedOAuthProviders: cfg.AllowedOAuthProviders,
+	}
+	if cfg.PasswordPolicy != nil {
+		out.PasswordPolicy = &api.AdminTenantPasswordPolicy{
+			MinLength:    cfg.PasswordPolicy.MinLength,
+			MaxLength:    cfg.PasswordPolicy.MaxLength,
+			MaxAgeDays:   cfg.PasswordPolicy.MaxAgeDays,
+			HistoryCount: cfg.PasswordPolicy.HistoryCount,
+		}
+	}
+	if cfg.MFA != nil {
+		out.MFA = &api.AdminTenantMFAConfig{
+			Required:        cfg.MFA.Required,
+			AllowedMethods:  cfg.MFA.AllowedMethods,
+			GracePeriodDays: cfg.MFA.GracePeriodDays,
+		}
+	}
+	if cfg.TokenTTLs != nil {
+		out.TokenTTLs = &api.AdminTenantTokenTTLs{
+			AccessTokenTTL:  cfg.TokenTTLs.AccessTokenTTL,
+			RefreshTokenTTL: cfg.TokenTTLs.RefreshTokenTTL,
+		}
+	}
+	return out
+}
+
+func adminConfigToDomain(cfg *api.AdminTenantConfig) domain.TenantConfig {
+	out := domain.TenantConfig{
+		AllowedOAuthProviders: cfg.AllowedOAuthProviders,
+	}
+	if cfg.PasswordPolicy != nil {
+		out.PasswordPolicy = &domain.TenantPasswordPolicy{
+			MinLength:    cfg.PasswordPolicy.MinLength,
+			MaxLength:    cfg.PasswordPolicy.MaxLength,
+			MaxAgeDays:   cfg.PasswordPolicy.MaxAgeDays,
+			HistoryCount: cfg.PasswordPolicy.HistoryCount,
+		}
+	}
+	if cfg.MFA != nil {
+		out.MFA = &domain.TenantMFAConfig{
+			Required:        cfg.MFA.Required,
+			AllowedMethods:  cfg.MFA.AllowedMethods,
+			GracePeriodDays: cfg.MFA.GracePeriodDays,
+		}
+	}
+	if cfg.TokenTTLs != nil {
+		out.TokenTTLs = &domain.TenantTokenTTLs{
+			AccessTokenTTL:  cfg.TokenTTLs.AccessTokenTTL,
+			RefreshTokenTTL: cfg.TokenTTLs.RefreshTokenTTL,
+		}
+	}
+	return out
+}

--- a/internal/admin/tenant_service_test.go
+++ b/internal/admin/tenant_service_test.go
@@ -1,0 +1,516 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/audit"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+	"github.com/qf-studio/auth-service/internal/storage/mocks"
+)
+
+// --- Helpers ---
+
+func testTenant() *domain.Tenant {
+	now := time.Now().UTC()
+	return &domain.Tenant{
+		ID:        uuid.New(),
+		Name:      "Test Tenant",
+		Slug:      "test-tenant",
+		Config:    domain.TenantConfig{},
+		Status:    domain.TenantStatusActive,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+func newTestTenantService(repo *mocks.MockTenantRepository) *TenantService {
+	return NewTenantService(repo, zap.NewNop(), audit.NopLogger{})
+}
+
+// --- ListTenants ---
+
+func TestTenantService_ListTenants(t *testing.T) {
+	tenant := testTenant()
+	repo := &mocks.MockTenantRepository{
+		ListFn: func(_ context.Context, limit, offset int) ([]*domain.Tenant, int, error) {
+			assert.Equal(t, 20, limit)
+			assert.Equal(t, 0, offset)
+			return []*domain.Tenant{tenant}, 1, nil
+		},
+	}
+	svc := newTestTenantService(repo)
+
+	result, err := svc.ListTenants(context.Background(), 1, 20)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Total)
+	assert.Len(t, result.Tenants, 1)
+	assert.Equal(t, tenant.ID.String(), result.Tenants[0].ID)
+}
+
+func TestTenantService_ListTenants_Error(t *testing.T) {
+	repo := &mocks.MockTenantRepository{
+		ListFn: func(_ context.Context, _, _ int) ([]*domain.Tenant, int, error) {
+			return nil, 0, fmt.Errorf("db error")
+		},
+	}
+	svc := newTestTenantService(repo)
+
+	_, err := svc.ListTenants(context.Background(), 1, 20)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrInternalError)
+}
+
+// --- GetTenant ---
+
+func TestTenantService_GetTenant(t *testing.T) {
+	tenant := testTenant()
+	repo := &mocks.MockTenantRepository{
+		FindByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Tenant, error) {
+			assert.Equal(t, tenant.ID, id)
+			return tenant, nil
+		},
+	}
+	svc := newTestTenantService(repo)
+
+	result, err := svc.GetTenant(context.Background(), tenant.ID.String())
+	require.NoError(t, err)
+	assert.Equal(t, tenant.ID.String(), result.ID)
+	assert.Equal(t, tenant.Name, result.Name)
+}
+
+func TestTenantService_GetTenant_InvalidID(t *testing.T) {
+	svc := newTestTenantService(&mocks.MockTenantRepository{})
+
+	_, err := svc.GetTenant(context.Background(), "not-a-uuid")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrNotFound)
+}
+
+func TestTenantService_GetTenant_NotFound(t *testing.T) {
+	repo := &mocks.MockTenantRepository{
+		FindByIDFn: func(_ context.Context, _ uuid.UUID) (*domain.Tenant, error) {
+			return nil, storage.ErrNotFound
+		},
+	}
+	svc := newTestTenantService(repo)
+
+	_, err := svc.GetTenant(context.Background(), uuid.New().String())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrNotFound)
+}
+
+// --- CreateTenant ---
+
+func TestTenantService_CreateTenant(t *testing.T) {
+	repo := &mocks.MockTenantRepository{
+		CreateFn: func(_ context.Context, tenant *domain.Tenant) (*domain.Tenant, error) {
+			return tenant, nil
+		},
+	}
+	svc := newTestTenantService(repo)
+
+	req := &api.CreateTenantRequest{
+		Name: "My Tenant",
+		Slug: "my-tenant",
+	}
+	result, err := svc.CreateTenant(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, "My Tenant", result.Name)
+	assert.Equal(t, "my-tenant", result.Slug)
+	assert.Equal(t, "active", result.Status)
+}
+
+func TestTenantService_CreateTenant_WithConfig(t *testing.T) {
+	repo := &mocks.MockTenantRepository{
+		CreateFn: func(_ context.Context, tenant *domain.Tenant) (*domain.Tenant, error) {
+			return tenant, nil
+		},
+	}
+	svc := newTestTenantService(repo)
+
+	minLen := 12
+	req := &api.CreateTenantRequest{
+		Name: "Configured Tenant",
+		Slug: "configured",
+		Config: &api.AdminTenantConfig{
+			PasswordPolicy: &api.AdminTenantPasswordPolicy{
+				MinLength: &minLen,
+			},
+			MFA: &api.AdminTenantMFAConfig{
+				Required:       true,
+				AllowedMethods: []string{"totp"},
+			},
+			AllowedOAuthProviders: []string{"google", "github"},
+			TokenTTLs: &api.AdminTenantTokenTTLs{
+				AccessTokenTTL:  intPtr(900),
+				RefreshTokenTTL: intPtr(86400),
+			},
+		},
+	}
+	result, err := svc.CreateTenant(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, "Configured Tenant", result.Name)
+	require.NotNil(t, result.Config.PasswordPolicy)
+	assert.Equal(t, 12, *result.Config.PasswordPolicy.MinLength)
+	require.NotNil(t, result.Config.MFA)
+	assert.True(t, result.Config.MFA.Required)
+	assert.Equal(t, []string{"google", "github"}, result.Config.AllowedOAuthProviders)
+	require.NotNil(t, result.Config.TokenTTLs)
+	assert.Equal(t, 900, *result.Config.TokenTTLs.AccessTokenTTL)
+}
+
+func TestTenantService_CreateTenant_DuplicateSlug(t *testing.T) {
+	repo := &mocks.MockTenantRepository{
+		CreateFn: func(_ context.Context, _ *domain.Tenant) (*domain.Tenant, error) {
+			return nil, fmt.Errorf("slug dup: %w", storage.ErrDuplicateTenant)
+		},
+	}
+	svc := newTestTenantService(repo)
+
+	_, err := svc.CreateTenant(context.Background(), &api.CreateTenantRequest{
+		Name: "Dup",
+		Slug: "dup",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrConflict)
+}
+
+// --- UpdateTenant ---
+
+func TestTenantService_UpdateTenant(t *testing.T) {
+	tenant := testTenant()
+	repo := &mocks.MockTenantRepository{
+		FindByIDFn: func(_ context.Context, id uuid.UUID) (*domain.Tenant, error) {
+			assert.Equal(t, tenant.ID, id)
+			return tenant, nil
+		},
+		UpdateFn: func(_ context.Context, t *domain.Tenant) (*domain.Tenant, error) {
+			return t, nil
+		},
+	}
+	svc := newTestTenantService(repo)
+
+	name := "Updated Name"
+	result, err := svc.UpdateTenant(context.Background(), tenant.ID.String(), &api.UpdateTenantRequest{Name: &name})
+	require.NoError(t, err)
+	assert.Equal(t, "Updated Name", result.Name)
+}
+
+func TestTenantService_UpdateTenant_Status(t *testing.T) {
+	tenant := testTenant()
+	repo := &mocks.MockTenantRepository{
+		FindByIDFn: func(_ context.Context, _ uuid.UUID) (*domain.Tenant, error) {
+			return tenant, nil
+		},
+		UpdateFn: func(_ context.Context, t *domain.Tenant) (*domain.Tenant, error) {
+			return t, nil
+		},
+	}
+	svc := newTestTenantService(repo)
+
+	status := "suspended"
+	result, err := svc.UpdateTenant(context.Background(), tenant.ID.String(), &api.UpdateTenantRequest{Status: &status})
+	require.NoError(t, err)
+	assert.Equal(t, "suspended", result.Status)
+}
+
+func TestTenantService_UpdateTenant_InvalidStatus(t *testing.T) {
+	tenant := testTenant()
+	repo := &mocks.MockTenantRepository{
+		FindByIDFn: func(_ context.Context, _ uuid.UUID) (*domain.Tenant, error) {
+			return tenant, nil
+		},
+	}
+	svc := newTestTenantService(repo)
+
+	status := "deleted"
+	_, err := svc.UpdateTenant(context.Background(), tenant.ID.String(), &api.UpdateTenantRequest{Status: &status})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrConflict)
+}
+
+func TestTenantService_UpdateTenant_InvalidID(t *testing.T) {
+	svc := newTestTenantService(&mocks.MockTenantRepository{})
+
+	name := "nope"
+	_, err := svc.UpdateTenant(context.Background(), "not-a-uuid", &api.UpdateTenantRequest{Name: &name})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrNotFound)
+}
+
+func TestTenantService_UpdateTenant_NotFound(t *testing.T) {
+	repo := &mocks.MockTenantRepository{
+		FindByIDFn: func(_ context.Context, _ uuid.UUID) (*domain.Tenant, error) {
+			return nil, storage.ErrNotFound
+		},
+	}
+	svc := newTestTenantService(repo)
+
+	name := "nope"
+	_, err := svc.UpdateTenant(context.Background(), uuid.New().String(), &api.UpdateTenantRequest{Name: &name})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrNotFound)
+}
+
+// --- DeleteTenant ---
+
+func TestTenantService_DeleteTenant(t *testing.T) {
+	repo := &mocks.MockTenantRepository{
+		DeleteFn: func(_ context.Context, _ uuid.UUID) error {
+			return nil
+		},
+	}
+	svc := newTestTenantService(repo)
+
+	err := svc.DeleteTenant(context.Background(), uuid.New().String())
+	require.NoError(t, err)
+}
+
+func TestTenantService_DeleteTenant_NotFound(t *testing.T) {
+	repo := &mocks.MockTenantRepository{
+		DeleteFn: func(_ context.Context, _ uuid.UUID) error {
+			return fmt.Errorf("not found: %w", storage.ErrNotFound)
+		},
+	}
+	svc := newTestTenantService(repo)
+
+	err := svc.DeleteTenant(context.Background(), uuid.New().String())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrNotFound)
+}
+
+func TestTenantService_DeleteTenant_InvalidID(t *testing.T) {
+	svc := newTestTenantService(&mocks.MockTenantRepository{})
+
+	err := svc.DeleteTenant(context.Background(), "not-a-uuid")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrNotFound)
+}
+
+func TestTenantService_DeleteTenant_DefaultTenant(t *testing.T) {
+	svc := newTestTenantService(&mocks.MockTenantRepository{})
+
+	err := svc.DeleteTenant(context.Background(), domain.DefaultTenantID.String())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrConflict)
+}
+
+// --- Config Validation ---
+
+func TestValidatePasswordPolicy(t *testing.T) {
+	tests := []struct {
+		name    string
+		policy  *api.AdminTenantPasswordPolicy
+		wantErr bool
+	}{
+		{
+			name:    "valid policy",
+			policy:  &api.AdminTenantPasswordPolicy{MinLength: intPtr(15), MaxLength: intPtr(64)},
+			wantErr: false,
+		},
+		{
+			name:    "min_length too small",
+			policy:  &api.AdminTenantPasswordPolicy{MinLength: intPtr(4)},
+			wantErr: true,
+		},
+		{
+			name:    "max_length exceeds limit",
+			policy:  &api.AdminTenantPasswordPolicy{MaxLength: intPtr(200)},
+			wantErr: true,
+		},
+		{
+			name:    "max_length less than min_length",
+			policy:  &api.AdminTenantPasswordPolicy{MinLength: intPtr(20), MaxLength: intPtr(10)},
+			wantErr: true,
+		},
+		{
+			name:    "negative max_age_days",
+			policy:  &api.AdminTenantPasswordPolicy{MaxAgeDays: intPtr(-1)},
+			wantErr: true,
+		},
+		{
+			name:    "negative history_count",
+			policy:  &api.AdminTenantPasswordPolicy{HistoryCount: intPtr(-1)},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePasswordPolicy(tt.policy)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, api.ErrConflict)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateMFAConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		mfa     *api.AdminTenantMFAConfig
+		wantErr bool
+	}{
+		{
+			name:    "valid config",
+			mfa:     &api.AdminTenantMFAConfig{Required: true, AllowedMethods: []string{"totp", "webauthn"}},
+			wantErr: false,
+		},
+		{
+			name:    "invalid method",
+			mfa:     &api.AdminTenantMFAConfig{AllowedMethods: []string{"sms"}},
+			wantErr: true,
+		},
+		{
+			name:    "negative grace period",
+			mfa:     &api.AdminTenantMFAConfig{GracePeriodDays: -1},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateMFAConfig(tt.mfa)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, api.ErrConflict)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateOAuthProviders(t *testing.T) {
+	assert.NoError(t, validateOAuthProviders([]string{"google", "github"}))
+	assert.Error(t, validateOAuthProviders([]string{"google", ""}))
+}
+
+func TestValidateTokenTTLs(t *testing.T) {
+	tests := []struct {
+		name    string
+		ttls    *api.AdminTenantTokenTTLs
+		wantErr bool
+	}{
+		{
+			name:    "valid ttls",
+			ttls:    &api.AdminTenantTokenTTLs{AccessTokenTTL: intPtr(900), RefreshTokenTTL: intPtr(86400)},
+			wantErr: false,
+		},
+		{
+			name:    "access_token_ttl too low",
+			ttls:    &api.AdminTenantTokenTTLs{AccessTokenTTL: intPtr(10)},
+			wantErr: true,
+		},
+		{
+			name:    "access_token_ttl too high",
+			ttls:    &api.AdminTenantTokenTTLs{AccessTokenTTL: intPtr(maxTokenTTL + 1)},
+			wantErr: true,
+		},
+		{
+			name:    "refresh_token_ttl too low",
+			ttls:    &api.AdminTenantTokenTTLs{RefreshTokenTTL: intPtr(5)},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTokenTTLs(tt.ttls)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, api.ErrConflict)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestTenantService_CreateTenant_InvalidConfig(t *testing.T) {
+	repo := &mocks.MockTenantRepository{}
+	svc := newTestTenantService(repo)
+
+	_, err := svc.CreateTenant(context.Background(), &api.CreateTenantRequest{
+		Name: "Bad Config",
+		Slug: "bad-config",
+		Config: &api.AdminTenantConfig{
+			PasswordPolicy: &api.AdminTenantPasswordPolicy{
+				MinLength: intPtr(3),
+			},
+		},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrConflict)
+}
+
+func TestTenantService_UpdateTenant_InvalidConfig(t *testing.T) {
+	tenant := testTenant()
+	repo := &mocks.MockTenantRepository{
+		FindByIDFn: func(_ context.Context, _ uuid.UUID) (*domain.Tenant, error) {
+			return tenant, nil
+		},
+	}
+	svc := newTestTenantService(repo)
+
+	_, err := svc.UpdateTenant(context.Background(), tenant.ID.String(), &api.UpdateTenantRequest{
+		Config: &api.AdminTenantConfig{
+			MFA: &api.AdminTenantMFAConfig{
+				AllowedMethods: []string{"sms"},
+			},
+		},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrConflict)
+}
+
+// --- domainTenantToAdmin ---
+
+func TestDomainTenantToAdmin(t *testing.T) {
+	tenant := testTenant()
+	minLen := 15
+	tenant.Config = domain.TenantConfig{
+		PasswordPolicy: &domain.TenantPasswordPolicy{
+			MinLength: &minLen,
+		},
+		MFA: &domain.TenantMFAConfig{
+			Required:       true,
+			AllowedMethods: []string{"totp"},
+		},
+		AllowedOAuthProviders: []string{"google"},
+		TokenTTLs: &domain.TenantTokenTTLs{
+			AccessTokenTTL:  intPtr(900),
+			RefreshTokenTTL: intPtr(86400),
+		},
+	}
+
+	admin := domainTenantToAdmin(tenant)
+	assert.Equal(t, tenant.ID.String(), admin.ID)
+	assert.Equal(t, tenant.Name, admin.Name)
+	assert.Equal(t, tenant.Slug, admin.Slug)
+	assert.Equal(t, string(tenant.Status), admin.Status)
+	require.NotNil(t, admin.Config.PasswordPolicy)
+	assert.Equal(t, 15, *admin.Config.PasswordPolicy.MinLength)
+	require.NotNil(t, admin.Config.MFA)
+	assert.True(t, admin.Config.MFA.Required)
+	assert.Equal(t, []string{"google"}, admin.Config.AllowedOAuthProviders)
+	require.NotNil(t, admin.Config.TokenTTLs)
+	assert.Equal(t, 900, *admin.Config.TokenTTLs.AccessTokenTTL)
+}
+
+// --- helpers ---
+
+func intPtr(v int) *int { return &v }

--- a/internal/api/admin_services.go
+++ b/internal/api/admin_services.go
@@ -237,6 +237,79 @@ type AdminAPIKeyService interface {
 	RotateAPIKey(ctx context.Context, keyID string) (*AdminAPIKeyWithSecret, error)
 }
 
+// --- Tenant admin types ---
+
+// AdminTenant represents a tenant in admin API responses.
+type AdminTenant struct {
+	ID        string              `json:"id"`
+	Name      string              `json:"name"`
+	Slug      string              `json:"slug"`
+	Config    AdminTenantConfig   `json:"config"`
+	Status    string              `json:"status"`
+	CreatedAt time.Time           `json:"created_at"`
+	UpdatedAt time.Time           `json:"updated_at"`
+}
+
+// AdminTenantConfig mirrors domain.TenantConfig for API responses.
+type AdminTenantConfig struct {
+	PasswordPolicy        *AdminTenantPasswordPolicy `json:"password_policy,omitempty"`
+	MFA                   *AdminTenantMFAConfig      `json:"mfa,omitempty"`
+	AllowedOAuthProviders []string                   `json:"allowed_oauth_providers,omitempty"`
+	TokenTTLs             *AdminTenantTokenTTLs      `json:"token_ttls,omitempty"`
+}
+
+// AdminTenantPasswordPolicy mirrors domain.TenantPasswordPolicy for API responses.
+type AdminTenantPasswordPolicy struct {
+	MinLength    *int `json:"min_length,omitempty"`
+	MaxLength    *int `json:"max_length,omitempty"`
+	MaxAgeDays   *int `json:"max_age_days,omitempty"`
+	HistoryCount *int `json:"history_count,omitempty"`
+}
+
+// AdminTenantMFAConfig mirrors domain.TenantMFAConfig for API responses.
+type AdminTenantMFAConfig struct {
+	Required        bool     `json:"required"`
+	AllowedMethods  []string `json:"allowed_methods,omitempty"`
+	GracePeriodDays int      `json:"grace_period_days,omitempty"`
+}
+
+// AdminTenantTokenTTLs mirrors domain.TenantTokenTTLs for API responses.
+type AdminTenantTokenTTLs struct {
+	AccessTokenTTL  *int `json:"access_token_ttl,omitempty"`
+	RefreshTokenTTL *int `json:"refresh_token_ttl,omitempty"`
+}
+
+// AdminTenantList is the paginated response for listing tenants.
+type AdminTenantList struct {
+	Tenants []AdminTenant `json:"tenants"`
+	Total   int           `json:"total"`
+	Page    int           `json:"page"`
+	PerPage int           `json:"per_page"`
+}
+
+// CreateTenantRequest is the request body for creating a tenant.
+type CreateTenantRequest struct {
+	Name   string              `json:"name"   validate:"required,min=1,max=255"`
+	Slug   string              `json:"slug"   validate:"required,min=1,max=63"`
+	Config *AdminTenantConfig  `json:"config" validate:"omitempty"`
+}
+
+// UpdateTenantRequest is the request body for updating a tenant.
+type UpdateTenantRequest struct {
+	Name   *string             `json:"name"   validate:"omitempty,min=1,max=255"`
+	Config *AdminTenantConfig  `json:"config" validate:"omitempty"`
+	Status *string             `json:"status" validate:"omitempty,oneof=active suspended"`
+}
+
+// AdminTenantService defines admin operations for tenant management.
+type AdminTenantService interface {
+	ListTenants(ctx context.Context, page, perPage int) (*AdminTenantList, error)
+	GetTenant(ctx context.Context, tenantID string) (*AdminTenant, error)
+	CreateTenant(ctx context.Context, req *CreateTenantRequest) (*AdminTenant, error)
+	UpdateTenant(ctx context.Context, tenantID string, req *UpdateTenantRequest) (*AdminTenant, error)
+	DeleteTenant(ctx context.Context, tenantID string) error
+}
+
 // --- Webhook admin types ---
 
 // AdminWebhook represents a webhook subscription in admin API responses.
@@ -462,4 +535,5 @@ type AdminServices struct {
 	Webhooks       AdminWebhookService
 	Brokers        AdminBrokerService
 	SAML           AdminSAMLService
+	Tenants        AdminTenantService
 }

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -53,6 +53,11 @@ const (
 	EventBrokerTokenIssue            = "broker_token_issue"
 	EventBrokerTokenDenied           = "broker_token_denied"
 
+	// Tenant events.
+	EventAdminTenantCreate = "admin_tenant_create"
+	EventAdminTenantUpdate = "admin_tenant_update"
+	EventAdminTenantDelete = "admin_tenant_delete"
+
 	// SAML events.
 	EventSAMLLogin            = "saml_login"
 	EventSAMLLoginFailure     = "saml_login_failure"


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-361.

Closes #361

## Changes

Define the `AdminTenantService` interface and all request/response types (`CreateTenantRequest`, `UpdateTenantRequest`, `AdminTenant`, `AdminTenantList`) in `internal/api/admin_services.go`, add the `Tenants` field to the `AdminServices` struct. Implement the tenant service CRUD logic in `internal/admin/tenant_service.go` (Create, Get, List, Update, Delete — including config validation for password policy, MFA, OAuth providers, and token TTLs). Add unit tests in `internal/admin/tenant_service_test.go` using the existing `MockTenantRepository`. Follow patterns from `internal/admin/user_service.go` and `internal/admin/client_service.go`.