### PR TITLE
GH-378: Sweep `fmt.Errorf` → `%w` wrapping across `internal/` - Mechanical find-and-replace across 92 call sites in ~17 packages (heaviest in `dpop/` at 38, `token/` at 18, `oauth/` at 14, `config/` at 8). For each site, determine if it's wrapping an existing error variable (convert `%s`/`%v` → `%w`) or constructing a fresh sentinel (leave as-is). Verify with `go vet ./...` and `go build ./...` after. This is the foundational subtask

### DIFF
--- a/internal/dpop/dpop.go
+++ b/internal/dpop/dpop.go
@@ -431,11 +431,11 @@ func (v *Validator) validateNonce(ctx context.Context, nonce string) (bool, erro
 func matchHTU(htu, expected string) error {
 	htuParsed, err := url.Parse(htu)
 	if err != nil {
-		return fmt.Errorf("htu is not a valid URL: %v", err)
+		return fmt.Errorf("htu is not a valid URL: %w", err)
 	}
 	expParsed, err := url.Parse(expected)
 	if err != nil {
-		return fmt.Errorf("expected URL is not valid: %v", err)
+		return fmt.Errorf("expected URL is not valid: %w", err)
 	}
 
 	if !strings.EqualFold(htuParsed.Scheme, expParsed.Scheme) {

--- a/internal/token/service.go
+++ b/internal/token/service.go
@@ -479,7 +479,7 @@ func parsePrivateKey(data []byte, algorithm string) (crypto.Signer, crypto.Publi
 		// Try EC-specific parse as fallback.
 		ecKey, ecErr := x509.ParseECPrivateKey(block.Bytes)
 		if ecErr != nil {
-			return nil, nil, nil, fmt.Errorf("parse private key (PKCS8: %v, EC: %v)", err, ecErr)
+			return nil, nil, nil, fmt.Errorf("parse private key (PKCS8: %w, EC: %w)", err, ecErr)
 		}
 		key = ecKey
 	}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-378.

Closes #378

## Changes

fixing error wrapping first ensures the session tests in subtask 3 can properly test error chain behavior.