### PR TITLE
GH-440: feat: gET /auth/me returns stubbed email/name for every user (real id, fake...

### DIFF
--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -403,13 +403,21 @@ func (s *Service) ConfirmPasswordReset(ctx context.Context, token, newPassword s
 }
 
 // GetMe returns the current user's profile.
-// Stub: full implementation depends on PostgreSQL user repository.
-func (s *Service) GetMe(_ context.Context, userID string) (*api.UserInfo, error) {
-	// TODO(GH-XX): wire PostgreSQL user repository.
+func (s *Service) GetMe(ctx context.Context, userID string) (*api.UserInfo, error) {
+	tenantID := domain.TenantIDFromContext(ctx)
+
+	user, err := s.users.FindByID(ctx, tenantID, userID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("user not found: %w", api.ErrNotFound)
+		}
+		return nil, fmt.Errorf("find user: %w", err)
+	}
+
 	return &api.UserInfo{
-		ID:    userID,
-		Email: "stub@example.com",
-		Name:  "Stub User",
+		ID:    user.ID,
+		Email: user.Email,
+		Name:  user.Name,
 	}, nil
 }
 

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -723,11 +723,61 @@ func TestRegister_ReturnsStub(t *testing.T) {
 	assert.NotEmpty(t, user.ID)
 }
 
-func TestGetMe_ReturnsStub(t *testing.T) {
-	svc := newUnitService(t, &mockUserRepository{}, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, &mockHasher{})
+func TestGetMe_ReturnsUserProfile(t *testing.T) {
+	users := &mockUserRepository{
+		findByIDFn: func(_ context.Context, id string) (*domain.User, error) {
+			assert.Equal(t, "user-42", id)
+			return &domain.User{
+				ID:    "user-42",
+				Email: "aleks@example.com",
+				Name:  "Aleks Petrov",
+			}, nil
+		},
+	}
+	svc := newUnitService(t, users, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, &mockHasher{})
+
 	user, err := svc.GetMe(context.Background(), "user-42")
 	require.NoError(t, err)
 	assert.Equal(t, "user-42", user.ID)
+	assert.Equal(t, "aleks@example.com", user.Email)
+	assert.Equal(t, "Aleks Petrov", user.Name)
+}
+
+func TestGetMe_DifferentUsersGetDifferentProfiles(t *testing.T) {
+	profiles := map[string]*domain.User{
+		"user-1": {ID: "user-1", Email: "one@example.com", Name: "User One"},
+		"user-2": {ID: "user-2", Email: "two@example.com", Name: "User Two"},
+	}
+	users := &mockUserRepository{
+		findByIDFn: func(_ context.Context, id string) (*domain.User, error) {
+			return profiles[id], nil
+		},
+	}
+	svc := newUnitService(t, users, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, &mockHasher{})
+
+	user1, err := svc.GetMe(context.Background(), "user-1")
+	require.NoError(t, err)
+	assert.Equal(t, "one@example.com", user1.Email)
+	assert.Equal(t, "User One", user1.Name)
+
+	user2, err := svc.GetMe(context.Background(), "user-2")
+	require.NoError(t, err)
+	assert.Equal(t, "two@example.com", user2.Email)
+	assert.Equal(t, "User Two", user2.Name)
+}
+
+func TestGetMe_UserNotFound(t *testing.T) {
+	users := &mockUserRepository{
+		findByIDFn: func(_ context.Context, _ string) (*domain.User, error) {
+			return nil, storage.ErrNotFound
+		},
+	}
+	svc := newUnitService(t, users, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, &mockHasher{})
+
+	user, err := svc.GetMe(context.Background(), "user-missing")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrNotFound)
+	assert.Nil(t, user)
 }
 
 // ── Register Tests ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-440.

Closes #440

## Changes

GitHub Issue GH-440: GET /auth/me returns stubbed email/name for every user (real id, fake profile)

## Bug

`GET /auth/me` returns HTTP 200 with the correct per-user `id` but **hardcoded stub values for `email` and `name`** — every authenticated user gets `"stub@example.com"` / `"Stub User"` regardless of who they are.

Unlike the unimplemented OIDC provider routes (#431), which honestly 404, this endpoint silently serves wrong identity data. Any client that wires it up will display "Stub User" for every account.

## Repro (v0.68.x fixture stack, 2026-07-21)

Two distinct users, both provisioned via the admin API with real email/name:

```
$ curl -s :4001/admin/users   # admin port — DB has full identity
{"users":[
  {"id":"usr_8373...","email":"mr.alex.petrov@gmail.com","name":"Aleks Petrov",...},
  {"id":"usr_fe5c...","email":"dev@pointer.local","name":"Pointer Dev",...}]}

$ TOK=$(curl -s -X POST :4000/auth/login -H 'Content-Type: application/json' \
    -d '{"email":"dev@pointer.local","password":"..."}' | jq -r .access_token)
$ curl -s -H "Authorization: Bearer $TOK" :4000/auth/me
{"id":"usr_fe5c...","email":"stub@example.com","name":"Stub User"}

# second user, same stub profile:
$ curl -s -H "Authorization: Bearer $TOK2" :4000/auth/me
{"id":"usr_8373...","email":"stub@example.com","name":"Stub User"}
```

## Root Cause

The handler chain is correct until the last hop:

- `internal/api/router.go:137` → `protected.GET("/me", authH.Me)`
- `internal/api/auth_handlers.go:88-102` — `Me()` reads `user_id` from context and returns `h.auth.GetMe(ctx, userID)` verbatim. Fine.
- **`internal/auth/service.go:405-414`** — `(*Service).GetMe` discards `ctx` (`_`), never touches storage, and returns literal `"stub@example.com"` / `"Stub User"` with a dangling `TODO(GH-XX)` placeholder (never replaced with a real issue number — this issue is that number now).

The real user store is **already available to that exact struct**: `Service` holds `users storage.UserRepository` (`internal/auth/service.go:55`), DI-wired in `cmd/server/main.go:94`, and used correctly two methods below in `ChangePassword` (`internal/auth/service.go:421`: `s.users.FindByID(ctx, tenantID, userID)`). `domain.User` carries `Email`/`Name` (`internal/domain/user.go:10-29`). No new wiring is needed — `GetMe` just never called what it already holds.

## Implementation

- `internal/auth/service.go` `GetMe`: use `ctx`, `tenantID := domain.TenantIDFromContext(ctx)`, `s.users.FindByID(ctx, tenantID, userID)`, map `domain.User.Email`/`.Name` into `api.UserInfo`; error path mirrors `ChangePassword`'s wrapping (line ~423), `storage.ErrNotFound` through the existing `handleServiceError` path.
- Tests (conventions: `newUnitService(t, ...)` + mock repos, testify, one func per case — see `internal/auth/service_test.go`):
  - `TestGetMe_ReturnsStub` (`service_test.go:726-731`) currently asserts only `ID` — rename and assert real email/name via `mockUserRepository`; add a not-found case.
  - `internal/api/router_test.go:71-75` / `TestMe_Success` (:448-457) are handler-layer mocks asserting only `ID` — unaffected, leave as-is.

## Acceptance Criteria

- [ ] `GET /auth/me` returns the authenticated user's actual `email` and `name` from the users table (same values `/admin/users` serves) for two different users.
- [ ] Unknown/deleted user id → error via the existing not-found path, not a fabricated profile.
- [ ] No stub literals remain in `GetMe`; the `TODO(GH-XX)` marker is gone.
- [ ] Unit tests assert per-user email/name round-trip through `mockUserRepository`; full suite green.

## Out of Scope

- OIDC provider / userinfo endpoint (#431).
- Response shape changes to `api.UserInfo` (id/email/name stays as-is).

## Impact

- SPAs cannot display who is signed in: access tokens are opaque (`qf_at_`, no identity claims), OIDC userinfo 404s (#431), so `/auth/me` is the only user-facing identity source — and it lies.
- Downstream (qf-studio/pointer TASK-38 / qf-studio/pointer#136) ships a client-side workaround (capture email at password login). Name display and PKCE-session identity stay blocked on this fix; once shipped, clients switch to `name ?? email` from `/auth/me`.

## Related

- #431 — OIDC provider unimplemented (userinfo 404s; this is the non-OIDC sibling that returns wrong data instead of 404ing)
- #432 — refresh-grant roles drop (prior report from the same downstream consumer)