### PR TITLE
GH-433: feat: tokens and JWKS keys carry no kid — verifiers can't select a key

### DIFF
--- a/.agent/tasks/gh-433.md
+++ b/.agent/tasks/gh-433.md
@@ -1,0 +1,25 @@
+# GH-433
+
+**Created:** 2026-07-20
+
+## Problem
+
+GitHub Issue GH-433: Tokens and JWKS keys carry no kid — verifiers can't select a key
+
+## Context
+
+Access-token JOSE headers carry no `kid`, and the JWKS document's keys also omit `kid` (verified live 2026-07-20 @ ee9defd: `/.well-known/jwks.json` returns one key, `kid` absent). Standard JWT middlewares select the verification key by matching header `kid` → JWKS `kid`, so out-of-the-box verifiers reject every token — pointer had to patch its verifier to try the full key set (pointer commit 532a138). Without `kid`, key rotation is also impossible to do safely.
+
+## Acceptance
+
+- [ ] Every key in `/.well-known/jwks.json` carries a stable `kid` (suggestion: RFC 7638 JWK thumbprint of the public key, so it's deterministic and survives restarts).
+- [ ] Every signed token (access, ID, refresh if JWS) includes the matching `kid` in its JOSE header.
+- [ ] Header `kid` and JWKS `kid` agree for the active signing key (test decodes a freshly minted token and matches it against the JWKS document).
+- [ ] Existing verification paths stay green; no change to claim payloads.
+
+## Implementation
+
+Signing lives in internal/token (service + JWKS handler). Compute the thumbprint once at key load, set it on the JWKS entry and pass it as the `kid` header option at signing time.
+
+## Acceptance Criteria
+

--- a/internal/token/service.go
+++ b/internal/token/service.go
@@ -61,6 +61,7 @@ type Service struct {
 	privateKey    crypto.Signer
 	publicKey     crypto.PublicKey
 	signingMethod jwt.SigningMethod
+	kid           string
 }
 
 // NewService creates a new token Service, loading the private key from the
@@ -76,6 +77,11 @@ func NewService(cfg config.JWTConfig, redisClient *redis.Client, logger *zap.Log
 		return nil, fmt.Errorf("parse private key: %w", err)
 	}
 
+	kid, err := jwkThumbprint(pub)
+	if err != nil {
+		return nil, fmt.Errorf("compute key thumbprint: %w", err)
+	}
+
 	return &Service{
 		logger:        logger,
 		audit:         auditor,
@@ -84,6 +90,7 @@ func NewService(cfg config.JWTConfig, redisClient *redis.Client, logger *zap.Log
 		privateKey:    signer,
 		publicKey:     pub,
 		signingMethod: method,
+		kid:           kid,
 	}, nil
 }
 
@@ -96,6 +103,11 @@ func NewServiceFromKey(cfg config.JWTConfig, privateKey crypto.Signer, redisClie
 		return nil, err
 	}
 
+	kid, err := jwkThumbprint(pub)
+	if err != nil {
+		return nil, fmt.Errorf("compute key thumbprint: %w", err)
+	}
+
 	return &Service{
 		logger:        logger,
 		audit:         auditor,
@@ -104,6 +116,7 @@ func NewServiceFromKey(cfg config.JWTConfig, privateKey crypto.Signer, redisClie
 		privateKey:    privateKey,
 		publicKey:     pub,
 		signingMethod: method,
+		kid:           kid,
 	}, nil
 }
 
@@ -238,7 +251,7 @@ func (s *Service) Revoke(ctx context.Context, rawToken string) error {
 
 // JWKS returns the JSON Web Key Set containing the public key for token verification.
 func (s *Service) JWKS(_ context.Context) (*api.JWKSResponse, error) {
-	jwk, err := publicKeyToJWK(s.publicKey, s.cfg.Algorithm)
+	jwk, err := publicKeyToJWK(s.publicKey, s.cfg.Algorithm, s.kid)
 	if err != nil {
 		return nil, fmt.Errorf("build JWK: %w", err)
 	}
@@ -313,6 +326,7 @@ func (s *Service) issueAccessToken(subject string, roles, scopes []string, clien
 	}
 
 	token := jwt.NewWithClaims(s.signingMethod, claims)
+	token.Header["kid"] = s.kid
 	signed, err := token.SignedString(s.privateKey)
 	if err != nil {
 		return "", fmt.Errorf("sign access token: %w", err)
@@ -525,7 +539,7 @@ func signingMethodForKey(key crypto.Signer, algorithm string) (jwt.SigningMethod
 // ── Internal: JWKS ───────────────────────────────────────────────────────────
 
 // publicKeyToJWK converts a public key to a JWK map (RFC 7517).
-func publicKeyToJWK(pub crypto.PublicKey, algorithm string) (map[string]interface{}, error) {
+func publicKeyToJWK(pub crypto.PublicKey, algorithm, kid string) (map[string]interface{}, error) {
 	switch k := pub.(type) {
 	case *ecdsa.PublicKey:
 		if k.Curve != elliptic.P256() {
@@ -546,6 +560,7 @@ func publicKeyToJWK(pub crypto.PublicKey, algorithm string) (map[string]interfac
 			"crv": "P-256",
 			"alg": algorithm,
 			"use": "sig",
+			"kid": kid,
 			"x":   base64.RawURLEncoding.EncodeToString(xPadded),
 			"y":   base64.RawURLEncoding.EncodeToString(yPadded),
 		}, nil
@@ -556,12 +571,56 @@ func publicKeyToJWK(pub crypto.PublicKey, algorithm string) (map[string]interfac
 			"crv": "Ed25519",
 			"alg": algorithm,
 			"use": "sig",
+			"kid": kid,
 			"x":   base64.RawURLEncoding.EncodeToString([]byte(k)),
 		}, nil
 
 	default:
 		return nil, fmt.Errorf("unsupported public key type: %T", pub)
 	}
+}
+
+// jwkThumbprint computes the RFC 7638 JWK thumbprint of a public key, used as
+// the stable `kid` for both the JWKS entry and the JOSE header of tokens
+// signed with the corresponding private key. Being a deterministic hash of
+// the key material, it is stable across restarts without requiring any
+// additional state, and changes automatically if the key is rotated.
+func jwkThumbprint(pub crypto.PublicKey) (string, error) {
+	// RFC 7638 §3.2: the JSON object must contain only the required members
+	// for the key type, with member names in lexicographic order and no
+	// whitespace, so the hash input is unambiguous.
+	var canonical string
+
+	switch k := pub.(type) {
+	case *ecdsa.PublicKey:
+		if k.Curve != elliptic.P256() {
+			return "", fmt.Errorf("unsupported ECDSA curve")
+		}
+		byteLen := (k.Curve.Params().BitSize + 7) / 8
+		xBytes := k.X.Bytes()
+		yBytes := k.Y.Bytes()
+
+		xPadded := make([]byte, byteLen)
+		yPadded := make([]byte, byteLen)
+		copy(xPadded[byteLen-len(xBytes):], xBytes)
+		copy(yPadded[byteLen-len(yBytes):], yBytes)
+
+		canonical = fmt.Sprintf(`{"crv":"P-256","kty":"EC","x":%q,"y":%q}`,
+			base64.RawURLEncoding.EncodeToString(xPadded),
+			base64.RawURLEncoding.EncodeToString(yPadded),
+		)
+
+	case ed25519.PublicKey:
+		canonical = fmt.Sprintf(`{"crv":"Ed25519","kty":"OKP","x":%q}`,
+			base64.RawURLEncoding.EncodeToString([]byte(k)),
+		)
+
+	default:
+		return "", fmt.Errorf("unsupported public key type: %T", pub)
+	}
+
+	sum := sha256.Sum256([]byte(canonical))
+	return base64.RawURLEncoding.EncodeToString(sum[:]), nil
 }
 
 // ── Internal: Crypto Helpers ─────────────────────────────────────────────────

--- a/internal/token/service_test.go
+++ b/internal/token/service_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	jwtv5 "github.com/golang-jwt/jwt/v5"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -491,6 +492,111 @@ func TestJWKS_EdDSA(t *testing.T) {
 	assert.Equal(t, "EdDSA", keyMap["alg"])
 	assert.Equal(t, "sig", keyMap["use"])
 	assert.NotEmpty(t, keyMap["x"])
+}
+
+// ── kid: JWKS + token header agreement ───────────────────────────────────────
+
+func TestJWKS_ES256_HasStableKID(t *testing.T) {
+	svc, _ := newES256Service(t)
+	ctx := context.Background()
+
+	jwks1, err := svc.JWKS(ctx)
+	require.NoError(t, err)
+	require.Len(t, jwks1.Keys, 1)
+	keyMap1, ok := jwks1.Keys[0].(map[string]interface{})
+	require.True(t, ok)
+
+	kid1, ok := keyMap1["kid"].(string)
+	require.True(t, ok, "JWKS entry must carry a kid")
+	assert.NotEmpty(t, kid1)
+
+	// Calling JWKS again must yield the same kid (deterministic, survives
+	// "restarts" in the sense of repeated derivation from the same key).
+	jwks2, err := svc.JWKS(ctx)
+	require.NoError(t, err)
+	keyMap2, ok := jwks2.Keys[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, kid1, keyMap2["kid"])
+}
+
+func TestJWKS_EdDSA_HasStableKID(t *testing.T) {
+	svc, _ := newEdDSAService(t)
+	ctx := context.Background()
+
+	jwks, err := svc.JWKS(ctx)
+	require.NoError(t, err)
+	require.Len(t, jwks.Keys, 1)
+	keyMap, ok := jwks.Keys[0].(map[string]interface{})
+	require.True(t, ok)
+
+	kid, ok := keyMap["kid"].(string)
+	require.True(t, ok, "JWKS entry must carry a kid")
+	assert.NotEmpty(t, kid)
+}
+
+func TestIssueAccessToken_HeaderKIDMatchesJWKS_ES256(t *testing.T) {
+	svc, _ := newES256Service(t)
+	ctx := context.Background()
+
+	result, err := svc.IssueTokenPair(ctx, "user-123", []string{"admin"}, nil, domain.ClientTypeUser)
+	require.NoError(t, err)
+
+	rawJWT := strings.TrimPrefix(result.AccessToken, "qf_at_")
+	parser := jwtv5.NewParser()
+	parsed, _, err := parser.ParseUnverified(rawJWT, jwtv5.MapClaims{})
+	require.NoError(t, err)
+
+	headerKID, ok := parsed.Header["kid"].(string)
+	require.True(t, ok, "access token header must carry a kid")
+	assert.NotEmpty(t, headerKID)
+
+	jwks, err := svc.JWKS(ctx)
+	require.NoError(t, err)
+	require.Len(t, jwks.Keys, 1)
+	keyMap, ok := jwks.Keys[0].(map[string]interface{})
+	require.True(t, ok)
+
+	assert.Equal(t, keyMap["kid"], headerKID, "token header kid must match the active JWKS key's kid")
+}
+
+func TestIssueAccessToken_HeaderKIDMatchesJWKS_EdDSA(t *testing.T) {
+	svc, _ := newEdDSAService(t)
+	ctx := context.Background()
+
+	result, err := svc.IssueTokenPair(ctx, "svc-456", []string{"service"}, nil, domain.ClientTypeService)
+	require.NoError(t, err)
+
+	rawJWT := strings.TrimPrefix(result.AccessToken, "qf_at_")
+	parser := jwtv5.NewParser()
+	parsed, _, err := parser.ParseUnverified(rawJWT, jwtv5.MapClaims{})
+	require.NoError(t, err)
+
+	headerKID, ok := parsed.Header["kid"].(string)
+	require.True(t, ok, "access token header must carry a kid")
+	assert.NotEmpty(t, headerKID)
+
+	jwks, err := svc.JWKS(ctx)
+	require.NoError(t, err)
+	keyMap, ok := jwks.Keys[0].(map[string]interface{})
+	require.True(t, ok)
+
+	assert.Equal(t, keyMap["kid"], headerKID, "token header kid must match the active JWKS key's kid")
+}
+
+func TestJWKS_DifferentKeysHaveDifferentKID(t *testing.T) {
+	svc1, _ := newES256Service(t)
+	svc2, _ := newES256Service(t)
+	ctx := context.Background()
+
+	jwks1, err := svc1.JWKS(ctx)
+	require.NoError(t, err)
+	jwks2, err := svc2.JWKS(ctx)
+	require.NoError(t, err)
+
+	keyMap1 := jwks1.Keys[0].(map[string]interface{})
+	keyMap2 := jwks2.Keys[0].(map[string]interface{})
+
+	assert.NotEqual(t, keyMap1["kid"], keyMap2["kid"], "distinct keys must produce distinct kids")
 }
 
 // ── ClientCredentials (stub) ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-433.

Closes #433

## Changes

GitHub Issue GH-433: Tokens and JWKS keys carry no kid — verifiers can't select a key

## Context

Access-token JOSE headers carry no `kid`, and the JWKS document's keys also omit `kid` (verified live 2026-07-20 @ ee9defd: `/.well-known/jwks.json` returns one key, `kid` absent). Standard JWT middlewares select the verification key by matching header `kid` → JWKS `kid`, so out-of-the-box verifiers reject every token — pointer had to patch its verifier to try the full key set (pointer commit 532a138). Without `kid`, key rotation is also impossible to do safely.

## Acceptance

- [ ] Every key in `/.well-known/jwks.json` carries a stable `kid` (suggestion: RFC 7638 JWK thumbprint of the public key, so it's deterministic and survives restarts).
- [ ] Every signed token (access, ID, refresh if JWS) includes the matching `kid` in its JOSE header.
- [ ] Header `kid` and JWKS `kid` agree for the active signing key (test decodes a freshly minted token and matches it against the JWKS document).
- [ ] Existing verification paths stay green; no change to claim payloads.

## Implementation

Signing lives in internal/token (service + JWKS handler). Compute the thumbprint once at key load, set it on the JWKS entry and pass it as the `kid` header option at signing time.