### PR TITLE
GH-414: Bump Go version in Dockerfile and verify CI references

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 # Stage 2: Minimal Alpine runtime
 
 # ---------- builder ----------
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 RUN apk add --no-cache git ca-certificates tzdata
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-414.

Closes #414

## Changes

Edit `docker/Dockerfile:6` to change `FROM golang:1.24-alpine AS builder` → `FROM golang:1.25-alpine AS builder`. No other files in the repo reference `golang:1.24` or pin `go-version: '1.24'` in CI workflows, so this is the only change required. Verify locally with `docker build -f docker/Dockerfile -t auth-service:test .` to confirm the build succeeds end-to-end before committing.
That's it — **one subtask**. Splitting a single-line change in a single file into multiple subtasks would be artificial and counterproductive.