### PR TITLE
GH-412: Bump Dockerfile Go version from 1.24 to 1.25

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 # Stage 2: Minimal Alpine runtime
 
 # ---------- builder ----------
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 RUN apk add --no-cache git ca-certificates tzdata
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-412.

Closes #412

## Changes

Edit `docker/Dockerfile` line 6 to change `FROM golang:1.24-alpine AS builder` → `FROM golang:1.25-alpine AS builder`. No other files in the repo pin Go 1.24 (confirmed via grep of `.github/`, `docker/`, `deployments/`, `scripts/`, and `Makefile` patterns). The `go.mod` already has `go 1.25.6` and must not be touched. Use floating minor (`1.25-alpine`) to match the existing convention. After the edit, verify with `docker build -f docker/Dockerfile -t auth-service:test .` locally. Once merged, the Release workflow should go green, GoReleaser cuts the next tag, and the downstream Deploy Staging workflow unblocks.