### PR TITLE
ci(test): add Go test workflow for PRs and main pushes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test ./...


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test.yml` running `go test ./...` on `pull_request` and pushes to `main`.
- Job name is `test`, matching Pilot's ci-monitor allowlist (`[test lint]`).
- No service containers needed — storage/Redis integration tests already skip gracefully without `TEST_DATABASE_URL`, so the suite runs hermetically.

Fixes the "no test CI" gap causing `waiting_ci`/`post_merge_ci` stalls (PR #441 timed out after 30m with zero checks; PR #439 retried a nonexistent main-push check all night).

## Scope
One workflow file only — no app code changes, no other workflows touched.

## Test plan
- [ ] Confirm this PR shows a green `test` check on itself (pull_request trigger)
- [ ] Confirm a push to `main` after merge runs `test`