### PR TITLE
GH-362: Tenant Admin API: Handlers, Router, and Middleware Wiring

### DIFF
--- a/internal/api/admin_router.go
+++ b/internal/api/admin_router.go
@@ -135,6 +135,19 @@ func NewAdminRouter(svc *AdminServices, deps *AdminDeps) *gin.Engine {
 		}
 	}
 
+	// Tenant management.
+	if svc.Tenants != nil {
+		tenantH := NewAdminTenantHandlers(svc.Tenants)
+		tenants := admin.Group("/tenants")
+		{
+			tenants.GET("", tenantH.List)
+			tenants.GET("/:id", tenantH.Get)
+			tenants.POST("", tenantH.Create)
+			tenants.PATCH("/:id", tenantH.Update)
+			tenants.DELETE("/:id", tenantH.Delete)
+		}
+	}
+
 	// SAML IdP management.
 	if svc.SAML != nil {
 		samlH := NewAdminSAMLHandlers(svc.SAML)

--- a/internal/api/admin_services.go
+++ b/internal/api/admin_services.go
@@ -3,6 +3,8 @@ package api
 import (
 	"context"
 	"time"
+
+	"github.com/qf-studio/auth-service/internal/domain"
 )
 
 // --- Admin response types ---
@@ -450,6 +452,50 @@ type AdminSAMLService interface {
 	GetAttributeMapping(ctx context.Context, idpID string) (map[string]string, error)
 }
 
+// --- Tenant admin types ---
+
+// AdminTenant represents a tenant in admin API responses.
+type AdminTenant struct {
+	ID        string              `json:"id"`
+	Name      string              `json:"name"`
+	Slug      string              `json:"slug"`
+	Config    domain.TenantConfig `json:"config"`
+	Status    string              `json:"status"`
+	CreatedAt time.Time           `json:"created_at"`
+	UpdatedAt time.Time           `json:"updated_at"`
+}
+
+// AdminTenantList is the paginated response for listing tenants.
+type AdminTenantList struct {
+	Tenants []AdminTenant `json:"tenants"`
+	Total   int           `json:"total"`
+	Page    int           `json:"page"`
+	PerPage int           `json:"per_page"`
+}
+
+// CreateTenantRequest is the request body for creating a tenant.
+type CreateTenantRequest struct {
+	Name   string              `json:"name"   validate:"required,min=1,max=255"`
+	Slug   string              `json:"slug"   validate:"required,min=1,max=63,alphanum"`
+	Config domain.TenantConfig `json:"config"`
+}
+
+// UpdateTenantRequest is the request body for updating a tenant.
+type UpdateTenantRequest struct {
+	Name   *string              `json:"name"   validate:"omitempty,min=1,max=255"`
+	Config *domain.TenantConfig `json:"config" validate:"omitempty"`
+	Status *string              `json:"status" validate:"omitempty,oneof=active suspended"`
+}
+
+// AdminTenantService defines admin operations for tenant management.
+type AdminTenantService interface {
+	ListTenants(ctx context.Context, page, perPage int, status string) (*AdminTenantList, error)
+	GetTenant(ctx context.Context, tenantID string) (*AdminTenant, error)
+	CreateTenant(ctx context.Context, req *CreateTenantRequest) (*AdminTenant, error)
+	UpdateTenant(ctx context.Context, tenantID string, req *UpdateTenantRequest) (*AdminTenant, error)
+	DeleteTenant(ctx context.Context, tenantID string) error
+}
+
 // AdminServices aggregates all admin service interfaces required by admin API handlers.
 type AdminServices struct {
 	Users          AdminUserService
@@ -462,4 +508,5 @@ type AdminServices struct {
 	Webhooks       AdminWebhookService
 	Brokers        AdminBrokerService
 	SAML           AdminSAMLService
+	Tenants        AdminTenantService
 }

--- a/internal/api/admin_tenant_handlers.go
+++ b/internal/api/admin_tenant_handlers.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// AdminTenantHandlers groups HTTP handlers for admin tenant management endpoints.
+type AdminTenantHandlers struct {
+	tenants AdminTenantService
+}
+
+// NewAdminTenantHandlers creates a new AdminTenantHandlers with the given AdminTenantService.
+func NewAdminTenantHandlers(tenants AdminTenantService) *AdminTenantHandlers {
+	return &AdminTenantHandlers{tenants: tenants}
+}
+
+// List handles GET /admin/tenants.
+// Query params: page (default 1), per_page (default 20), status (active|suspended|deleted).
+func (h *AdminTenantHandlers) List(c *gin.Context) {
+	page, perPage := parsePagination(c)
+	status := c.DefaultQuery("status", "")
+
+	result, err := h.tenants.ListTenants(c.Request.Context(), page, perPage, status)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// Get handles GET /admin/tenants/:id.
+func (h *AdminTenantHandlers) Get(c *gin.Context) {
+	tenantID := c.Param("id")
+
+	tenant, err := h.tenants.GetTenant(c.Request.Context(), tenantID)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, tenant)
+}
+
+// Create handles POST /admin/tenants.
+func (h *AdminTenantHandlers) Create(c *gin.Context) {
+	var req CreateTenantRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid request body")
+		return
+	}
+
+	if err := adminValidator.Struct(req); err != nil {
+		handleValidationError(c, err)
+		return
+	}
+
+	tenant, err := h.tenants.CreateTenant(c.Request.Context(), &req)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, tenant)
+}
+
+// Update handles PATCH /admin/tenants/:id.
+func (h *AdminTenantHandlers) Update(c *gin.Context) {
+	tenantID := c.Param("id")
+
+	var req UpdateTenantRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid request body")
+		return
+	}
+
+	if err := adminValidator.Struct(req); err != nil {
+		handleValidationError(c, err)
+		return
+	}
+
+	tenant, err := h.tenants.UpdateTenant(c.Request.Context(), tenantID, &req)
+	if err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, tenant)
+}
+
+// Delete handles DELETE /admin/tenants/:id (soft delete).
+func (h *AdminTenantHandlers) Delete(c *gin.Context) {
+	tenantID := c.Param("id")
+
+	if err := h.tenants.DeleteTenant(c.Request.Context(), tenantID); err != nil {
+		handleServiceError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "tenant deleted"})
+}

--- a/internal/api/admin_tenant_handlers_test.go
+++ b/internal/api/admin_tenant_handlers_test.go
@@ -1,0 +1,321 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/health"
+)
+
+// --- Mock AdminTenantService ---
+
+type mockAdminTenantService struct {
+	listTenantsFn  func(ctx context.Context, page, perPage int, status string) (*api.AdminTenantList, error)
+	getTenantFn    func(ctx context.Context, tenantID string) (*api.AdminTenant, error)
+	createTenantFn func(ctx context.Context, req *api.CreateTenantRequest) (*api.AdminTenant, error)
+	updateTenantFn func(ctx context.Context, tenantID string, req *api.UpdateTenantRequest) (*api.AdminTenant, error)
+	deleteTenantFn func(ctx context.Context, tenantID string) error
+}
+
+func (m *mockAdminTenantService) ListTenants(ctx context.Context, page, perPage int, status string) (*api.AdminTenantList, error) {
+	if m.listTenantsFn != nil {
+		return m.listTenantsFn(ctx, page, perPage, status)
+	}
+	return &api.AdminTenantList{
+		Tenants: []api.AdminTenant{{ID: "t1", Name: "default", Slug: "default", Status: "active", Config: domain.TenantConfig{}, CreatedAt: time.Now(), UpdatedAt: time.Now()}},
+		Total:   1,
+		Page:    page,
+		PerPage: perPage,
+	}, nil
+}
+
+func (m *mockAdminTenantService) GetTenant(ctx context.Context, tenantID string) (*api.AdminTenant, error) {
+	if m.getTenantFn != nil {
+		return m.getTenantFn(ctx, tenantID)
+	}
+	return &api.AdminTenant{ID: tenantID, Name: "default", Slug: "default", Status: "active", Config: domain.TenantConfig{}, CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+}
+
+func (m *mockAdminTenantService) CreateTenant(ctx context.Context, req *api.CreateTenantRequest) (*api.AdminTenant, error) {
+	if m.createTenantFn != nil {
+		return m.createTenantFn(ctx, req)
+	}
+	return &api.AdminTenant{
+		ID:        "new-tenant",
+		Name:      req.Name,
+		Slug:      req.Slug,
+		Config:    req.Config,
+		Status:    "active",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}, nil
+}
+
+func (m *mockAdminTenantService) UpdateTenant(ctx context.Context, tenantID string, req *api.UpdateTenantRequest) (*api.AdminTenant, error) {
+	if m.updateTenantFn != nil {
+		return m.updateTenantFn(ctx, tenantID, req)
+	}
+	name := "default"
+	if req.Name != nil {
+		name = *req.Name
+	}
+	return &api.AdminTenant{ID: tenantID, Name: name, Slug: "default", Status: "active", Config: domain.TenantConfig{}, CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+}
+
+func (m *mockAdminTenantService) DeleteTenant(ctx context.Context, tenantID string) error {
+	if m.deleteTenantFn != nil {
+		return m.deleteTenantFn(ctx, tenantID)
+	}
+	return nil
+}
+
+// --- Helper ---
+
+func newAdminTenantRouter(tenantSvc api.AdminTenantService) *gin.Engine {
+	svc := &api.AdminServices{Tenants: tenantSvc}
+	return api.NewAdminRouter(svc, &api.AdminDeps{Health: health.NewService()})
+}
+
+// --- List Tenants ---
+
+func TestAdminListTenants_Success(t *testing.T) {
+	r := newAdminTenantRouter(&mockAdminTenantService{})
+	w := doRequest(r, http.MethodGet, "/admin/tenants", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminTenantList
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.Total)
+	assert.Len(t, resp.Tenants, 1)
+}
+
+func TestAdminListTenants_Pagination(t *testing.T) {
+	svc := &mockAdminTenantService{
+		listTenantsFn: func(_ context.Context, page, perPage int, status string) (*api.AdminTenantList, error) {
+			assert.Equal(t, 2, page)
+			assert.Equal(t, 10, perPage)
+			assert.Equal(t, "", status)
+			return &api.AdminTenantList{Tenants: []api.AdminTenant{}, Total: 50, Page: page, PerPage: perPage}, nil
+		},
+	}
+	r := newAdminTenantRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/tenants?page=2&per_page=10", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminTenantList
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 2, resp.Page)
+	assert.Equal(t, 10, resp.PerPage)
+}
+
+func TestAdminListTenants_StatusFilter(t *testing.T) {
+	svc := &mockAdminTenantService{
+		listTenantsFn: func(_ context.Context, page, perPage int, status string) (*api.AdminTenantList, error) {
+			assert.Equal(t, "active", status)
+			return &api.AdminTenantList{Tenants: []api.AdminTenant{}, Total: 0, Page: page, PerPage: perPage}, nil
+		},
+	}
+	r := newAdminTenantRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/tenants?status=active", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestAdminListTenants_PerPageCapped(t *testing.T) {
+	svc := &mockAdminTenantService{
+		listTenantsFn: func(_ context.Context, page, perPage int, _ string) (*api.AdminTenantList, error) {
+			assert.Equal(t, 1, page)
+			assert.Equal(t, 100, perPage) // Capped at 100
+			return &api.AdminTenantList{Tenants: []api.AdminTenant{}, Total: 0, Page: page, PerPage: perPage}, nil
+		},
+	}
+	r := newAdminTenantRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/tenants?per_page=999", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestAdminListTenants_ServiceError(t *testing.T) {
+	svc := &mockAdminTenantService{
+		listTenantsFn: func(_ context.Context, _, _ int, _ string) (*api.AdminTenantList, error) {
+			return nil, fmt.Errorf("database error")
+		},
+	}
+	r := newAdminTenantRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/tenants", nil)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- Get Tenant ---
+
+func TestAdminGetTenant_Success(t *testing.T) {
+	r := newAdminTenantRouter(&mockAdminTenantService{})
+	w := doRequest(r, http.MethodGet, "/admin/tenants/tenant-1", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminTenant
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "tenant-1", resp.ID)
+}
+
+func TestAdminGetTenant_NotFound(t *testing.T) {
+	svc := &mockAdminTenantService{
+		getTenantFn: func(_ context.Context, _ string) (*api.AdminTenant, error) {
+			return nil, fmt.Errorf("tenant not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminTenantRouter(svc)
+	w := doRequest(r, http.MethodGet, "/admin/tenants/nonexistent", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- Create Tenant ---
+
+func TestAdminCreateTenant_Success(t *testing.T) {
+	r := newAdminTenantRouter(&mockAdminTenantService{})
+	body := map[string]interface{}{
+		"name": "acme-corp",
+		"slug": "acmecorp",
+	}
+	w := doRequest(r, http.MethodPost, "/admin/tenants", body)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp api.AdminTenant
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "acme-corp", resp.Name)
+	assert.Equal(t, "acmecorp", resp.Slug)
+}
+
+func TestAdminCreateTenant_MissingName(t *testing.T) {
+	r := newAdminTenantRouter(&mockAdminTenantService{})
+	body := map[string]interface{}{
+		"slug": "nope",
+	}
+	w := doRequest(r, http.MethodPost, "/admin/tenants", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestAdminCreateTenant_MissingSlug(t *testing.T) {
+	r := newAdminTenantRouter(&mockAdminTenantService{})
+	body := map[string]interface{}{
+		"name": "acme-corp",
+	}
+	w := doRequest(r, http.MethodPost, "/admin/tenants", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestAdminCreateTenant_InvalidJSON(t *testing.T) {
+	r := newAdminTenantRouter(&mockAdminTenantService{})
+	w := doRequest(r, http.MethodPost, "/admin/tenants", nil)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminCreateTenant_Conflict(t *testing.T) {
+	svc := &mockAdminTenantService{
+		createTenantFn: func(_ context.Context, _ *api.CreateTenantRequest) (*api.AdminTenant, error) {
+			return nil, fmt.Errorf("slug already exists: %w", api.ErrConflict)
+		},
+	}
+	r := newAdminTenantRouter(svc)
+	body := map[string]interface{}{
+		"name": "acme-corp",
+		"slug": "acmecorp",
+	}
+	w := doRequest(r, http.MethodPost, "/admin/tenants", body)
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+// --- Update Tenant ---
+
+func TestAdminUpdateTenant_Success(t *testing.T) {
+	r := newAdminTenantRouter(&mockAdminTenantService{})
+	body := map[string]interface{}{"name": "updated-name"}
+	w := doRequest(r, http.MethodPatch, "/admin/tenants/tenant-1", body)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp api.AdminTenant
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "updated-name", resp.Name)
+}
+
+func TestAdminUpdateTenant_NotFound(t *testing.T) {
+	svc := &mockAdminTenantService{
+		updateTenantFn: func(_ context.Context, _ string, _ *api.UpdateTenantRequest) (*api.AdminTenant, error) {
+			return nil, fmt.Errorf("tenant not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminTenantRouter(svc)
+	body := map[string]interface{}{"name": "nope"}
+	w := doRequest(r, http.MethodPatch, "/admin/tenants/nonexistent", body)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestAdminUpdateTenant_InvalidJSON(t *testing.T) {
+	r := newAdminTenantRouter(&mockAdminTenantService{})
+	w := doRequest(r, http.MethodPatch, "/admin/tenants/tenant-1", nil)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminUpdateTenant_InvalidStatus(t *testing.T) {
+	r := newAdminTenantRouter(&mockAdminTenantService{})
+	body := map[string]interface{}{"status": "invalid"}
+	w := doRequest(r, http.MethodPatch, "/admin/tenants/tenant-1", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+// --- Delete Tenant ---
+
+func TestAdminDeleteTenant_Success(t *testing.T) {
+	r := newAdminTenantRouter(&mockAdminTenantService{})
+	w := doRequest(r, http.MethodDelete, "/admin/tenants/tenant-1", nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestAdminDeleteTenant_NotFound(t *testing.T) {
+	svc := &mockAdminTenantService{
+		deleteTenantFn: func(_ context.Context, _ string) error {
+			return fmt.Errorf("tenant not found: %w", api.ErrNotFound)
+		},
+	}
+	r := newAdminTenantRouter(svc)
+	w := doRequest(r, http.MethodDelete, "/admin/tenants/nonexistent", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestAdminDeleteTenant_AlreadyDeleted(t *testing.T) {
+	svc := &mockAdminTenantService{
+		deleteTenantFn: func(_ context.Context, _ string) error {
+			return fmt.Errorf("tenant already deleted: %w", api.ErrConflict)
+		},
+	}
+	r := newAdminTenantRouter(svc)
+	w := doRequest(r, http.MethodDelete, "/admin/tenants/deleted-tenant", nil)
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -38,6 +38,9 @@ func NewPublicRouter(svc *Services, mw *MiddlewareStack, healthSvc *health.Servi
 		if mw.Metrics != nil {
 			r.Use(mw.Metrics)
 		}
+		if mw.Tenant != nil {
+			r.Use(mw.Tenant)
+		}
 	}
 
 	v := domain.NewValidator()

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -362,4 +362,5 @@ type MiddlewareStack struct {
 	Auth            gin.HandlerFunc
 	DPoP            gin.HandlerFunc
 	Metrics         gin.HandlerFunc
+	Tenant          gin.HandlerFunc
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-362.

Closes #362

## Changes

Create `internal/api/admin_tenant_handlers.go` with HTTP handlers (List, Get, Create, Update, Delete) following the pattern in `admin_user_handlers.go` (parse pagination, bind JSON, validate with `adminValidator`, call service, return JSON or `handleServiceError`). Register the `/admin/tenants` route group in `internal/api/admin_router.go` with conditional nil-check on `svc.Tenants`. Wire `TenantMiddleware` into the public router middleware stack in `internal/api/router.go`. Add handler tests in `internal/api/admin_tenant_handlers_test.go` using function-pointer mocks.