### PR TITLE
GH-429: fix(tenancy): single-tenant fallback — TenantIDFromContext must coalesce uuid.Nil to the Default tenant (unwired middleware FK failures)

### DIFF
--- a/internal/domain/context.go
+++ b/internal/domain/context.go
@@ -16,10 +16,12 @@ func WithTenantID(ctx context.Context, id uuid.UUID) context.Context {
 }
 
 // TenantIDFromContext extracts the tenant ID from the context.
-// Returns uuid.Nil if no tenant ID is set.
+// Falls back to DefaultTenantID when no tenant ID is set on the context,
+// so single-tenant deployments (TenantMiddleware unwired) resolve to the
+// seeded Default tenant instead of the zero UUID.
 func TenantIDFromContext(ctx context.Context) uuid.UUID {
 	if v, ok := ctx.Value(tenantIDKey).(uuid.UUID); ok {
 		return v
 	}
-	return uuid.Nil
+	return DefaultTenantID
 }

--- a/internal/domain/context_test.go
+++ b/internal/domain/context_test.go
@@ -1,0 +1,34 @@
+package domain_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+func TestTenantIDFromContext_NoTenantSet(t *testing.T) {
+	got := domain.TenantIDFromContext(context.Background())
+	assert.Equal(t, domain.DefaultTenantID, got)
+	assert.NotEqual(t, uuid.Nil, got)
+}
+
+func TestTenantIDFromContext_TenantSet(t *testing.T) {
+	want := uuid.New()
+	ctx := domain.WithTenantID(context.Background(), want)
+
+	got := domain.TenantIDFromContext(ctx)
+
+	assert.Equal(t, want, got)
+}
+
+func TestTenantIDFromContext_TenantSetToNil(t *testing.T) {
+	ctx := domain.WithTenantID(context.Background(), uuid.Nil)
+
+	got := domain.TenantIDFromContext(ctx)
+
+	assert.Equal(t, uuid.Nil, got)
+}

--- a/internal/storage/tenant_fallback_integration_test.go
+++ b/internal/storage/tenant_fallback_integration_test.go
@@ -1,0 +1,62 @@
+package storage_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/password"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+// TestTenantFallback_RegisterLoginRoundTrip proves that user registration and
+// login succeed against real Postgres when TenantMiddleware is not wired
+// (i.e. the context carries no tenant ID). Before the Nil->Default fallback
+// in domain.TenantIDFromContext, this failed the tenant_id FK to tenants(id)
+// because uuid.Nil doesn't match any seeded tenant row.
+func TestTenantFallback_RegisterLoginRoundTrip(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresUserRepository(pool)
+	hasher := password.New(nil)
+
+	// No TenantMiddleware wired: plain background context, no tenant on it.
+	ctx := context.Background()
+	tenantID := domain.TenantIDFromContext(ctx)
+	require.Equal(t, domain.DefaultTenantID, tenantID)
+
+	hash, err := hasher.Hash("super-secure-password-123")
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	user := &domain.User{
+		ID:                "usr_tenant_fallback_test",
+		TenantID:          tenantID,
+		Email:             "tenant-fallback@example.com",
+		PasswordHash:      hash,
+		Name:              "Fallback User",
+		Roles:             []string{"user"},
+		PasswordChangedAt: &now,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+
+	// "Registration": insert should not FK-fail against the Default tenant.
+	created, err := repo.Create(ctx, user)
+	require.NoError(t, err)
+	assert.Equal(t, domain.DefaultTenantID, created.TenantID)
+
+	// "Login": lookup by email using the same fallback tenant ID, then
+	// verify the password as the login flow would.
+	loginTenantID := domain.TenantIDFromContext(context.Background())
+	found, err := repo.FindByEmail(ctx, loginTenantID, user.Email)
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, found.ID)
+
+	ok, err := hasher.Verify("super-secure-password-123", user.PasswordHash)
+	require.NoError(t, err)
+	assert.True(t, ok)
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-429.

Closes #429

## Changes

GitHub Issue GH-429: fix(tenancy): single-tenant fallback — TenantIDFromContext must coalesce uuid.Nil to the Default tenant (unwired middleware FK failures)

## Context

SaaS pre-work S0.1 (TASK-405 / `.agent/system/saas-roadmap.md` in qf-studio/pilot). The SaaS control plane will run auth-service single-tenant, but single-tenant mode is broken today: `TenantMiddleware` exists (`internal/middleware/tenant.go:90-160`) but is never wired — `cmd/server/main.go` builds the MiddlewareStack (~lines 214-224) without it, so `domain.TenantIDFromContext` returns `uuid.Nil` (`internal/domain/context.go:20-24`). All tenant-scoped queries and inserts (e.g. `storage/user_repository.go:129` `WHERE ... AND tenant_id = $2`) then run with the zero UUID, which fails the FK to `tenants(id)` (migration `000015_multi_tenancy.up.sql` lines 45-49). The seeded Default tenant is `00000000-0000-0000-0000-000000000001` (`internal/domain/tenant.go:28`, migration line 30). No code coalesces Nil→Default.

## Implementation

In `internal/domain/context.go`: make `TenantIDFromContext` return the seeded Default tenant ID instead of `uuid.Nil` when no tenant is set on the context (single-tenant fallback). Keep the behavior overridable: when TenantMiddleware IS wired later, its context value wins. Add a package constant for the Default tenant UUID if one doesn't exist; do NOT change TenantMiddleware itself and do NOT wire it into main.go in this issue.

## Acceptance

- [ ] `TenantIDFromContext` returns the Default tenant UUID when the context carries no tenant, and the context value when it does (unit tests for both)
- [ ] Integration test: user registration + login round-trip succeeds against Postgres with the middleware unwired (previously FK-failed)
- [ ] No behavior change for contexts that already carry a tenant ID
- [ ] Existing tests stay green

## Refs

- Verified defect record: qf-studio/pilot `.agent/system/saas-asset-research.md` (2026-07-13 verification appendix, auth-service section)