### PR TITLE
GH-405: Sweep `fmt.Errorf` → `%w` in `internal/storage/`, `internal/admin/`, `internal/config/`, and all remaining packages - Same audit for the data layer, admin services, config, and remaining packages (email, webhook, rbac, hibp, logger, grpc, mfa, api, httpserver, docs

### DIFF
--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -95,7 +95,7 @@ func (s *Service) HandleCallback(ctx context.Context, provider, code, state stri
 				zap.String("provider", provider),
 				zap.Error(err),
 			)
-			return nil, fmt.Errorf("%w: %v", api.ErrUnauthorized, domain.ErrOAuthStateMismatch)
+			return nil, fmt.Errorf("%w: %w", api.ErrUnauthorized, domain.ErrOAuthStateMismatch)
 		}
 		ctx = WithCodeVerifier(ctx, verifier)
 	}
@@ -106,7 +106,7 @@ func (s *Service) HandleCallback(ctx context.Context, provider, code, state stri
 			zap.String("provider", provider),
 			zap.Error(err),
 		)
-		return nil, fmt.Errorf("%w: %v", api.ErrUnauthorized, domain.ErrOAuthCodeExchangeFailed)
+		return nil, fmt.Errorf("%w: %w", api.ErrUnauthorized, domain.ErrOAuthCodeExchangeFailed)
 	}
 
 	// Look up existing linked account.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-405.

Closes #405

## Changes

~39 sites total). Convert wrapping calls, leave fresh constructions. These packages have simpler error patterns (mostly validation errors that construct fresh errors rather than wrapping).