### PR TITLE
GH-416: Disable Deploy Staging workflow until staging infra is ready

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,12 +1,9 @@
 name: Deploy Staging
 
+# Disabled 2026-04-07: staging server not provisioned. Re-enable by restoring
+# the workflow_run trigger once DEPLOY_HOST/DEPLOY_USER/SSH key secrets are set.
 on:
-  workflow_run:
-    workflows: ["Release"]
-    types:
-      - completed
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-416.

Closes #416

## Changes

GitHub Issue #416: Disable Deploy Staging workflow until staging infra is ready

## Context

The \`Deploy Staging\` workflow (\`.github/workflows/deploy-staging.yml\`) fails on every successful Release run because the GitHub repo has no staging server secrets configured:

\`\`\`
DEPLOY_HOST: (empty)
DEPLOY_USER: (empty)
2026/04/07 15:30:36 error: missing server host
\`\`\`

Failing run: https://github.com/qf-studio/auth-service/actions/runs/24089809641

There is no provisioned staging server yet — that infra work is deferred. Until then, the workflow generates a red badge and a failure notification on every push to main, which is noise.

## Implementation Plan

Disable the workflow by gating its trigger on a manual \`workflow_dispatch\` only. Edit \`.github/workflows/deploy-staging.yml\`:

1. Find the \`on:\` block at the top of the file.
2. Replace the existing trigger (likely \`workflow_run\` listening to Release) with \`workflow_dispatch\` only:
   \`\`\`yaml
   on:
     workflow_dispatch:
   \`\`\`
3. Add a comment above explaining why:
   \`\`\`yaml
   # Disabled 2026-04-07: staging server not provisioned. Re-enable by restoring
   # the workflow_run trigger once DEPLOY_HOST/DEPLOY_USER/SSH key secrets are set.
   \`\`\`

Do **not** delete the workflow file or any of its job steps. The deploy logic should remain intact so re-enabling is a one-line change.

## Technical Decisions

- **Why \`workflow_dispatch\` and not file deletion**: keeps the deploy script wired up. When staging infra lands, we just restore the trigger.
- **Why not just unset secrets**: the workflow would still fail on the same step. Disabling the trigger is the cleanest no-noise option.
- **Why not rename to \`.disabled\`**: GitHub Actions only loads \`.yml\`/\`.yaml\` extensions, but renaming makes the file invisible in the Actions tab. Keeping the name + neutering the trigger preserves discoverability.

## Dependencies

None. Single-file edit.

## Verify

- [ ] After merging, push another commit (or merge another PR) — Deploy Staging should NOT auto-trigger
- [ ] The workflow should still appear in the Actions tab and be runnable manually via \`gh workflow run deploy-staging.yml\`
- [ ] Release workflow remains green and untouched

## Done

\`Deploy Staging\` no longer auto-runs and stops emitting failures on every release. Manual run path remains available for when staging infra is ready.

## Key Files

- \`.github/workflows/deploy-staging.yml\` — only file that should change