### PR TITLE
GH-379: Delete empty stub packages `internal/client/` and `internal/user/`

### DIFF
--- a/.agent/tasks/gh-379.md
+++ b/.agent/tasks/gh-379.md
@@ -1,0 +1,10 @@
+# GH-379
+
+**Created:** 2026-04-07
+
+## Problem
+
+Both packages contain only a package declaration comment (92 and 60 bytes respectively). Neither is imported anywhere in the codebase. Delete both directories entirely. Verify with `go build ./...` that nothing breaks. This is the smallest, most isolated change.
+
+## Acceptance Criteria
+

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/var/folders/_8/nnsxrdhn46x08pb886hrggv00000gn/T/pilot-hooks-3367293168/pilot-bash-guard.sh"
+            "command": "/var/folders/_8/nnsxrdhn46x08pb886hrggv00000gn/T/pilot-hooks-1451057675/pilot-bash-guard.sh"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/var/folders/_8/nnsxrdhn46x08pb886hrggv00000gn/T/pilot-hooks-3367293168/pilot-stop-gate.sh"
+            "command": "/var/folders/_8/nnsxrdhn46x08pb886hrggv00000gn/T/pilot-hooks-1451057675/pilot-stop-gate.sh"
           }
         ]
       }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,2 +1,0 @@
-// Package client provides OAuth2 client management for services and agents.
-package client

--- a/internal/user/user.go
+++ b/internal/user/user.go
@@ -1,2 +1,0 @@
-// Package user provides user CRUD operations.
-package user


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-379.

Closes #379

## Changes

Both packages contain only a package declaration comment (92 and 60 bytes respectively). Neither is imported anywhere in the codebase. Delete both directories entirely. Verify with `go build ./...` that nothing breaks. This is the smallest, most isolated change.