### PR TITLE
GH-369: fix(api): router validation middleware panics on unknown request type — return error instead

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"fmt"
+	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -86,14 +88,14 @@ func NewPublicRouter(svc *Services, mw *MiddlewareStack, healthSvc *health.Servi
 	// Public auth routes.
 	auth := r.Group("/auth")
 	{
-		auth.POST("/register", validateReq(v, &domain.RegisterRequest{}), authH.Register)
-		auth.POST("/login", validateReq(v, &domain.LoginRequest{}), authH.Login)
-		auth.POST("/token", validateReq(v, &domain.TokenRequest{}), tokenH.Token)
-		auth.POST("/revoke", validateReq(v, &domain.RevokeRequest{}), tokenH.Revoke)
+		auth.POST("/register", ValidateReq(v, &domain.RegisterRequest{}), authH.Register)
+		auth.POST("/login", ValidateReq(v, &domain.LoginRequest{}), authH.Login)
+		auth.POST("/token", ValidateReq(v, &domain.TokenRequest{}), tokenH.Token)
+		auth.POST("/revoke", ValidateReq(v, &domain.RevokeRequest{}), tokenH.Revoke)
 
 		pw := auth.Group("/password")
-		pw.POST("/reset", validateReq(v, &domain.PasswordResetRequest{}), authH.ResetPassword)
-		pw.POST("/reset/confirm", validateReq(v, &domain.PasswordResetConfirmRequest{}), authH.ConfirmPasswordReset)
+		pw.POST("/reset", ValidateReq(v, &domain.PasswordResetRequest{}), authH.ResetPassword)
+		pw.POST("/reset/confirm", ValidateReq(v, &domain.PasswordResetConfirmRequest{}), authH.ConfirmPasswordReset)
 
 		// Broker token issuance (public, authenticates via client credentials in body).
 		if svc.Broker != nil {
@@ -133,7 +135,7 @@ func NewPublicRouter(svc *Services, mw *MiddlewareStack, healthSvc *health.Servi
 		protected.Use(mw.DPoP)
 	}
 	protected.GET("/me", authH.Me)
-	protected.PUT("/me/password", validateReq(v, &domain.PasswordChangeRequest{}), authH.ChangePassword)
+	protected.PUT("/me/password", ValidateReq(v, &domain.PasswordChangeRequest{}), authH.ChangePassword)
 	protected.POST("/logout", authH.Logout)
 	protected.POST("/logout/all", authH.LogoutAll)
 
@@ -171,9 +173,9 @@ func NewPublicRouter(svc *Services, mw *MiddlewareStack, healthSvc *health.Servi
 	return r
 }
 
-// validateReq creates validation middleware for the given request struct type.
+// ValidateReq creates validation middleware for the given request struct type.
 // The zero parameter is used only to capture the type — a fresh instance is created per request.
-func validateReq(v *validator.Validate, zero interface{}) gin.HandlerFunc {
+func ValidateReq(v *validator.Validate, zero interface{}) gin.HandlerFunc {
 	switch zero.(type) {
 	case *domain.RegisterRequest:
 		return domain.ValidateRequest(v, func() interface{} { return &domain.RegisterRequest{} })
@@ -190,7 +192,11 @@ func validateReq(v *validator.Validate, zero interface{}) gin.HandlerFunc {
 	case *domain.PasswordChangeRequest:
 		return domain.ValidateRequest(v, func() interface{} { return &domain.PasswordChangeRequest{} })
 	default:
-		panic("unsupported request type for validation middleware")
+		log.Printf("ERROR: unsupported request type for validation middleware: %T", zero)
+		return func(c *gin.Context) {
+			domain.RespondWithError(c, http.StatusInternalServerError, domain.CodeInternalError,
+				fmt.Sprintf("unsupported request type for validation middleware: %T", zero))
+		}
 	}
 }
 

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -582,6 +582,29 @@ func TestFullAuthFlow_RegisterLoginRefreshLogout(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 }
 
+// --- Validation middleware tests ---
+
+func TestValidateReq_UnknownType_Returns500WithoutPanic(t *testing.T) {
+	// Wire a route with an unsupported request type (plain string).
+	v := domain.NewValidator()
+	handler := api.ValidateReq(v, "not-a-request-struct")
+
+	r := gin.New()
+	r.POST("/test", handler, func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := doRequest(r, http.MethodPost, "/test", map[string]string{"foo": "bar"})
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+
+	var resp domain.ErrorResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, domain.CodeInternalError, resp.Code)
+	assert.Contains(t, resp.Error, "unsupported request type")
+	assert.Contains(t, resp.Error, "string") // %T of the actual type
+}
+
 // --- Middleware ordering test ---
 
 func TestMiddlewareOrdering(t *testing.T) {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-369.

Closes #369

## Changes

GitHub Issue #369: fix(api): router validation middleware panics on unknown request type — return error instead

## Bug

`internal/api/router.go:193` panics in the `default` case of the validation middleware's type switch:

```go
default:
    panic("unsupported request type for validation middleware")
```

An unrecognized request type kills the entire HTTP server process. A runtime panic in request-handling code is a denial-of-service hazard: a new endpoint handler wired with the wrong request type will crash the whole process on first request, instead of returning a 500 with a logged error.

## Fix

Return an error from the validation switch. The surrounding middleware should propagate it as a 500 with a logged message.

```go
default:
    return fmt.Errorf("unsupported request type for validation middleware: %T", req)
```

If the caller signature doesn't currently return an error, update it to do so and adjust callers. Log at ERROR level with the concrete type name so the gap is observable in production.

## Acceptance

- [ ] No `panic(...)` in `internal/api/router.go`
- [ ] Unknown request type returns `500 Internal Server Error` with a descriptive log line including `%T` of the actual type
- [ ] Test: pass an unhandled type through the middleware and assert error returned, no panic
- [ ] `go build ./...` and `go test ./internal/api/...` pass

## Files

- `internal/api/router.go`
- `internal/api/router_test.go` (add panic-free path test)

## Dependencies

Waits for **#367** (compile-breaker fix) to land first so tests can actually run.