### PR TITLE
fix(migrations): match user_id FK types to users.id TEXT (GH-444)

### DIFF
--- a/migrations/000010_password_policy_and_history.up.sql
+++ b/migrations/000010_password_policy_and_history.up.sql
@@ -5,7 +5,7 @@ ALTER TABLE users ADD COLUMN password_changed_at TIMESTAMPTZ;
 -- Password history for reuse detection.
 CREATE TABLE IF NOT EXISTS password_history (
     id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     password_hash TEXT NOT NULL,
     created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/migrations/000014_create_saml_tables.up.sql
+++ b/migrations/000014_create_saml_tables.up.sql
@@ -15,7 +15,7 @@ CREATE TABLE saml_idp_configs (
 
 CREATE TABLE saml_accounts (
     id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id             UUID        NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    user_id             TEXT        NOT NULL REFERENCES users (id) ON DELETE CASCADE,
     idp_id              UUID        NOT NULL REFERENCES saml_idp_configs (id) ON DELETE CASCADE,
     name_id             TEXT        NOT NULL,
     session_index       TEXT        NOT NULL DEFAULT '',


### PR DESCRIPTION
## Context

Fresh-database migrations fail at version 10: `000010` and `000014` declare `user_id UUID` FKs referencing `users.id`, which is `TEXT` (defined in `000003`). Postgres rejects the FK on type mismatch, so every fresh install fails deterministically. Incrementally-migrated environments never hit it.

## Change

`UUID` → `TEXT` for `user_id` in:
- `migrations/000010_password_policy_and_history.up.sql`
- `migrations/000014_create_saml_tables.up.sql`

No-op for databases already past these versions (golang-migrate does not checksum applied files). Matches the fixture patches pointer already vendors.

## Verify

- Ran `go run cmd/migrate/main.go up` against a clean `postgres:16-alpine` — all 15 migrations applied (previously died at 10).
- Confirmed `password_history.user_id` and `saml_accounts.user_id` are `text` with FKs in place.
- CI migration-dry-run job in the Release workflow exercises the same scenario.

Fixes #444
Refs #435 (its remaining ask — shipping migrations in the image — is not addressed here)