### PR TITLE
GH-434: chore: gHCR image publishing: version tags and linux/arm64 manifests

### DIFF
--- a/.agent/tasks/gh-434.md
+++ b/.agent/tasks/gh-434.md
@@ -1,0 +1,25 @@
+# GH-434
+
+**Created:** 2026-07-20
+
+## Problem
+
+GitHub Issue GH-434: GHCR image publishing: version tags and linux/arm64 manifests
+
+## Context
+
+release.yml publishes GHCR images tagged only with the short commit SHA (+ `latest`), and the manifest is amd64-only. Consequences (both hit 2026-07-20): consumers must manually resolve release tag → SHA to pin a version (pointer pins `ee9defd` for v0.67.3), and `docker pull` on Apple Silicon fails with "no matching manifest for linux/arm64/v8" unless forced with `--platform linux/amd64`.
+
+## Acceptance
+
+- [ ] Pushing a `vX.Y.Z` git tag publishes `ghcr.io/qf-studio/auth-service:vX.Y.Z` (SHA + `latest` tags may stay as-is for main pushes).
+- [ ] Published manifests are multi-arch: `linux/amd64` and `linux/arm64` (docker buildx + QEMU in the workflow).
+- [ ] `docker pull ghcr.io/qf-studio/auth-service:<new tag>` succeeds on an arm64 host without `--platform`.
+- [ ] CI build time stays reasonable (arm64 layer cache or native runner if cross-build is too slow).
+
+## Implementation
+
+`.github/workflows/release.yml`: add `docker/setup-qemu-action` + `docker/setup-buildx-action`, `platforms: linux/amd64,linux/arm64` on the build-push step, and a `docker/metadata-action` (or equivalent) tag rule mapping git tags `v*` to image tags.
+
+## Acceptance Criteria
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
 
 permissions:
   contents: read
@@ -21,6 +23,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -37,8 +42,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=sha,prefix=
-            type=raw,value=latest
+            type=sha,prefix=,enable=${{ github.ref_type != 'tag' }}
+            type=raw,value=latest,enable=${{ github.ref_type != 'tag' }}
+            type=ref,event=tag
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -46,6 +52,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-434.

Closes #434

## Changes

GitHub Issue GH-434: GHCR image publishing: version tags and linux/arm64 manifests

## Context

release.yml publishes GHCR images tagged only with the short commit SHA (+ `latest`), and the manifest is amd64-only. Consequences (both hit 2026-07-20): consumers must manually resolve release tag → SHA to pin a version (pointer pins `ee9defd` for v0.67.3), and `docker pull` on Apple Silicon fails with "no matching manifest for linux/arm64/v8" unless forced with `--platform linux/amd64`.

## Acceptance

- [ ] Pushing a `vX.Y.Z` git tag publishes `ghcr.io/qf-studio/auth-service:vX.Y.Z` (SHA + `latest` tags may stay as-is for main pushes).
- [ ] Published manifests are multi-arch: `linux/amd64` and `linux/arm64` (docker buildx + QEMU in the workflow).
- [ ] `docker pull ghcr.io/qf-studio/auth-service:<new tag>` succeeds on an arm64 host without `--platform`.
- [ ] CI build time stays reasonable (arm64 layer cache or native runner if cross-build is too slow).

## Implementation

`.github/workflows/release.yml`: add `docker/setup-qemu-action` + `docker/setup-buildx-action`, `platforms: linux/amd64,linux/arm64` on the build-push step, and a `docker/metadata-action` (or equivalent) tag rule mapping git tags `v*` to image tags.