### PR TITLE
GH-374: `cmd/server/main.go`

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/qf-studio/auth-service/internal/audit"
 	"github.com/qf-studio/auth-service/internal/auth"
 	"github.com/qf-studio/auth-service/internal/config"
+	"github.com/qf-studio/auth-service/internal/email"
 	"github.com/qf-studio/auth-service/internal/dpop"
 	grpcserver "github.com/qf-studio/auth-service/internal/grpc"
 	"github.com/qf-studio/auth-service/internal/webhook"
@@ -92,6 +93,18 @@ func run(log *zap.Logger, cfg *config.Config) error {
 	}
 	hibpClient := hibp.NewClient(http.DefaultClient)
 	authSvc := auth.NewService(redisClient, log, auditSvc, userRepo, refreshTokenRepo, tokenSvc, hasher, hibpClient)
+
+	// ── Email sender ─────────────────────────────────────────────────────
+	var emailSender email.EmailSender
+	if cfg.Email.ServiceURL != "" {
+		emailSender = email.NewHTTPSender(cfg.Email.ServiceURL, cfg.Email.APIKey, cfg.Email.SenderAddress, nil)
+		log.Info("email sender: HTTP", zap.String("service_url", cfg.Email.ServiceURL))
+	} else {
+		emailSender = email.NewConsoleSender(log)
+		log.Info("email sender: console (EMAIL_SERVICE_URL not set)")
+	}
+	authSvc.SetEmailSender(emailSender)
+	authSvc.SetBaseURL(cfg.App.BaseURL)
 
 	// ── Session ──────────────────────────────────────────────────────────
 	sessionStore := session.NewMemoryStore()

--- a/internal/api/admin_services.go
+++ b/internal/api/admin_services.go
@@ -3,8 +3,6 @@ package api
 import (
 	"context"
 	"time"
-
-	"github.com/qf-studio/auth-service/internal/domain"
 )
 
 // --- Admin response types ---
@@ -239,79 +237,6 @@ type AdminAPIKeyService interface {
 	RotateAPIKey(ctx context.Context, keyID string) (*AdminAPIKeyWithSecret, error)
 }
 
-// --- Tenant admin types ---
-
-// AdminTenant represents a tenant in admin API responses.
-type AdminTenant struct {
-	ID        string              `json:"id"`
-	Name      string              `json:"name"`
-	Slug      string              `json:"slug"`
-	Config    AdminTenantConfig   `json:"config"`
-	Status    string              `json:"status"`
-	CreatedAt time.Time           `json:"created_at"`
-	UpdatedAt time.Time           `json:"updated_at"`
-}
-
-// AdminTenantConfig mirrors domain.TenantConfig for API responses.
-type AdminTenantConfig struct {
-	PasswordPolicy        *AdminTenantPasswordPolicy `json:"password_policy,omitempty"`
-	MFA                   *AdminTenantMFAConfig      `json:"mfa,omitempty"`
-	AllowedOAuthProviders []string                   `json:"allowed_oauth_providers,omitempty"`
-	TokenTTLs             *AdminTenantTokenTTLs      `json:"token_ttls,omitempty"`
-}
-
-// AdminTenantPasswordPolicy mirrors domain.TenantPasswordPolicy for API responses.
-type AdminTenantPasswordPolicy struct {
-	MinLength    *int `json:"min_length,omitempty"`
-	MaxLength    *int `json:"max_length,omitempty"`
-	MaxAgeDays   *int `json:"max_age_days,omitempty"`
-	HistoryCount *int `json:"history_count,omitempty"`
-}
-
-// AdminTenantMFAConfig mirrors domain.TenantMFAConfig for API responses.
-type AdminTenantMFAConfig struct {
-	Required        bool     `json:"required"`
-	AllowedMethods  []string `json:"allowed_methods,omitempty"`
-	GracePeriodDays int      `json:"grace_period_days,omitempty"`
-}
-
-// AdminTenantTokenTTLs mirrors domain.TenantTokenTTLs for API responses.
-type AdminTenantTokenTTLs struct {
-	AccessTokenTTL  *int `json:"access_token_ttl,omitempty"`
-	RefreshTokenTTL *int `json:"refresh_token_ttl,omitempty"`
-}
-
-// AdminTenantList is the paginated response for listing tenants.
-type AdminTenantList struct {
-	Tenants []AdminTenant `json:"tenants"`
-	Total   int           `json:"total"`
-	Page    int           `json:"page"`
-	PerPage int           `json:"per_page"`
-}
-
-// CreateTenantRequest is the request body for creating a tenant.
-type CreateTenantRequest struct {
-	Name   string              `json:"name"   validate:"required,min=1,max=255"`
-	Slug   string              `json:"slug"   validate:"required,min=1,max=63"`
-	Config *AdminTenantConfig  `json:"config" validate:"omitempty"`
-}
-
-// UpdateTenantRequest is the request body for updating a tenant.
-type UpdateTenantRequest struct {
-	Name   *string             `json:"name"   validate:"omitempty,min=1,max=255"`
-	Config *AdminTenantConfig  `json:"config" validate:"omitempty"`
-	Status *string             `json:"status" validate:"omitempty,oneof=active suspended"`
-}
-
-// AdminTenantService defines admin operations for tenant management.
-type AdminTenantService interface {
-	ListTenants(ctx context.Context, page, perPage int) (*AdminTenantList, error)
-	GetTenant(ctx context.Context, tenantID string) (*AdminTenant, error)
-	CreateTenant(ctx context.Context, req *CreateTenantRequest) (*AdminTenant, error)
-	UpdateTenant(ctx context.Context, tenantID string, req *UpdateTenantRequest) (*AdminTenant, error)
-	DeleteTenant(ctx context.Context, tenantID string) error
-}
-
 // --- Webhook admin types ---
 
 // AdminWebhook represents a webhook subscription in admin API responses.
@@ -527,15 +452,44 @@ type AdminSAMLService interface {
 
 // --- Tenant admin types ---
 
+// AdminTenantConfig mirrors domain.TenantConfig for API responses.
+type AdminTenantConfig struct {
+	PasswordPolicy        *AdminTenantPasswordPolicy `json:"password_policy,omitempty"`
+	MFA                   *AdminTenantMFAConfig      `json:"mfa,omitempty"`
+	AllowedOAuthProviders []string                   `json:"allowed_oauth_providers,omitempty"`
+	TokenTTLs             *AdminTenantTokenTTLs      `json:"token_ttls,omitempty"`
+}
+
+// AdminTenantPasswordPolicy mirrors domain.TenantPasswordPolicy for API responses.
+type AdminTenantPasswordPolicy struct {
+	MinLength    *int `json:"min_length,omitempty"`
+	MaxLength    *int `json:"max_length,omitempty"`
+	MaxAgeDays   *int `json:"max_age_days,omitempty"`
+	HistoryCount *int `json:"history_count,omitempty"`
+}
+
+// AdminTenantMFAConfig mirrors domain.TenantMFAConfig for API responses.
+type AdminTenantMFAConfig struct {
+	Required        bool     `json:"required"`
+	AllowedMethods  []string `json:"allowed_methods,omitempty"`
+	GracePeriodDays int      `json:"grace_period_days,omitempty"`
+}
+
+// AdminTenantTokenTTLs mirrors domain.TenantTokenTTLs for API responses.
+type AdminTenantTokenTTLs struct {
+	AccessTokenTTL  *int `json:"access_token_ttl,omitempty"`
+	RefreshTokenTTL *int `json:"refresh_token_ttl,omitempty"`
+}
+
 // AdminTenant represents a tenant in admin API responses.
 type AdminTenant struct {
-	ID        string              `json:"id"`
-	Name      string              `json:"name"`
-	Slug      string              `json:"slug"`
-	Config    domain.TenantConfig `json:"config"`
-	Status    string              `json:"status"`
-	CreatedAt time.Time           `json:"created_at"`
-	UpdatedAt time.Time           `json:"updated_at"`
+	ID        string            `json:"id"`
+	Name      string            `json:"name"`
+	Slug      string            `json:"slug"`
+	Config    AdminTenantConfig `json:"config"`
+	Status    string            `json:"status"`
+	CreatedAt time.Time         `json:"created_at"`
+	UpdatedAt time.Time         `json:"updated_at"`
 }
 
 // AdminTenantList is the paginated response for listing tenants.
@@ -548,16 +502,16 @@ type AdminTenantList struct {
 
 // CreateTenantRequest is the request body for creating a tenant.
 type CreateTenantRequest struct {
-	Name   string              `json:"name"   validate:"required,min=1,max=255"`
-	Slug   string              `json:"slug"   validate:"required,min=1,max=63,alphanum"`
-	Config domain.TenantConfig `json:"config"`
+	Name   string             `json:"name"   validate:"required,min=1,max=255"`
+	Slug   string             `json:"slug"   validate:"required,min=1,max=63,alphanum"`
+	Config *AdminTenantConfig `json:"config" validate:"omitempty"`
 }
 
 // UpdateTenantRequest is the request body for updating a tenant.
 type UpdateTenantRequest struct {
-	Name   *string              `json:"name"   validate:"omitempty,min=1,max=255"`
-	Config *domain.TenantConfig `json:"config" validate:"omitempty"`
-	Status *string              `json:"status" validate:"omitempty,oneof=active suspended"`
+	Name   *string            `json:"name"   validate:"omitempty,min=1,max=255"`
+	Config *AdminTenantConfig `json:"config" validate:"omitempty"`
+	Status *string            `json:"status" validate:"omitempty,oneof=active suspended"`
 }
 
 // AdminTenantService defines admin operations for tenant management.

--- a/internal/api/admin_tenant_handlers_test.go
+++ b/internal/api/admin_tenant_handlers_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/qf-studio/auth-service/internal/api"
-	"github.com/qf-studio/auth-service/internal/domain"
 	"github.com/qf-studio/auth-service/internal/health"
 )
 
@@ -32,7 +31,7 @@ func (m *mockAdminTenantService) ListTenants(ctx context.Context, page, perPage 
 		return m.listTenantsFn(ctx, page, perPage, status)
 	}
 	return &api.AdminTenantList{
-		Tenants: []api.AdminTenant{{ID: "t1", Name: "default", Slug: "default", Status: "active", Config: domain.TenantConfig{}, CreatedAt: time.Now(), UpdatedAt: time.Now()}},
+		Tenants: []api.AdminTenant{{ID: "t1", Name: "default", Slug: "default", Status: "active", Config: api.AdminTenantConfig{}, CreatedAt: time.Now(), UpdatedAt: time.Now()}},
 		Total:   1,
 		Page:    page,
 		PerPage: perPage,
@@ -43,18 +42,22 @@ func (m *mockAdminTenantService) GetTenant(ctx context.Context, tenantID string)
 	if m.getTenantFn != nil {
 		return m.getTenantFn(ctx, tenantID)
 	}
-	return &api.AdminTenant{ID: tenantID, Name: "default", Slug: "default", Status: "active", Config: domain.TenantConfig{}, CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+	return &api.AdminTenant{ID: tenantID, Name: "default", Slug: "default", Status: "active", Config: api.AdminTenantConfig{}, CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
 }
 
 func (m *mockAdminTenantService) CreateTenant(ctx context.Context, req *api.CreateTenantRequest) (*api.AdminTenant, error) {
 	if m.createTenantFn != nil {
 		return m.createTenantFn(ctx, req)
 	}
+	cfg := api.AdminTenantConfig{}
+	if req.Config != nil {
+		cfg = *req.Config
+	}
 	return &api.AdminTenant{
 		ID:        "new-tenant",
 		Name:      req.Name,
 		Slug:      req.Slug,
-		Config:    req.Config,
+		Config:    cfg,
 		Status:    "active",
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -69,7 +72,7 @@ func (m *mockAdminTenantService) UpdateTenant(ctx context.Context, tenantID stri
 	if req.Name != nil {
 		name = *req.Name
 	}
-	return &api.AdminTenant{ID: tenantID, Name: name, Slug: "default", Status: "active", Config: domain.TenantConfig{}, CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+	return &api.AdminTenant{ID: tenantID, Name: name, Slug: "default", Status: "active", Config: api.AdminTenantConfig{}, CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
 }
 
 func (m *mockAdminTenantService) DeleteTenant(ctx context.Context, tenantID string) error {

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/qf-studio/auth-service/internal/api"
 	"github.com/qf-studio/auth-service/internal/audit"
 	"github.com/qf-studio/auth-service/internal/domain"
+	emailpkg "github.com/qf-studio/auth-service/internal/email"
 	"github.com/qf-studio/auth-service/internal/hibp"
 	"github.com/qf-studio/auth-service/internal/password"
 	"github.com/qf-studio/auth-service/internal/storage"
@@ -49,16 +50,18 @@ type MFAChecker interface {
 // Service implements api.AuthService with Redis-backed password reset tokens
 // and PostgreSQL-backed user authentication.
 type Service struct {
-	redis    *redis.Client
-	logger   *zap.Logger
-	audit    audit.EventLogger
-	users    storage.UserRepository
-	tokens   storage.RefreshTokenRepository
-	issuer   TokenIssuer
-	hasher   password.Hasher
-	breaches hibp.BreachChecker
-	mfa      MFAChecker
-	policy   *password.PolicyValidator
+	redis        *redis.Client
+	logger       *zap.Logger
+	audit        audit.EventLogger
+	users        storage.UserRepository
+	tokens       storage.RefreshTokenRepository
+	issuer       TokenIssuer
+	hasher       password.Hasher
+	breaches     hibp.BreachChecker
+	mfa          MFAChecker
+	policy       *password.PolicyValidator
+	emailSender  emailpkg.EmailSender
+	baseURL      string
 }
 
 // NewService creates a new auth Service.
@@ -94,6 +97,18 @@ func (s *Service) SetPasswordPolicy(pv *password.PolicyValidator) {
 // circular dependency between auth.Service and mfa.Service.
 func (s *Service) SetMFAChecker(mfa MFAChecker) {
 	s.mfa = mfa
+}
+
+// SetEmailSender injects the email sender after construction.
+// When nil, password reset emails are logged but not delivered.
+func (s *Service) SetEmailSender(sender emailpkg.EmailSender) {
+	s.emailSender = sender
+}
+
+// SetBaseURL sets the public-facing base URL used to construct links in emails
+// (e.g. password reset URLs).
+func (s *Service) SetBaseURL(baseURL string) {
+	s.baseURL = baseURL
 }
 
 // Register creates a new user account with policy-aware password validation.
@@ -320,7 +335,20 @@ func (s *Service) ResetPassword(ctx context.Context, email string) error {
 		Metadata: map[string]string{"email": email},
 	})
 
-	// TODO(GH-XX): send email with reset link containing the token.
+	if s.emailSender != nil {
+		resetURL := fmt.Sprintf("%s/reset-password?token=%s", s.baseURL, token)
+		msg := emailpkg.Message{
+			To:      email,
+			Subject: "Password Reset Request",
+			Body:    fmt.Sprintf("Click the link below to reset your password:\n\n%s\n\nThis link expires in %s.", resetURL, resetTokenTTL),
+		}
+		if sendErr := s.emailSender.Send(ctx, msg); sendErr != nil {
+			s.logger.Error("failed to send password reset email",
+				zap.String("email", email),
+				zap.Error(sendErr),
+			)
+		}
+	}
 
 	return nil
 }

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/qf-studio/auth-service/internal/api"
 	"github.com/qf-studio/auth-service/internal/audit"
 	"github.com/qf-studio/auth-service/internal/domain"
+	emailpkg "github.com/qf-studio/auth-service/internal/email"
 	"github.com/qf-studio/auth-service/internal/password"
 	"github.com/qf-studio/auth-service/internal/storage"
 )
@@ -913,4 +914,70 @@ func TestLogin_PasswordExpired(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.True(t, result.ForcePasswordChange)
+}
+
+// ── Email Sender Wiring Tests ──────────────────────────────────────────────
+
+type mockEmailSender struct {
+	sent []emailpkg.Message
+	err  error
+}
+
+func (m *mockEmailSender) Send(_ context.Context, msg emailpkg.Message) error {
+	m.sent = append(m.sent, msg)
+	return m.err
+}
+
+func TestSetEmailSender(t *testing.T) {
+	svc := newUnitService(t, &mockUserRepository{}, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, &mockHasher{})
+	assert.Nil(t, svc.emailSender)
+
+	sender := &mockEmailSender{}
+	svc.SetEmailSender(sender)
+	assert.Equal(t, sender, svc.emailSender)
+}
+
+func TestSetBaseURL(t *testing.T) {
+	svc := newUnitService(t, &mockUserRepository{}, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, &mockHasher{})
+	assert.Empty(t, svc.baseURL)
+
+	svc.SetBaseURL("https://auth.example.com")
+	assert.Equal(t, "https://auth.example.com", svc.baseURL)
+}
+
+func TestResetPassword_SendsEmail(t *testing.T) {
+	svc := newIntegrationService(t)
+	sender := &mockEmailSender{}
+	svc.SetEmailSender(sender)
+	svc.SetBaseURL("https://auth.example.com")
+
+	err := svc.ResetPassword(context.Background(), "alice@example.com")
+	require.NoError(t, err)
+
+	require.Len(t, sender.sent, 1)
+	msg := sender.sent[0]
+	assert.Equal(t, "alice@example.com", msg.To)
+	assert.Equal(t, "Password Reset Request", msg.Subject)
+	assert.Contains(t, msg.Body, "https://auth.example.com/reset-password?token=")
+}
+
+func TestResetPassword_NoEmailSender_DoesNotPanic(t *testing.T) {
+	svc := newIntegrationService(t)
+	// emailSender is nil by default — should not panic.
+	err := svc.ResetPassword(context.Background(), "bob@example.com")
+	require.NoError(t, err)
+}
+
+func TestResetPassword_EmailSendFailure_DoesNotBlockReset(t *testing.T) {
+	svc := newIntegrationService(t)
+	sender := &mockEmailSender{err: fmt.Errorf("SMTP connection refused")}
+	svc.SetEmailSender(sender)
+	svc.SetBaseURL("https://auth.example.com")
+
+	// Email failure is logged but does not return an error.
+	err := svc.ResetPassword(context.Background(), "carol@example.com")
+	require.NoError(t, err)
+
+	// Email was still attempted.
+	require.Len(t, sender.sent, 1)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,6 +101,7 @@ type AppConfig struct {
 	AdminPort  int
 	GRPCPort   int
 	LogLevel   string
+	BaseURL    string // BASE_URL: public-facing base URL for links in emails, e.g. "https://auth.quantflow.studio"
 }
 
 // PostgresConfig holds PostgreSQL connection parameters.
@@ -327,6 +328,7 @@ func Load() (*Config, error) {
 func loadApp(l *loader) (AppConfig, error) {
 	appEnv := l.requireStr("APP_ENV")
 	logLevel := l.optStr("LOG_LEVEL", "info")
+	baseURL := l.optStr("BASE_URL", "http://localhost:4000")
 
 	publicPort, err := l.optInt("PUBLIC_PORT", 4000)
 	if err != nil {
@@ -347,6 +349,7 @@ func loadApp(l *loader) (AppConfig, error) {
 		AdminPort:  adminPort,
 		GRPCPort:   grpcPort,
 		LogLevel:   logLevel,
+		BaseURL:    baseURL,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-374.

Closes #374

## Changes

Wire email sender into auth service bootstrap — In `cmd/server/main.go`, after creating `authSvc` at line 94, instantiate the appropriate `email.EmailSender` implementation and call `authSvc.SetEmailSender(sender)`. Use `email.NewHTTPSender()` when `EMAIL_SERVICE_URL` env var is set (production), otherwise fall back to `email.NewConsoleSender(log)` (development). Add the base URL config (e.g., `BASE_URL` env var) and pass it via `authSvc.SetBaseURL()` or equivalent setter added in subtask 1. If the project uses a central config struct (check `internal/config/`), add the email-related fields there; otherwise read env vars directly at the wiring site. Verify `go build ./...` compiles cleanly and `go test ./...` passes.