### PR TITLE
GH-432: feat: refresh grant drops the roles claim from access tokens

### DIFF
--- a/.agent/tasks/gh-432.md
+++ b/.agent/tasks/gh-432.md
@@ -1,0 +1,26 @@
+# GH-432
+
+**Created:** 2026-07-20
+
+## Problem
+
+GitHub Issue GH-432: Refresh grant drops the roles claim from access tokens
+
+## Context
+
+The refresh grant mints access tokens without the `roles` claim that login-minted tokens carry. Repro (2026-07-20, image ee9defd): user has roles `["user","admin"]` (set via admin API `PATCH /admin/users/:id`); `POST /auth/login` → access token payload contains `"roles":["user","admin"]`; `POST /auth/token` with the returned refresh_token → 200 with a rotated pair, but the new access token has no roles claim at all.
+
+Downstream impact: pointer gates admin routes on the token's roles claim, so a transparent 401-refresh-retry silently demotes an admin mid-session (role-gated routes 403 until re-login).
+
+## Acceptance
+
+- [ ] An access token minted via the refresh grant (`POST /auth/token`) carries the same `roles` claim the user's login-minted token would carry (looked up at refresh time, so role changes since login are reflected).
+- [ ] Test: register user → assign roles via admin API → login → refresh → decode both access tokens and assert the roles claim is present and equal to the user's current roles.
+- [ ] Existing token/auth test suites stay green.
+
+## Implementation
+
+The refresh path in the token service (internal/token/service.go) mints claims without loading the user's roles — mirror whatever the login path does (fetch user → include roles) when handling `grant_type=refresh_token`.
+
+## Acceptance Criteria
+

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -90,6 +90,8 @@ func run(log *zap.Logger, cfg *config.Config) error {
 	if err != nil {
 		return fmt.Errorf("token service init failed: %w", err)
 	}
+	// Enrich refresh-minted access tokens with the user's current roles (GH-432).
+	tokenSvc.SetUserLookup(userRepo)
 	hibpClient := hibp.NewClient(http.DefaultClient)
 	authSvc := auth.NewService(redisClient, log, auditSvc, userRepo, refreshTokenRepo, tokenSvc, hasher, hibpClient)
 

--- a/internal/token/service.go
+++ b/internal/token/service.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 
@@ -52,6 +53,12 @@ const (
 	issuer = "https://auth.qf.studio"
 )
 
+// UserLookup abstracts user retrieval for refresh-token role enrichment.
+// This is a narrow interface satisfied by storage.UserRepository.
+type UserLookup interface {
+	FindByID(ctx context.Context, tenantID uuid.UUID, id string) (*domain.User, error)
+}
+
 // Service implements api.TokenService and middleware.TokenValidator.
 type Service struct {
 	logger        *zap.Logger
@@ -61,6 +68,7 @@ type Service struct {
 	privateKey    crypto.Signer
 	publicKey     crypto.PublicKey
 	signingMethod jwt.SigningMethod
+	users         UserLookup
 }
 
 // NewService creates a new token Service, loading the private key from the
@@ -105,6 +113,15 @@ func NewServiceFromKey(cfg config.JWTConfig, privateKey crypto.Signer, redisClie
 		publicKey:     pub,
 		signingMethod: method,
 	}, nil
+}
+
+// SetUserLookup injects the user repository used to enrich refresh-minted
+// access tokens with the user's current roles (GH-432). Optional: if unset,
+// refreshed access tokens carry no roles claim. Injected post-construction
+// so callers that don't need role enrichment (e.g. tests) can skip it,
+// mirroring auth.Service.SetMFAChecker.
+func (s *Service) SetUserLookup(users UserLookup) {
+	s.users = users
 }
 
 // IssueTokenPair generates an access/refresh token pair for the given subject.
@@ -161,9 +178,23 @@ func (s *Service) refreshInternal(ctx context.Context, rawRefreshToken, jktThumb
 	// Revoke the old refresh token (rotate).
 	s.deleteRefreshToken(ctx, rawRefreshToken)
 
-	// Issue new pair — refresh tokens carry no roles/scopes, so we issue with empty.
-	// The caller (auth service) should enrich with user's current roles/scopes.
-	result, err := s.issueTokenPair(ctx, subject, nil, nil, domain.ClientTypeUser, jktThumbprint)
+	// Refresh tokens carry no roles/scopes of their own, so look up the user's
+	// current roles (as of refresh time) and mirror what the login path does,
+	// otherwise refresh-minted access tokens would silently drop the roles
+	// claim and demote the user until they re-login (GH-432).
+	var roles []string
+	if s.users != nil {
+		tenantID := domain.TenantIDFromContext(ctx)
+		user, lookupErr := s.users.FindByID(ctx, tenantID, subject)
+		if lookupErr != nil {
+			s.logger.Error("failed to look up user for refresh role enrichment",
+				zap.String("subject", subject), zap.Error(lookupErr))
+		} else {
+			roles = user.Roles
+		}
+	}
+
+	result, err := s.issueTokenPair(ctx, subject, roles, nil, domain.ClientTypeUser, jktThumbprint)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/token/service_test.go
+++ b/internal/token/service_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,6 +25,7 @@ import (
 	"github.com/qf-studio/auth-service/internal/audit"
 	"github.com/qf-studio/auth-service/internal/config"
 	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage/mocks"
 	"github.com/qf-studio/auth-service/internal/token"
 )
 
@@ -452,6 +455,95 @@ func TestRefresh_SecretRotation(t *testing.T) {
 	newResult, err := newSvc.Refresh(ctx, result.RefreshToken)
 	require.NoError(t, err)
 	require.NotNil(t, newResult)
+}
+
+// ── Refresh Role Enrichment (GH-432) ────────────────────────────────────────
+
+// TestRefresh_EnrichesRolesFromUserLookup simulates the full acceptance flow:
+// register (user starts with role "user") -> assign roles via admin API
+// (roles become ["user","admin"]) -> login (mints an access token carrying
+// the roles at login time) -> refresh (must mint an access token carrying
+// the user's *current* roles, not the stale login-time roles). Regression
+// test for GH-432: the refresh grant previously dropped the roles claim
+// entirely.
+func TestRefresh_EnrichesRolesFromUserLookup(t *testing.T) {
+	svc, _ := newES256Service(t)
+	ctx := context.Background()
+
+	userID := "usr_gh432"
+	currentRoles := []string{"user"} // roles at "registration" time
+
+	userLookup := &mocks.MockUserRepository{
+		FindByIDFn: func(_ context.Context, _ uuid.UUID, id string) (*domain.User, error) {
+			require.Equal(t, userID, id)
+			return &domain.User{ID: userID, Roles: currentRoles}, nil
+		},
+	}
+	svc.SetUserLookup(userLookup)
+
+	// "login": mints an access token carrying roles as they were at login time.
+	loginResult, err := svc.IssueTokenPair(ctx, userID, currentRoles, nil, domain.ClientTypeUser)
+	require.NoError(t, err)
+
+	loginClaims, err := svc.ValidateToken(ctx, strings.TrimPrefix(loginResult.AccessToken, "qf_at_"))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"user"}, loginClaims.Roles)
+
+	// "assign roles via admin API": promote the user to admin after login.
+	currentRoles = []string{"user", "admin"}
+
+	// "refresh": must reflect the user's *current* roles, looked up at refresh time.
+	refreshResult, err := svc.Refresh(ctx, loginResult.RefreshToken)
+	require.NoError(t, err)
+
+	refreshClaims, err := svc.ValidateToken(ctx, strings.TrimPrefix(refreshResult.AccessToken, "qf_at_"))
+	require.NoError(t, err)
+	require.NotNil(t, refreshClaims)
+	assert.Equal(t, []string{"user", "admin"}, refreshClaims.Roles, "refreshed access token must carry the user's current roles")
+}
+
+// TestRefresh_NoRolesClaimWhenUserLookupUnset preserves the pre-GH-432
+// behavior when no UserLookup is wired (e.g. tests, or services that opt out
+// of role enrichment): refresh must still succeed, just without roles.
+func TestRefresh_NoRolesClaimWhenUserLookupUnset(t *testing.T) {
+	svc, _ := newES256Service(t)
+	ctx := context.Background()
+
+	result, err := svc.IssueTokenPair(ctx, "user-123", []string{"admin"}, nil, domain.ClientTypeUser)
+	require.NoError(t, err)
+
+	refreshResult, err := svc.Refresh(ctx, result.RefreshToken)
+	require.NoError(t, err)
+
+	refreshClaims, err := svc.ValidateToken(ctx, strings.TrimPrefix(refreshResult.AccessToken, "qf_at_"))
+	require.NoError(t, err)
+	assert.Empty(t, refreshClaims.Roles)
+}
+
+// TestRefresh_UserLookupErrorFailsOpenWithNoRoles verifies that a transient
+// user-lookup failure during refresh doesn't fail the whole refresh (fail-open
+// for availability, matching this codebase's convention elsewhere), it just
+// results in an access token without the roles claim.
+func TestRefresh_UserLookupErrorFailsOpenWithNoRoles(t *testing.T) {
+	svc, _ := newES256Service(t)
+	ctx := context.Background()
+
+	userLookup := &mocks.MockUserRepository{
+		FindByIDFn: func(_ context.Context, _ uuid.UUID, _ string) (*domain.User, error) {
+			return nil, errors.New("db unavailable")
+		},
+	}
+	svc.SetUserLookup(userLookup)
+
+	result, err := svc.IssueTokenPair(ctx, "user-123", []string{"admin"}, nil, domain.ClientTypeUser)
+	require.NoError(t, err)
+
+	refreshResult, err := svc.Refresh(ctx, result.RefreshToken)
+	require.NoError(t, err)
+
+	refreshClaims, err := svc.ValidateToken(ctx, strings.TrimPrefix(refreshResult.AccessToken, "qf_at_"))
+	require.NoError(t, err)
+	assert.Empty(t, refreshClaims.Roles)
 }
 
 // ── JWKS ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-432.

Closes #432

## Changes

GitHub Issue GH-432: Refresh grant drops the roles claim from access tokens

## Context

The refresh grant mints access tokens without the `roles` claim that login-minted tokens carry. Repro (2026-07-20, image ee9defd): user has roles `["user","admin"]` (set via admin API `PATCH /admin/users/:id`); `POST /auth/login` → access token payload contains `"roles":["user","admin"]`; `POST /auth/token` with the returned refresh_token → 200 with a rotated pair, but the new access token has no roles claim at all.

Downstream impact: pointer gates admin routes on the token's roles claim, so a transparent 401-refresh-retry silently demotes an admin mid-session (role-gated routes 403 until re-login).

## Acceptance

- [ ] An access token minted via the refresh grant (`POST /auth/token`) carries the same `roles` claim the user's login-minted token would carry (looked up at refresh time, so role changes since login are reflected).
- [ ] Test: register user → assign roles via admin API → login → refresh → decode both access tokens and assert the roles claim is present and equal to the user's current roles.
- [ ] Existing token/auth test suites stay green.

## Implementation

The refresh path in the token service (internal/token/service.go) mints claims without loading the user's roles — mirror whatever the login path does (fetch user → include roles) when handling `grant_type=refresh_token`.