### PR TITLE
GH-368: Fix duplicate tenant types, reconcile ListTenants signature, and update storage layer

### DIFF
--- a/internal/admin/tenant_service.go
+++ b/internal/admin/tenant_service.go
@@ -53,11 +53,11 @@ func NewTenantService(repo storage.TenantRepository, logger *zap.Logger, auditor
 	}
 }
 
-// ListTenants returns a paginated list of tenants.
-func (s *TenantService) ListTenants(ctx context.Context, page, perPage int) (*api.AdminTenantList, error) {
+// ListTenants returns a paginated list of tenants, optionally filtered by status.
+func (s *TenantService) ListTenants(ctx context.Context, page, perPage int, status string) (*api.AdminTenantList, error) {
 	offset := (page - 1) * perPage
 
-	tenants, total, err := s.repo.List(ctx, perPage, offset)
+	tenants, total, err := s.repo.List(ctx, perPage, offset, status)
 	if err != nil {
 		s.logger.Error("list tenants failed", zap.Error(err))
 		return nil, fmt.Errorf("list tenants: %w", api.ErrInternalError)

--- a/internal/admin/tenant_service_test.go
+++ b/internal/admin/tenant_service_test.go
@@ -42,30 +42,59 @@ func newTestTenantService(repo *mocks.MockTenantRepository) *TenantService {
 func TestTenantService_ListTenants(t *testing.T) {
 	tenant := testTenant()
 	repo := &mocks.MockTenantRepository{
-		ListFn: func(_ context.Context, limit, offset int) ([]*domain.Tenant, int, error) {
+		ListFn: func(_ context.Context, limit, offset int, status string) ([]*domain.Tenant, int, error) {
 			assert.Equal(t, 20, limit)
 			assert.Equal(t, 0, offset)
+			assert.Equal(t, "", status)
 			return []*domain.Tenant{tenant}, 1, nil
 		},
 	}
 	svc := newTestTenantService(repo)
 
-	result, err := svc.ListTenants(context.Background(), 1, 20)
+	result, err := svc.ListTenants(context.Background(), 1, 20, "")
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Total)
 	assert.Len(t, result.Tenants, 1)
 	assert.Equal(t, tenant.ID.String(), result.Tenants[0].ID)
 }
 
+func TestTenantService_ListTenants_StatusFilter(t *testing.T) {
+	activeTenant := testTenant()
+	tests := []struct {
+		name   string
+		status string
+	}{
+		{"filter active", "active"},
+		{"filter suspended", "suspended"},
+		{"filter deleted", "deleted"},
+		{"no filter", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mocks.MockTenantRepository{
+				ListFn: func(_ context.Context, limit, offset int, status string) ([]*domain.Tenant, int, error) {
+					assert.Equal(t, tt.status, status)
+					return []*domain.Tenant{activeTenant}, 1, nil
+				},
+			}
+			svc := newTestTenantService(repo)
+
+			result, err := svc.ListTenants(context.Background(), 1, 20, tt.status)
+			require.NoError(t, err)
+			assert.Equal(t, 1, result.Total)
+		})
+	}
+}
+
 func TestTenantService_ListTenants_Error(t *testing.T) {
 	repo := &mocks.MockTenantRepository{
-		ListFn: func(_ context.Context, _, _ int) ([]*domain.Tenant, int, error) {
+		ListFn: func(_ context.Context, _, _ int, _ string) ([]*domain.Tenant, int, error) {
 			return nil, 0, fmt.Errorf("db error")
 		},
 	}
 	svc := newTestTenantService(repo)
 
-	_, err := svc.ListTenants(context.Background(), 1, 20)
+	_, err := svc.ListTenants(context.Background(), 1, 20, "")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, api.ErrInternalError)
 }

--- a/internal/api/admin_services.go
+++ b/internal/api/admin_services.go
@@ -3,8 +3,6 @@ package api
 import (
 	"context"
 	"time"
-
-	"github.com/qf-studio/auth-service/internal/domain"
 )
 
 // --- Admin response types ---
@@ -305,7 +303,7 @@ type UpdateTenantRequest struct {
 
 // AdminTenantService defines admin operations for tenant management.
 type AdminTenantService interface {
-	ListTenants(ctx context.Context, page, perPage int) (*AdminTenantList, error)
+	ListTenants(ctx context.Context, page, perPage int, status string) (*AdminTenantList, error)
 	GetTenant(ctx context.Context, tenantID string) (*AdminTenant, error)
 	CreateTenant(ctx context.Context, req *CreateTenantRequest) (*AdminTenant, error)
 	UpdateTenant(ctx context.Context, tenantID string, req *UpdateTenantRequest) (*AdminTenant, error)
@@ -523,50 +521,6 @@ type AdminSAMLService interface {
 	ExportMetadata(ctx context.Context, idpID string) ([]byte, error)
 	UpdateAttributeMapping(ctx context.Context, idpID string, req *SAMLAttributeMappingRequest) (*AdminSAMLIdP, error)
 	GetAttributeMapping(ctx context.Context, idpID string) (map[string]string, error)
-}
-
-// --- Tenant admin types ---
-
-// AdminTenant represents a tenant in admin API responses.
-type AdminTenant struct {
-	ID        string              `json:"id"`
-	Name      string              `json:"name"`
-	Slug      string              `json:"slug"`
-	Config    domain.TenantConfig `json:"config"`
-	Status    string              `json:"status"`
-	CreatedAt time.Time           `json:"created_at"`
-	UpdatedAt time.Time           `json:"updated_at"`
-}
-
-// AdminTenantList is the paginated response for listing tenants.
-type AdminTenantList struct {
-	Tenants []AdminTenant `json:"tenants"`
-	Total   int           `json:"total"`
-	Page    int           `json:"page"`
-	PerPage int           `json:"per_page"`
-}
-
-// CreateTenantRequest is the request body for creating a tenant.
-type CreateTenantRequest struct {
-	Name   string              `json:"name"   validate:"required,min=1,max=255"`
-	Slug   string              `json:"slug"   validate:"required,min=1,max=63,alphanum"`
-	Config domain.TenantConfig `json:"config"`
-}
-
-// UpdateTenantRequest is the request body for updating a tenant.
-type UpdateTenantRequest struct {
-	Name   *string              `json:"name"   validate:"omitempty,min=1,max=255"`
-	Config *domain.TenantConfig `json:"config" validate:"omitempty"`
-	Status *string              `json:"status" validate:"omitempty,oneof=active suspended"`
-}
-
-// AdminTenantService defines admin operations for tenant management.
-type AdminTenantService interface {
-	ListTenants(ctx context.Context, page, perPage int, status string) (*AdminTenantList, error)
-	GetTenant(ctx context.Context, tenantID string) (*AdminTenant, error)
-	CreateTenant(ctx context.Context, req *CreateTenantRequest) (*AdminTenant, error)
-	UpdateTenant(ctx context.Context, tenantID string, req *UpdateTenantRequest) (*AdminTenant, error)
-	DeleteTenant(ctx context.Context, tenantID string) error
 }
 
 // AdminServices aggregates all admin service interfaces required by admin API handlers.

--- a/internal/api/admin_tenant_handlers_test.go
+++ b/internal/api/admin_tenant_handlers_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/qf-studio/auth-service/internal/api"
-	"github.com/qf-studio/auth-service/internal/domain"
 	"github.com/qf-studio/auth-service/internal/health"
 )
 
@@ -32,7 +31,7 @@ func (m *mockAdminTenantService) ListTenants(ctx context.Context, page, perPage 
 		return m.listTenantsFn(ctx, page, perPage, status)
 	}
 	return &api.AdminTenantList{
-		Tenants: []api.AdminTenant{{ID: "t1", Name: "default", Slug: "default", Status: "active", Config: domain.TenantConfig{}, CreatedAt: time.Now(), UpdatedAt: time.Now()}},
+		Tenants: []api.AdminTenant{{ID: "t1", Name: "default", Slug: "default", Status: "active", Config: api.AdminTenantConfig{}, CreatedAt: time.Now(), UpdatedAt: time.Now()}},
 		Total:   1,
 		Page:    page,
 		PerPage: perPage,
@@ -43,18 +42,22 @@ func (m *mockAdminTenantService) GetTenant(ctx context.Context, tenantID string)
 	if m.getTenantFn != nil {
 		return m.getTenantFn(ctx, tenantID)
 	}
-	return &api.AdminTenant{ID: tenantID, Name: "default", Slug: "default", Status: "active", Config: domain.TenantConfig{}, CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+	return &api.AdminTenant{ID: tenantID, Name: "default", Slug: "default", Status: "active", Config: api.AdminTenantConfig{}, CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
 }
 
 func (m *mockAdminTenantService) CreateTenant(ctx context.Context, req *api.CreateTenantRequest) (*api.AdminTenant, error) {
 	if m.createTenantFn != nil {
 		return m.createTenantFn(ctx, req)
 	}
+	cfg := api.AdminTenantConfig{}
+	if req.Config != nil {
+		cfg = *req.Config
+	}
 	return &api.AdminTenant{
 		ID:        "new-tenant",
 		Name:      req.Name,
 		Slug:      req.Slug,
-		Config:    req.Config,
+		Config:    cfg,
 		Status:    "active",
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -69,7 +72,7 @@ func (m *mockAdminTenantService) UpdateTenant(ctx context.Context, tenantID stri
 	if req.Name != nil {
 		name = *req.Name
 	}
-	return &api.AdminTenant{ID: tenantID, Name: name, Slug: "default", Status: "active", Config: domain.TenantConfig{}, CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+	return &api.AdminTenant{ID: tenantID, Name: name, Slug: "default", Status: "active", Config: api.AdminTenantConfig{}, CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
 }
 
 func (m *mockAdminTenantService) DeleteTenant(ctx context.Context, tenantID string) error {

--- a/internal/storage/mocks/tenant_repository.go
+++ b/internal/storage/mocks/tenant_repository.go
@@ -13,7 +13,7 @@ type MockTenantRepository struct {
 	CreateFn     func(ctx context.Context, tenant *domain.Tenant) (*domain.Tenant, error)
 	FindByIDFn   func(ctx context.Context, id uuid.UUID) (*domain.Tenant, error)
 	FindBySlugFn func(ctx context.Context, slug string) (*domain.Tenant, error)
-	ListFn       func(ctx context.Context, limit, offset int) ([]*domain.Tenant, int, error)
+	ListFn       func(ctx context.Context, limit, offset int, status string) ([]*domain.Tenant, int, error)
 	UpdateFn     func(ctx context.Context, tenant *domain.Tenant) (*domain.Tenant, error)
 	DeleteFn     func(ctx context.Context, id uuid.UUID) error
 }
@@ -34,8 +34,8 @@ func (m *MockTenantRepository) FindBySlug(ctx context.Context, slug string) (*do
 }
 
 // List delegates to ListFn.
-func (m *MockTenantRepository) List(ctx context.Context, limit, offset int) ([]*domain.Tenant, int, error) {
-	return m.ListFn(ctx, limit, offset)
+func (m *MockTenantRepository) List(ctx context.Context, limit, offset int, status string) ([]*domain.Tenant, int, error) {
+	return m.ListFn(ctx, limit, offset, status)
 }
 
 // Update delegates to UpdateFn.

--- a/internal/storage/tenant_repository.go
+++ b/internal/storage/tenant_repository.go
@@ -20,7 +20,7 @@ type TenantRepository interface {
 	Create(ctx context.Context, tenant *domain.Tenant) (*domain.Tenant, error)
 	FindByID(ctx context.Context, id uuid.UUID) (*domain.Tenant, error)
 	FindBySlug(ctx context.Context, slug string) (*domain.Tenant, error)
-	List(ctx context.Context, limit, offset int) ([]*domain.Tenant, int, error)
+	List(ctx context.Context, limit, offset int, status string) ([]*domain.Tenant, int, error)
 	Update(ctx context.Context, tenant *domain.Tenant) (*domain.Tenant, error)
 	Delete(ctx context.Context, id uuid.UUID) error
 }
@@ -104,15 +104,27 @@ func (r *PostgresTenantRepository) FindBySlug(ctx context.Context, slug string) 
 	return t, nil
 }
 
-// List returns a paginated list of tenants ordered by name.
-func (r *PostgresTenantRepository) List(ctx context.Context, limit, offset int) ([]*domain.Tenant, int, error) {
+// List returns a paginated list of tenants ordered by name, optionally filtered by status.
+func (r *PostgresTenantRepository) List(ctx context.Context, limit, offset int, status string) ([]*domain.Tenant, int, error) {
 	var total int
-	if err := r.pool.QueryRow(ctx, `SELECT COUNT(*) FROM tenants`).Scan(&total); err != nil {
+	args := []interface{}{}
+	where := ""
+	if status != "" {
+		where = " WHERE status = $1"
+		args = append(args, status)
+	}
+
+	countQuery := `SELECT COUNT(*) FROM tenants` + where
+	if err := r.pool.QueryRow(ctx, countQuery, args...).Scan(&total); err != nil {
 		return nil, 0, fmt.Errorf("count tenants: %w", err)
 	}
 
-	query := fmt.Sprintf(`SELECT %s FROM tenants ORDER BY name LIMIT $1 OFFSET $2`, tenantColumns)
-	rows, err := r.pool.Query(ctx, query, limit, offset)
+	limitIdx := len(args) + 1
+	offsetIdx := len(args) + 2
+	query := fmt.Sprintf(`SELECT %s FROM tenants%s ORDER BY name LIMIT $%d OFFSET $%d`,
+		tenantColumns, where, limitIdx, offsetIdx)
+	listArgs := append(args, limit, offset)
+	rows, err := r.pool.Query(ctx, query, listArgs...)
 	if err != nil {
 		return nil, 0, fmt.Errorf("list tenants: %w", err)
 	}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-368.

Closes #368

## Changes

This is the complete fix:
- **`internal/api/admin_services.go`**: Delete the duplicate type block at lines 528–570 (second copies of `AdminTenant`, `AdminTenantList`, `CreateTenantRequest`, `UpdateTenantRequest`, `AdminTenantService`). Update the kept `AdminTenantService.ListTenants` at line 308 to add `status string` parameter: `ListTenants(ctx context.Context, page, perPage int, status string) (*AdminTenantList, error)`. The first block's types (lines 245–304) use `AdminTenantConfig` which is the correct API DTO; the duplicate block incorrectly uses `domain.TenantConfig` directly — so the first block is the one to keep.
- **`internal/storage/tenant_repository.go`**: Update `TenantRepository` interface `List` method (line 23) to accept `status string`. Update `PostgresTenantRepository.List` (line 108) to accept and apply the status filter with a conditional `WHERE status = $N` clause when non-empty.
- **`internal/storage/mocks/tenant_repository.go`**: Update `MockTenantRepository.List` (line 37) to match the new signature.
- **`internal/admin/tenant_service.go`**: Update `TenantService.ListTenants` (line 57) to accept `status string` and pass it through to `s.repo.List`.
- **`internal/admin/tenant_service_test.go`**: Update existing tests and add cases for status filtering (active, suspended, deleted, empty string).
- **`internal/api/admin_tenant_handlers_test.go`**: Update test expectations to match the 4-arg `ListTenants` call.
- **Verify**: `go vet ./...`, `go build ./...`, `go test ./internal/api/... ./internal/admin/...` all pass.