### PR TITLE
GH-427: Fix broken ASCII architecture diagram in README.md (replace with Mermaid)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,30 +86,17 @@ Full API specification: [`api/`](./api/)
 
 ## Architecture
 
-```
-┌─────────────┐     ┌─────────────┐
-│  Public :4000│     │  Admin :4001 │
-└──────┬──────┘     └──────┬──────┘
-       │                   │
-       └─────┬─────────────┘
-             │
-      ┌──────▼──────┐
-      │  Gin Router  │
-      │  + Middleware │
-      └──────┬──────┘
-             │
-   ┌─────────┼─────────┐
-   │         │         │
-┌──▼──┐  ┌──▼──┐  ┌──▼──┐
-│ Auth │  │Token│  │RBAC │
-└──┬──┘  └──┬──┘  └──┬──┘
-   │        │        │
-   └────────┼────────┘
-            │
-   ┌────────▼────────┐
-   │   Storage Layer  │
-   │ PostgreSQL Redis │
-   └─────────────────┘
+```mermaid
+flowchart TB
+    Public[Public API :4000] --> Router
+    Admin[Admin API :4001] --> Router
+    Router["Gin Router + Middleware<br/>auth · rate limit · CORS · TLS"] --> Auth[Auth]
+    Router --> Token[Token]
+    Router --> RBAC[RBAC]
+    Auth --> Storage
+    Token --> Storage
+    RBAC --> Storage
+    Storage[("PostgreSQL + Redis<br/>persistent storage · sessions · cache")]
 ```
 
 See [architecture diagrams](./.agent/system/architecture-diagrams.md) and [project architecture](./.agent/system/project-architecture.md) for details.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-427.

Closes #427

## Changes

GitHub Issue #427: Fix broken ASCII architecture diagram in README.md (replace with Mermaid)

The ASCII architecture diagram in \`README.md\` (the \`## Architecture\` section) renders with broken borders on GitHub — box-drawing characters and pipes don't connect properly in the rendered markdown.

## Fix

Replace the entire \`\`\` code block under \`## Architecture\` with a Mermaid diagram. GitHub renders Mermaid natively in fenced code blocks tagged \`\`\`\`mermaid\`\`\`\`.

Use this exact block:

\`\`\`mermaid
flowchart TB
    Public[Public API :4000] --> Router
    Admin[Admin API :4001] --> Router
    Router["Gin Router + Middleware<br/>auth · rate limit · CORS · TLS"] --> Auth[Auth]
    Router --> Token[Token]
    Router --> RBAC[RBAC]
    Auth --> Storage
    Token --> Storage
    RBAC --> Storage
    Storage[("PostgreSQL + Redis<br/>persistent storage · sessions · cache")]
\`\`\`

Keep the existing \"See [architecture diagrams]...\" link line below the new diagram.

## Scope

**ONE file**: \`README.md\`. **ONE PR**. Do not touch other files. Do not decompose into subtasks.

## Verify

- [ ] The \`## Architecture\` section in README.md contains a \`\`\`mermaid block (not ASCII art)
- [ ] No other files modified
- [ ] \`git diff --stat\` shows only \`README.md\`