### PR TITLE
GH-363: Server Wiring and Integration

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -188,6 +188,7 @@ func run(log *zap.Logger, cfg *config.Config) error {
 	adminUserRepo := storage.NewPostgresAdminUserRepository(pgPool)
 	clientRepo := storage.NewPostgresClientRepository(pgPool)
 	apiKeyRepo := storage.NewPostgresAPIKeyRepository(pgPool)
+	tenantRepo := storage.NewPostgresTenantRepository(pgPool)
 
 	// ── Webhook repositories ─────────────────────────────────────────────
 	webhookRepo := storage.NewPostgresWebhookRepository(pgPool)
@@ -202,6 +203,11 @@ func run(log *zap.Logger, cfg *config.Config) error {
 	adminTokenSvc := admin.NewTokenService(tokenSvc, refreshTokenRepo, "auth-service", log, auditSvc)
 	adminAPIKeySvc := admin.NewAPIKeyService(apiKeyRepo, hasher, log, auditSvc)
 	adminWebhookSvc := admin.NewWebhookService(webhookRepo, webhookDeliveryRepo, webhookDispatcher, log, auditSvc)
+	adminTenantSvc := admin.NewTenantService(tenantRepo, log, auditSvc)
+
+	// ── Tenant resolution ─────────────────────────────────────────────────
+	tenantCache := middleware.NewTenantCache(cfg.Tenant.CacheTTL)
+	tenantResolver := middleware.NewTenantRepositoryResolver(tenantRepo)
 
 	// ── Middleware ─────────────────────────────────────────────────────────
 	rateLimiter := middleware.NewRateLimiter(cfg.Rate)
@@ -221,6 +227,7 @@ func run(log *zap.Logger, cfg *config.Config) error {
 		Auth:            middleware.AuthMiddleware(tokenSvc),
 		DPoP:            dpopMW,
 		Metrics:         metricsCollector.Middleware(),
+		Tenant:          middleware.TenantMiddleware(cfg.Tenant, tenantResolver, tenantCache),
 	}
 
 	// Consent and client approval services are registered in subsequent issues.
@@ -246,6 +253,7 @@ func run(log *zap.Logger, cfg *config.Config) error {
 		Webhooks:       adminWebhookSvc,
 		Brokers:        adminBrokerSvc,
 		SAML:           adminSAMLSvc,
+		Tenants:        adminTenantSvc,
 	}
 
 	adminDeps := &api.AdminDeps{

--- a/internal/admin/tenant_service.go
+++ b/internal/admin/tenant_service.go
@@ -1,0 +1,101 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/audit"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+// Tenant audit event type constants.
+const (
+	eventAdminTenantCreate = "admin_tenant_create"
+	eventAdminTenantUpdate = "admin_tenant_update"
+	eventAdminTenantDelete = "admin_tenant_delete"
+)
+
+// TenantService implements admin tenant management operations.
+type TenantService struct {
+	repo   storage.TenantRepository
+	logger *zap.Logger
+	audit  audit.EventLogger
+}
+
+// NewTenantService creates a new admin tenant service.
+func NewTenantService(repo storage.TenantRepository, logger *zap.Logger, auditor audit.EventLogger) *TenantService {
+	return &TenantService{
+		repo:   repo,
+		logger: logger,
+		audit:  auditor,
+	}
+}
+
+// GetTenant returns a tenant by ID.
+func (s *TenantService) GetTenant(ctx context.Context, id string) (*domain.Tenant, error) {
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		return nil, fmt.Errorf("invalid tenant id: %w", err)
+	}
+	tenant, err := s.repo.FindByID(ctx, parsed)
+	if err != nil {
+		return nil, fmt.Errorf("get tenant: %w", err)
+	}
+	return tenant, nil
+}
+
+// ListTenants returns a paginated list of tenants.
+func (s *TenantService) ListTenants(ctx context.Context, page, perPage int) ([]*domain.Tenant, int, error) {
+	offset := (page - 1) * perPage
+	tenants, total, err := s.repo.List(ctx, perPage, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list tenants: %w", err)
+	}
+	return tenants, total, nil
+}
+
+// CreateTenant creates a new tenant.
+func (s *TenantService) CreateTenant(ctx context.Context, tenant *domain.Tenant) (*domain.Tenant, error) {
+	created, err := s.repo.Create(ctx, tenant)
+	if err != nil {
+		return nil, fmt.Errorf("create tenant: %w", err)
+	}
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     eventAdminTenantCreate,
+		TargetID: created.ID.String(),
+	})
+	return created, nil
+}
+
+// UpdateTenant updates an existing tenant.
+func (s *TenantService) UpdateTenant(ctx context.Context, tenant *domain.Tenant) (*domain.Tenant, error) {
+	updated, err := s.repo.Update(ctx, tenant)
+	if err != nil {
+		return nil, fmt.Errorf("update tenant: %w", err)
+	}
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     eventAdminTenantUpdate,
+		TargetID: updated.ID.String(),
+	})
+	return updated, nil
+}
+
+// DeleteTenant removes a tenant by ID.
+func (s *TenantService) DeleteTenant(ctx context.Context, id string) error {
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		return fmt.Errorf("invalid tenant id: %w", err)
+	}
+	if err := s.repo.Delete(ctx, parsed); err != nil {
+		return fmt.Errorf("delete tenant: %w", err)
+	}
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     eventAdminTenantDelete,
+		TargetID: id,
+	})
+	return nil
+}

--- a/internal/admin/tenant_service_test.go
+++ b/internal/admin/tenant_service_test.go
@@ -1,0 +1,157 @@
+package admin_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/admin"
+	"github.com/qf-studio/auth-service/internal/audit"
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+// stubTenantRepo is a minimal in-memory stub for testing TenantService.
+type stubTenantRepo struct {
+	byID   map[uuid.UUID]*domain.Tenant
+	bySlug map[string]*domain.Tenant
+	err    error
+}
+
+func newStubTenantRepo(tenants ...*domain.Tenant) *stubTenantRepo {
+	r := &stubTenantRepo{
+		byID:   make(map[uuid.UUID]*domain.Tenant),
+		bySlug: make(map[string]*domain.Tenant),
+	}
+	for _, t := range tenants {
+		r.byID[t.ID] = t
+		r.bySlug[t.Slug] = t
+	}
+	return r
+}
+
+func (r *stubTenantRepo) Create(_ context.Context, t *domain.Tenant) (*domain.Tenant, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	r.byID[t.ID] = t
+	return t, nil
+}
+
+func (r *stubTenantRepo) FindByID(_ context.Context, id uuid.UUID) (*domain.Tenant, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	t, ok := r.byID[id]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return t, nil
+}
+
+func (r *stubTenantRepo) FindBySlug(_ context.Context, slug string) (*domain.Tenant, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	t, ok := r.bySlug[slug]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return t, nil
+}
+
+func (r *stubTenantRepo) List(_ context.Context, limit, offset int) ([]*domain.Tenant, int, error) {
+	if r.err != nil {
+		return nil, 0, r.err
+	}
+	all := make([]*domain.Tenant, 0, len(r.byID))
+	for _, t := range r.byID {
+		all = append(all, t)
+	}
+	return all, len(all), nil
+}
+
+func (r *stubTenantRepo) Update(_ context.Context, t *domain.Tenant) (*domain.Tenant, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	r.byID[t.ID] = t
+	return t, nil
+}
+
+func (r *stubTenantRepo) Delete(_ context.Context, id uuid.UUID) error {
+	if r.err != nil {
+		return r.err
+	}
+	delete(r.byID, id)
+	return nil
+}
+
+// noopAudit discards all audit events.
+type noopAudit struct{}
+
+func (n *noopAudit) LogEvent(_ context.Context, _ audit.Event) {}
+
+func newTenantSvc(repo *stubTenantRepo) *admin.TenantService {
+	return admin.NewTenantService(repo, zap.NewNop(), &noopAudit{})
+}
+
+func TestTenantService_GetTenant(t *testing.T) {
+	id := uuid.New()
+	tenant := &domain.Tenant{ID: id, Name: "Acme", Slug: "acme", Status: domain.TenantStatusActive}
+	svc := newTenantSvc(newStubTenantRepo(tenant))
+
+	t.Run("found", func(t *testing.T) {
+		got, err := svc.GetTenant(context.Background(), id.String())
+		require.NoError(t, err)
+		assert.Equal(t, id, got.ID)
+	})
+
+	t.Run("invalid uuid", func(t *testing.T) {
+		_, err := svc.GetTenant(context.Background(), "not-a-uuid")
+		require.Error(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := svc.GetTenant(context.Background(), uuid.NewString())
+		require.Error(t, err)
+	})
+}
+
+func TestTenantService_CreateTenant(t *testing.T) {
+	repo := newStubTenantRepo()
+	svc := newTenantSvc(repo)
+
+	tenant := &domain.Tenant{ID: uuid.New(), Name: "Beta", Slug: "beta", Status: domain.TenantStatusActive}
+	got, err := svc.CreateTenant(context.Background(), tenant)
+	require.NoError(t, err)
+	assert.Equal(t, tenant.ID, got.ID)
+}
+
+func TestTenantService_DeleteTenant(t *testing.T) {
+	id := uuid.New()
+	tenant := &domain.Tenant{ID: id, Name: "Del", Slug: "del", Status: domain.TenantStatusActive}
+	svc := newTenantSvc(newStubTenantRepo(tenant))
+
+	err := svc.DeleteTenant(context.Background(), id.String())
+	require.NoError(t, err)
+
+	// Verify deleted.
+	_, err = svc.GetTenant(context.Background(), id.String())
+	require.Error(t, err)
+}
+
+func TestTenantService_ListTenants(t *testing.T) {
+	id := uuid.New()
+	tenant := &domain.Tenant{ID: id, Name: "Gamma", Slug: "gamma", Status: domain.TenantStatusActive}
+	svc := newTenantSvc(newStubTenantRepo(tenant))
+
+	tenants, total, err := svc.ListTenants(context.Background(), 1, 10)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	assert.Len(t, tenants, 1)
+}

--- a/internal/api/admin_services.go
+++ b/internal/api/admin_services.go
@@ -3,6 +3,8 @@ package api
 import (
 	"context"
 	"time"
+
+	"github.com/qf-studio/auth-service/internal/domain"
 )
 
 // --- Admin response types ---
@@ -450,6 +452,15 @@ type AdminSAMLService interface {
 	GetAttributeMapping(ctx context.Context, idpID string) (map[string]string, error)
 }
 
+// AdminTenantService defines admin operations for tenant management.
+type AdminTenantService interface {
+	GetTenant(ctx context.Context, id string) (*domain.Tenant, error)
+	ListTenants(ctx context.Context, page, perPage int) ([]*domain.Tenant, int, error)
+	CreateTenant(ctx context.Context, tenant *domain.Tenant) (*domain.Tenant, error)
+	UpdateTenant(ctx context.Context, tenant *domain.Tenant) (*domain.Tenant, error)
+	DeleteTenant(ctx context.Context, id string) error
+}
+
 // AdminServices aggregates all admin service interfaces required by admin API handlers.
 type AdminServices struct {
 	Users          AdminUserService
@@ -462,4 +473,5 @@ type AdminServices struct {
 	Webhooks       AdminWebhookService
 	Brokers        AdminBrokerService
 	SAML           AdminSAMLService
+	Tenants        AdminTenantService
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -38,6 +38,9 @@ func NewPublicRouter(svc *Services, mw *MiddlewareStack, healthSvc *health.Servi
 		if mw.Metrics != nil {
 			r.Use(mw.Metrics)
 		}
+		if mw.Tenant != nil {
+			r.Use(mw.Tenant)
+		}
 	}
 
 	v := domain.NewValidator()

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -362,4 +362,5 @@ type MiddlewareStack struct {
 	Auth            gin.HandlerFunc
 	DPoP            gin.HandlerFunc
 	Metrics         gin.HandlerFunc
+	Tenant          gin.HandlerFunc
 }

--- a/internal/middleware/tenant_resolver.go
+++ b/internal/middleware/tenant_resolver.go
@@ -1,0 +1,44 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+// TenantRepositoryResolver adapts a storage.TenantRepository to the TenantResolver
+// interface used by TenantMiddleware. It resolves tenants by UUID or slug.
+type TenantRepositoryResolver struct {
+	repo storage.TenantRepository
+}
+
+// NewTenantRepositoryResolver creates a TenantResolver backed by the tenant repository.
+func NewTenantRepositoryResolver(repo storage.TenantRepository) *TenantRepositoryResolver {
+	return &TenantRepositoryResolver{repo: repo}
+}
+
+// ResolveTenant looks up a tenant by UUID string or slug. It tries UUID parse first;
+// if that fails it falls back to slug lookup.
+func (r *TenantRepositoryResolver) ResolveTenant(ctx context.Context, identifier string) (*TenantConfig, error) {
+	var tenant *domain.Tenant
+	var err error
+
+	if parsed, parseErr := uuid.Parse(identifier); parseErr == nil {
+		tenant, err = r.repo.FindByID(ctx, parsed)
+	} else {
+		tenant, err = r.repo.FindBySlug(ctx, identifier)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("resolve tenant %q: %w", identifier, err)
+	}
+
+	return &TenantConfig{
+		TenantID: tenant.ID.String(),
+		Name:     tenant.Name,
+		Active:   tenant.IsActive(),
+	}, nil
+}

--- a/internal/middleware/tenant_resolver_test.go
+++ b/internal/middleware/tenant_resolver_test.go
@@ -1,0 +1,103 @@
+package middleware_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/middleware"
+)
+
+// stubRepoForResolver is a minimal stub for storage.TenantRepository.
+type stubRepoForResolver struct {
+	byID   map[uuid.UUID]*domain.Tenant
+	bySlug map[string]*domain.Tenant
+}
+
+func newStubRepoForResolver(tenants ...*domain.Tenant) *stubRepoForResolver {
+	r := &stubRepoForResolver{
+		byID:   make(map[uuid.UUID]*domain.Tenant),
+		bySlug: make(map[string]*domain.Tenant),
+	}
+	for _, t := range tenants {
+		r.byID[t.ID] = t
+		r.bySlug[t.Slug] = t
+	}
+	return r
+}
+
+func (r *stubRepoForResolver) Create(_ context.Context, t *domain.Tenant) (*domain.Tenant, error) {
+	return t, nil
+}
+
+func (r *stubRepoForResolver) FindByID(_ context.Context, id uuid.UUID) (*domain.Tenant, error) {
+	t, ok := r.byID[id]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return t, nil
+}
+
+func (r *stubRepoForResolver) FindBySlug(_ context.Context, slug string) (*domain.Tenant, error) {
+	t, ok := r.bySlug[slug]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return t, nil
+}
+
+func (r *stubRepoForResolver) List(_ context.Context, _, _ int) ([]*domain.Tenant, int, error) {
+	return nil, 0, nil
+}
+
+func (r *stubRepoForResolver) Update(_ context.Context, t *domain.Tenant) (*domain.Tenant, error) {
+	return t, nil
+}
+
+func (r *stubRepoForResolver) Delete(_ context.Context, _ uuid.UUID) error {
+	return nil
+}
+
+func TestTenantRepositoryResolver_ByUUID(t *testing.T) {
+	id := uuid.New()
+	tenant := &domain.Tenant{ID: id, Name: "Acme", Slug: "acme", Status: domain.TenantStatusActive}
+	resolver := middleware.NewTenantRepositoryResolver(newStubRepoForResolver(tenant))
+
+	cfg, err := resolver.ResolveTenant(context.Background(), id.String())
+	require.NoError(t, err)
+	assert.Equal(t, id.String(), cfg.TenantID)
+	assert.True(t, cfg.Active)
+}
+
+func TestTenantRepositoryResolver_BySlug(t *testing.T) {
+	id := uuid.New()
+	tenant := &domain.Tenant{ID: id, Name: "Acme", Slug: "acme", Status: domain.TenantStatusActive}
+	resolver := middleware.NewTenantRepositoryResolver(newStubRepoForResolver(tenant))
+
+	cfg, err := resolver.ResolveTenant(context.Background(), "acme")
+	require.NoError(t, err)
+	assert.Equal(t, id.String(), cfg.TenantID)
+	assert.Equal(t, "Acme", cfg.Name)
+}
+
+func TestTenantRepositoryResolver_NotFound(t *testing.T) {
+	resolver := middleware.NewTenantRepositoryResolver(newStubRepoForResolver())
+
+	_, err := resolver.ResolveTenant(context.Background(), "unknown-slug")
+	require.Error(t, err)
+}
+
+func TestTenantRepositoryResolver_Inactive(t *testing.T) {
+	id := uuid.New()
+	tenant := &domain.Tenant{ID: id, Name: "Suspended", Slug: "susp", Status: domain.TenantStatusSuspended}
+	resolver := middleware.NewTenantRepositoryResolver(newStubRepoForResolver(tenant))
+
+	cfg, err := resolver.ResolveTenant(context.Background(), id.String())
+	require.NoError(t, err)
+	assert.False(t, cfg.Active)
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-363.

Closes #363

## Changes

In `cmd/server/main.go`: instantiate `admin.NewTenantService(tenantRepo, logger, auditSvc)`, assign it to `adminServices.Tenants`, create a `TenantCache`, build a `TenantResolver` adapter backed by the existing `TenantRepository`, and apply `middleware.TenantMiddleware(cfg.Tenant, resolver, cache)` to the public router's middleware stack. Ensure the tenant config env vars (`TENANT_DEFAULT_ID`, `TENANT_RESOLUTION_MODE`, `TENANT_BASE_DOMAIN`, `TENANT_CACHE_TTL`) are loaded via the existing `config.TenantConfig`.