### PR TITLE
GH-448: feat(oauth): add public client type with redirect uri storage and admin api

### DIFF
--- a/.agent/tasks/gh-448.md
+++ b/.agent/tasks/gh-448.md
@@ -1,0 +1,10 @@
+# GH-448
+
+**Created:** 2026-07-25
+
+## Problem
+
+Introduce `ClientTypePublic` in `internal/domain/client.go` (and mirror in the dead `internal/domain/admin.go` / `validation.go` path for consistency). Add migrations `000016_add_public_client_type` (enum `ADD VALUE 'public'`, no-op down) and `000017_add_client_redirect_uris` (`TEXT[] NOT NULL DEFAULT '{}'`, drop-column down). Extend `domain.Client` with `RedirectURIs []string` and thread through `internal/storage/client_repository.go` scans/inserts/updates. Update `internal/api/admin_services.go` `CreateClientRequest` to accept `public` and an optional `redirect_uris` slice (required non-empty for public, absolute http(s) URIs, no fragments). In `internal/admin/client_service.go`, branch `CreateClient` so public clients skip secret generation and store empty `secret_hash`; add a guard rejecting `RotateSecret` on public clients / empty-hash clients with a domain error. Have `internal/api/admin_client_handlers.go` return `AdminClient` (no secret) for public clients and `AdminClientWithSecret` otherwise; populate `RedirectURIs` in `domainClientToAdmin`. Allow updating `redirect_uris` via existing `Update`. Verify: fresh-DB `migrate up` 1→17 passes; POST /admin/clients with `public`+URIs returns 201 without secret, without URIs returns 400; service/agent flow unchanged; rotating a public client's secret returns 4xx.
+
+## Acceptance Criteria
+

--- a/internal/admin/client_service.go
+++ b/internal/admin/client_service.go
@@ -91,19 +91,29 @@ func (s *ClientService) GetClient(ctx context.Context, clientID string) (*api.Ad
 	return &admin, nil
 }
 
-// CreateClient creates a new OAuth2 client with a generated secret.
+// CreateClient creates a new OAuth2 client. Public clients (SPAs, mobile
+// apps) cannot securely hold a secret, so no secret is generated for them
+// and secret_hash is stored empty; they authenticate via redirect URIs
+// instead.
 func (s *ClientService) CreateClient(ctx context.Context, req *api.CreateClientRequest) (*api.AdminClientWithSecret, error) {
 	tenantID := domain.TenantIDFromContext(ctx)
-	secret, err := generateClientSecret()
-	if err != nil {
-		s.logger.Error("generate client secret failed", zap.Error(err))
-		return nil, fmt.Errorf("create client: %w", api.ErrInternalError)
-	}
+	clientType := domain.ClientType(req.ClientType)
+	isPublic := clientType == domain.ClientTypePublic
 
-	hash, err := s.hasher.Hash(secret)
-	if err != nil {
-		s.logger.Error("hash client secret failed", zap.Error(err))
-		return nil, fmt.Errorf("create client: %w", api.ErrInternalError)
+	var secret, hash string
+	if !isPublic {
+		var err error
+		secret, err = generateClientSecret()
+		if err != nil {
+			s.logger.Error("generate client secret failed", zap.Error(err))
+			return nil, fmt.Errorf("create client: %w", api.ErrInternalError)
+		}
+
+		hash, err = s.hasher.Hash(secret)
+		if err != nil {
+			s.logger.Error("hash client secret failed", zap.Error(err))
+			return nil, fmt.Errorf("create client: %w", api.ErrInternalError)
+		}
 	}
 
 	now := time.Now().UTC()
@@ -111,14 +121,19 @@ func (s *ClientService) CreateClient(ctx context.Context, req *api.CreateClientR
 	if scopes == nil {
 		scopes = []string{}
 	}
+	redirectURIs := req.RedirectURIs
+	if redirectURIs == nil {
+		redirectURIs = []string{}
+	}
 
 	client := &domain.Client{
 		ID:             uuid.New(),
 		TenantID:       tenantID,
 		Name:           req.Name,
-		ClientType:     domain.ClientType(req.ClientType),
+		ClientType:     clientType,
 		SecretHash:     hash,
 		Scopes:         scopes,
+		RedirectURIs:   redirectURIs,
 		Owner:          "admin",
 		AccessTokenTTL: 900,
 		Status:         domain.ClientStatusActive,
@@ -170,6 +185,9 @@ func (s *ClientService) UpdateClient(ctx context.Context, clientID string, req *
 	if req.Scopes != nil {
 		existing.Scopes = req.Scopes
 	}
+	if req.RedirectURIs != nil {
+		existing.RedirectURIs = req.RedirectURIs
+	}
 
 	updated, err := s.repo.Update(ctx, existing)
 	if err != nil {
@@ -219,11 +237,25 @@ func (s *ClientService) DeleteClient(ctx context.Context, clientID string) error
 }
 
 // RotateSecret generates a new secret for the client with a grace period.
+// Public clients (and any client with no stored secret) cannot rotate a
+// secret they never had; this is rejected with a conflict error.
 func (s *ClientService) RotateSecret(ctx context.Context, clientID string) (*api.AdminClientWithSecret, error) {
 	tenantID := domain.TenantIDFromContext(ctx)
 	id, err := uuid.Parse(clientID)
 	if err != nil {
 		return nil, fmt.Errorf("invalid client ID: %w", api.ErrNotFound)
+	}
+
+	existing, err := s.repo.FindByID(ctx, tenantID, id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("client %s: %w", clientID, api.ErrNotFound)
+		}
+		s.logger.Error("find client for rotate secret failed", zap.String("client_id", clientID), zap.Error(err))
+		return nil, fmt.Errorf("rotate secret: %w", api.ErrInternalError)
+	}
+	if existing.ClientType == domain.ClientTypePublic || existing.SecretHash == "" {
+		return nil, fmt.Errorf("client %s is a public client and has no secret to rotate: %w", clientID, api.ErrConflict)
 	}
 
 	secret, err := generateClientSecret()
@@ -278,11 +310,12 @@ func generateClientSecret() (string, error) {
 // domainClientToAdmin converts a domain.Client to an api.AdminClient response DTO.
 func domainClientToAdmin(c *domain.Client) api.AdminClient {
 	return api.AdminClient{
-		ID:         c.ID.String(),
-		Name:       c.Name,
-		ClientType: string(c.ClientType),
-		Scopes:     c.Scopes,
-		CreatedAt:  c.CreatedAt,
-		UpdatedAt:  c.UpdatedAt,
+		ID:           c.ID.String(),
+		Name:         c.Name,
+		ClientType:   string(c.ClientType),
+		Scopes:       c.Scopes,
+		RedirectURIs: c.RedirectURIs,
+		CreatedAt:    c.CreatedAt,
+		UpdatedAt:    c.UpdatedAt,
 	}
 }

--- a/internal/admin/client_service_test.go
+++ b/internal/admin/client_service_test.go
@@ -193,6 +193,41 @@ func TestClientService_CreateClient(t *testing.T) {
 	assert.Contains(t, result.ClientSecret, clientSecretPrefix)
 }
 
+func TestClientService_CreateClient_Public(t *testing.T) {
+	svc := newTestClientService(&mockClientRepo{})
+
+	req := &api.CreateClientRequest{
+		Name:         "spa-client",
+		ClientType:   "public",
+		RedirectURIs: []string{"https://app.example.com/callback"},
+	}
+	result, err := svc.CreateClient(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, "public", result.ClientType)
+	assert.Empty(t, result.ClientSecret)
+	assert.Equal(t, []string{"https://app.example.com/callback"}, result.RedirectURIs)
+}
+
+func TestClientService_CreateClient_Public_NoSecretHashStored(t *testing.T) {
+	var created *domain.Client
+	repo := &mockClientRepo{
+		createFn: func(_ context.Context, client *domain.Client) (*domain.Client, error) {
+			created = client
+			return client, nil
+		},
+	}
+	svc := newTestClientService(repo)
+
+	_, err := svc.CreateClient(context.Background(), &api.CreateClientRequest{
+		Name:         "spa-client",
+		ClientType:   "public",
+		RedirectURIs: []string{"https://app.example.com/callback"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	assert.Empty(t, created.SecretHash)
+}
+
 func TestClientService_CreateClient_Conflict(t *testing.T) {
 	repo := &mockClientRepo{
 		createFn: func(_ context.Context, _ *domain.Client) (*domain.Client, error) {
@@ -226,6 +261,23 @@ func TestClientService_UpdateClient(t *testing.T) {
 	client, err := svc.UpdateClient(context.Background(), clientID.String(), &api.UpdateClientRequest{Name: &name})
 	require.NoError(t, err)
 	assert.Equal(t, "updated-name", client.Name)
+}
+
+func TestClientService_UpdateClient_RedirectURIs(t *testing.T) {
+	clientID := uuid.New()
+	repo := &mockClientRepo{
+		findByIDFn: func(_ context.Context, _ uuid.UUID, id uuid.UUID) (*domain.Client, error) {
+			c := testClient()
+			c.ID = id
+			return c, nil
+		},
+	}
+	svc := newTestClientService(repo)
+
+	uris := []string{"https://app.example.com/callback"}
+	client, err := svc.UpdateClient(context.Background(), clientID.String(), &api.UpdateClientRequest{RedirectURIs: uris})
+	require.NoError(t, err)
+	assert.Equal(t, uris, client.RedirectURIs)
 }
 
 func TestClientService_UpdateClient_NotFound(t *testing.T) {
@@ -289,6 +341,41 @@ func TestClientService_RotateSecret(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, result.ClientSecret, clientSecretPrefix)
 	assert.NotNil(t, result.GracePeriodEnds)
+}
+
+func TestClientService_RotateSecret_PublicClient(t *testing.T) {
+	clientID := uuid.New()
+	repo := &mockClientRepo{
+		findByIDFn: func(_ context.Context, _ uuid.UUID, id uuid.UUID) (*domain.Client, error) {
+			c := testClient()
+			c.ID = id
+			c.ClientType = domain.ClientTypePublic
+			c.SecretHash = ""
+			return c, nil
+		},
+	}
+	svc := newTestClientService(repo)
+
+	_, err := svc.RotateSecret(context.Background(), clientID.String())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrConflict)
+}
+
+func TestClientService_RotateSecret_EmptySecretHash(t *testing.T) {
+	clientID := uuid.New()
+	repo := &mockClientRepo{
+		findByIDFn: func(_ context.Context, _ uuid.UUID, id uuid.UUID) (*domain.Client, error) {
+			c := testClient()
+			c.ID = id
+			c.SecretHash = ""
+			return c, nil
+		},
+	}
+	svc := newTestClientService(repo)
+
+	_, err := svc.RotateSecret(context.Background(), clientID.String())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrConflict)
 }
 
 func TestClientService_RotateSecret_NotFound(t *testing.T) {

--- a/internal/api/admin_client_handlers.go
+++ b/internal/api/admin_client_handlers.go
@@ -49,7 +49,9 @@ func (h *AdminClientHandlers) Get(c *gin.Context) {
 }
 
 // Create handles POST /admin/clients.
-// Returns the client with the generated secret (only time secret is visible).
+// Returns the client with the generated secret (only time secret is
+// visible) for service/agent clients. Public clients never have a secret,
+// so only the AdminClient (no secret field) is returned for them.
 func (h *AdminClientHandlers) Create(c *gin.Context) {
 	var req CreateClientRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -65,6 +67,11 @@ func (h *AdminClientHandlers) Create(c *gin.Context) {
 	client, err := h.clients.CreateClient(c.Request.Context(), &req)
 	if err != nil {
 		handleServiceError(c, err)
+		return
+	}
+
+	if client.ClientType == string(domain.ClientTypePublic) {
+		c.JSON(http.StatusCreated, client.AdminClient)
 		return
 	}
 

--- a/internal/api/admin_client_handlers_test.go
+++ b/internal/api/admin_client_handlers_test.go
@@ -219,6 +219,61 @@ func TestAdminCreateClient_MissingName(t *testing.T) {
 	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
 }
 
+func TestAdminCreateClient_PublicType_Success(t *testing.T) {
+	svc := &mockAdminClientService{
+		createClientFn: func(_ context.Context, req *api.CreateClientRequest) (*api.AdminClientWithSecret, error) {
+			return &api.AdminClientWithSecret{
+				AdminClient: api.AdminClient{
+					ID:           "spa-client",
+					Name:         req.Name,
+					ClientType:   req.ClientType,
+					RedirectURIs: req.RedirectURIs,
+					CreatedAt:    time.Now(),
+					UpdatedAt:    time.Now(),
+				},
+			}, nil
+		},
+	}
+	r := newAdminClientRouter(svc)
+	body := map[string]interface{}{
+		"name":          "spa-client",
+		"client_type":   "public",
+		"redirect_uris": []string{"https://app.example.com/callback"},
+	}
+	w := doRequest(r, http.MethodPost, "/admin/clients", body)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	_, hasSecret := resp["client_secret"]
+	assert.False(t, hasSecret, "public client response must not include client_secret")
+	assert.Equal(t, []interface{}{"https://app.example.com/callback"}, resp["redirect_uris"])
+}
+
+func TestAdminCreateClient_PublicType_MissingRedirectURIs(t *testing.T) {
+	r := newAdminClientRouter(&mockAdminClientService{})
+	body := map[string]interface{}{
+		"name":        "spa-client",
+		"client_type": "public",
+	}
+	w := doRequest(r, http.MethodPost, "/admin/clients", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestAdminCreateClient_PublicType_InvalidRedirectURI(t *testing.T) {
+	r := newAdminClientRouter(&mockAdminClientService{})
+	body := map[string]interface{}{
+		"name":          "spa-client",
+		"client_type":   "public",
+		"redirect_uris": []string{"not-a-valid-uri"},
+	}
+	w := doRequest(r, http.MethodPost, "/admin/clients", body)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
 func TestAdminCreateClient_Conflict(t *testing.T) {
 	svc := &mockAdminClientService{
 		createClientFn: func(_ context.Context, _ *api.CreateClientRequest) (*api.AdminClientWithSecret, error) {
@@ -296,6 +351,19 @@ func TestAdminRotateSecret_Success(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.NotEmpty(t, resp.ClientSecret, "new secret must be returned on rotation")
 	assert.NotNil(t, resp.GracePeriodEnds, "grace period must be set on rotation")
+}
+
+func TestAdminRotateSecret_PublicClient_Rejected(t *testing.T) {
+	svc := &mockAdminClientService{
+		rotateSecretFn: func(_ context.Context, clientID string) (*api.AdminClientWithSecret, error) {
+			return nil, fmt.Errorf("client %s is a public client and has no secret to rotate: %w", clientID, api.ErrConflict)
+		},
+	}
+	r := newAdminClientRouter(svc)
+	w := doRequest(r, http.MethodPost, "/admin/clients/spa-client/rotate-secret", nil)
+
+	assert.GreaterOrEqual(t, w.Code, 400)
+	assert.Less(t, w.Code, 500)
 }
 
 func TestAdminRotateSecret_NotFound(t *testing.T) {

--- a/internal/api/admin_router.go
+++ b/internal/api/admin_router.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -14,7 +15,33 @@ import (
 )
 
 // adminValidator is the shared validator instance for admin request structs.
-var adminValidator = validator.New()
+var adminValidator = newAdminValidator()
+
+// newAdminValidator builds the validator.Validate instance used for admin
+// request structs, registering custom validation tags on top of the
+// built-ins.
+func newAdminValidator() *validator.Validate {
+	v := validator.New()
+	_ = v.RegisterValidation("http_url_no_fragment", validateHTTPURLNoFragment)
+	return v
+}
+
+// validateHTTPURLNoFragment ensures the field is an absolute http(s) URI
+// with no fragment component, as required for OAuth2 client redirect URIs.
+func validateHTTPURLNoFragment(fl validator.FieldLevel) bool {
+	raw := fl.Field().String()
+	u, err := url.Parse(raw)
+	if err != nil || !u.IsAbs() {
+		return false
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return false
+	}
+	if u.Fragment != "" {
+		return false
+	}
+	return true
+}
 
 // AdminDeps holds infrastructure dependencies for the admin router.
 type AdminDeps struct {

--- a/internal/api/admin_services.go
+++ b/internal/api/admin_services.go
@@ -160,18 +160,21 @@ type UserActivityTimeline struct {
 }
 
 // CreateClientRequest is the request body for creating an OAuth2 client.
+// RedirectURIs is required (and must be non-empty) for public clients, since
+// they authenticate via redirect URI validation rather than a secret; it is
+// optional for service/agent clients.
 type CreateClientRequest struct {
 	Name         string   `json:"name"          validate:"required,min=1,max=255"`
-	ClientType   string   `json:"client_type"   validate:"required,oneof=service agent"`
+	ClientType   string   `json:"client_type"   validate:"required,oneof=service agent public"`
 	Scopes       []string `json:"scopes"        validate:"omitempty"`
-	RedirectURIs []string `json:"redirect_uris" validate:"omitempty"`
+	RedirectURIs []string `json:"redirect_uris" validate:"required_if=ClientType public,omitempty,dive,http_url_no_fragment"`
 }
 
 // UpdateClientRequest is the request body for updating an OAuth2 client.
 type UpdateClientRequest struct {
 	Name         *string  `json:"name"          validate:"omitempty,min=1,max=255"`
 	Scopes       []string `json:"scopes"        validate:"omitempty"`
-	RedirectURIs []string `json:"redirect_uris" validate:"omitempty"`
+	RedirectURIs []string `json:"redirect_uris" validate:"omitempty,dive,http_url_no_fragment"`
 }
 
 // IntrospectRequest is the request body for RFC 7662 token introspection.

--- a/internal/domain/admin.go
+++ b/internal/domain/admin.go
@@ -37,17 +37,19 @@ func (r *ListUsersRequest) DefaultLimit() int {
 
 // CreateClientRequest is the validated request body for admin client creation.
 type CreateClientRequest struct {
-	Name       string   `json:"name"        validate:"required,min=1,max=255"`
-	ClientType string   `json:"client_type" validate:"required,client_type"`
-	Scopes     []string `json:"scopes"      validate:"required,min=1,dive,valid_scope"`
-	OwnerID    string   `json:"owner_id"    validate:"omitempty"`
+	Name         string   `json:"name"          validate:"required,min=1,max=255"`
+	ClientType   string   `json:"client_type"   validate:"required,client_type"`
+	Scopes       []string `json:"scopes"        validate:"required,min=1,dive,valid_scope"`
+	OwnerID      string   `json:"owner_id"      validate:"omitempty"`
+	RedirectURIs []string `json:"redirect_uris" validate:"omitempty"`
 }
 
 // UpdateClientRequest is the validated request body for admin client updates.
 type UpdateClientRequest struct {
-	Name   *string  `json:"name"   validate:"omitempty,min=1,max=255"`
-	Scopes []string `json:"scopes" validate:"omitempty,min=1,dive,valid_scope"`
-	Active *bool    `json:"active"`
+	Name         *string  `json:"name"          validate:"omitempty,min=1,max=255"`
+	Scopes       []string `json:"scopes"        validate:"omitempty,min=1,dive,valid_scope"`
+	Active       *bool    `json:"active"`
+	RedirectURIs []string `json:"redirect_uris" validate:"omitempty"`
 }
 
 // ListClientsRequest holds pagination parameters for listing clients.
@@ -87,15 +89,16 @@ type AdminUserResponse struct {
 
 // AdminClientResponse is the admin view of an OAuth2 client.
 type AdminClientResponse struct {
-	ID         string    `json:"id"`
-	Name       string    `json:"name"`
-	ClientID   string    `json:"client_id"`
-	ClientType string    `json:"client_type"`
-	Scopes     []string  `json:"scopes"`
-	OwnerID    string    `json:"owner_id,omitempty"`
-	Active     bool      `json:"active"`
-	CreatedAt  time.Time `json:"created_at"`
-	UpdatedAt  time.Time `json:"updated_at"`
+	ID           string    `json:"id"`
+	Name         string    `json:"name"`
+	ClientID     string    `json:"client_id"`
+	ClientType   string    `json:"client_type"`
+	Scopes       []string  `json:"scopes"`
+	OwnerID      string    `json:"owner_id,omitempty"`
+	Active       bool      `json:"active"`
+	RedirectURIs []string  `json:"redirect_uris,omitempty"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
 }
 
 // IntrospectionResponse follows RFC 7662 token introspection response format.
@@ -123,6 +126,7 @@ type PaginatedResponse struct {
 var ValidClientTypes = map[string]bool{
 	string(ClientTypeService): true,
 	string(ClientTypeAgent):   true,
+	string(ClientTypePublic):  true,
 }
 
 // ValidScopes are the allowed OAuth2 scope values for system clients.

--- a/internal/domain/client.go
+++ b/internal/domain/client.go
@@ -13,6 +13,10 @@ const (
 	ClientTypeUser    ClientType = "user"
 	ClientTypeService ClientType = "service"
 	ClientTypeAgent   ClientType = "agent"
+	// ClientTypePublic identifies an OAuth2 public client (e.g. SPA or mobile
+	// app) that cannot securely hold a client secret and instead authenticates
+	// via registered redirect URIs.
+	ClientTypePublic ClientType = "public"
 )
 
 // IsValid returns true if the ClientType is a recognised value.
@@ -38,6 +42,7 @@ type Client struct {
 	PreviousSecretHash      string     `json:"-"                           db:"previous_secret_hash"`
 	PreviousSecretExpiresAt *time.Time `json:"-"                           db:"previous_secret_expires_at"`
 	Scopes                  []string   `json:"scopes"                      db:"scopes"`
+	RedirectURIs            []string   `json:"redirect_uris"               db:"redirect_uris"`
 	Owner                   string     `json:"owner"                       db:"owner"`
 	AccessTokenTTL          int        `json:"access_token_ttl"            db:"access_token_ttl"` // seconds
 	Status                  string     `json:"status"                      db:"status"`

--- a/internal/domain/validation.go
+++ b/internal/domain/validation.go
@@ -95,7 +95,7 @@ func NewValidator() *validator.Validate {
 	return v
 }
 
-// validateClientType ensures the value is one of "service" or "agent".
+// validateClientType ensures the value is one of "service", "agent", or "public".
 func validateClientType(fl validator.FieldLevel) bool {
 	return ValidClientTypes[fl.Field().String()]
 }
@@ -173,7 +173,7 @@ func validationMessage(fe validator.FieldError) string {
 	case "required_if":
 		return fmt.Sprintf("%s is required for this grant type", strings.ToLower(fe.Field()))
 	case "client_type":
-		return "must be one of: service, agent"
+		return "must be one of: service, agent, public"
 	case "valid_scope":
 		return "invalid scope"
 	default:

--- a/internal/storage/client_repository.go
+++ b/internal/storage/client_repository.go
@@ -38,7 +38,7 @@ func NewPostgresClientRepository(pool *pgxpool.Pool) *PostgresClientRepository {
 	return &PostgresClientRepository{pool: pool}
 }
 
-const clientColumns = `id, tenant_id, name, client_type, secret_hash, previous_secret_hash, previous_secret_expires_at, scopes, owner, access_token_ttl, status, created_at, updated_at, last_used_at`
+const clientColumns = `id, tenant_id, name, client_type, secret_hash, previous_secret_hash, previous_secret_expires_at, scopes, owner, access_token_ttl, status, created_at, updated_at, last_used_at, redirect_uris`
 
 func scanClient(row pgx.Row) (*domain.Client, error) {
 	c := &domain.Client{}
@@ -46,7 +46,7 @@ func scanClient(row pgx.Row) (*domain.Client, error) {
 		&c.ID, &c.TenantID, &c.Name, &c.ClientType, &c.SecretHash,
 		&c.PreviousSecretHash, &c.PreviousSecretExpiresAt,
 		&c.Scopes, &c.Owner, &c.AccessTokenTTL, &c.Status,
-		&c.CreatedAt, &c.UpdatedAt, &c.LastUsedAt,
+		&c.CreatedAt, &c.UpdatedAt, &c.LastUsedAt, &c.RedirectURIs,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -100,7 +100,7 @@ func (r *PostgresClientRepository) List(ctx context.Context, tenantID uuid.UUID,
 			&c.ID, &c.TenantID, &c.Name, &c.ClientType, &c.SecretHash,
 			&c.PreviousSecretHash, &c.PreviousSecretExpiresAt,
 			&c.Scopes, &c.Owner, &c.AccessTokenTTL, &c.Status,
-			&c.CreatedAt, &c.UpdatedAt, &c.LastUsedAt,
+			&c.CreatedAt, &c.UpdatedAt, &c.LastUsedAt, &c.RedirectURIs,
 		); err != nil {
 			return nil, 0, fmt.Errorf("scan client: %w", err)
 		}
@@ -136,14 +136,14 @@ func (r *PostgresClientRepository) FindByName(ctx context.Context, tenantID uuid
 // Create inserts a new client. Returns ErrDuplicateClient on name conflict.
 func (r *PostgresClientRepository) Create(ctx context.Context, client *domain.Client) (*domain.Client, error) {
 	query := fmt.Sprintf(`
-		INSERT INTO clients (id, tenant_id, name, client_type, secret_hash, scopes, owner, access_token_ttl, status, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		INSERT INTO clients (id, tenant_id, name, client_type, secret_hash, scopes, owner, access_token_ttl, status, created_at, updated_at, redirect_uris)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 		RETURNING %s`, clientColumns)
 
 	c, err := scanClient(r.pool.QueryRow(ctx, query,
 		client.ID, client.TenantID, client.Name, client.ClientType, client.SecretHash,
 		client.Scopes, client.Owner, client.AccessTokenTTL, client.Status,
-		client.CreatedAt, client.UpdatedAt,
+		client.CreatedAt, client.UpdatedAt, client.RedirectURIs,
 	))
 	if err != nil {
 		var pgErr *pgconn.PgError
@@ -158,12 +158,12 @@ func (r *PostgresClientRepository) Create(ctx context.Context, client *domain.Cl
 // Update modifies mutable fields of a client (name, scopes).
 func (r *PostgresClientRepository) Update(ctx context.Context, client *domain.Client) (*domain.Client, error) {
 	query := fmt.Sprintf(`
-		UPDATE clients SET name = $1, scopes = $2, updated_at = $3
-		WHERE id = $4 AND tenant_id = $5 AND status != 'revoked'
+		UPDATE clients SET name = $1, scopes = $2, redirect_uris = $3, updated_at = $4
+		WHERE id = $5 AND tenant_id = $6 AND status != 'revoked'
 		RETURNING %s`, clientColumns)
 
 	c, err := scanClient(r.pool.QueryRow(ctx, query,
-		client.Name, client.Scopes, time.Now().UTC(), client.ID, client.TenantID,
+		client.Name, client.Scopes, client.RedirectURIs, time.Now().UTC(), client.ID, client.TenantID,
 	))
 	if err != nil {
 		var pgErr *pgconn.PgError

--- a/internal/storage/repository_integration_test.go
+++ b/internal/storage/repository_integration_test.go
@@ -98,7 +98,7 @@ func createTables(t *testing.T, pool *pgxpool.Pool) {
 		);
 
 		DO $$ BEGIN
-			CREATE TYPE client_type AS ENUM ('service', 'agent');
+			CREATE TYPE client_type AS ENUM ('service', 'agent', 'public');
 		EXCEPTION
 			WHEN duplicate_object THEN NULL;
 		END $$;
@@ -117,7 +117,8 @@ func createTables(t *testing.T, pool *pgxpool.Pool) {
 			status                      TEXT        NOT NULL DEFAULT 'active',
 			created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 			updated_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-			last_used_at                TIMESTAMPTZ
+			last_used_at                TIMESTAMPTZ,
+			redirect_uris               TEXT[]      NOT NULL DEFAULT '{}'
 		);
 
 		CREATE TABLE IF NOT EXISTS mfa_secrets (
@@ -739,6 +740,7 @@ func newTestClient() *domain.Client {
 		ClientType:     domain.ClientTypeService,
 		SecretHash:     "$argon2id$v=19$m=19456,t=2,p=1$salt$hash",
 		Scopes:         []string{"read:users"},
+		RedirectURIs:   []string{},
 		Owner:          "admin",
 		AccessTokenTTL: 900,
 		Status:         domain.ClientStatusActive,

--- a/migrations/000016_add_public_client_type.down.sql
+++ b/migrations/000016_add_public_client_type.down.sql
@@ -1,0 +1,6 @@
+-- 000016_add_public_client_type.down.sql
+-- No-op: PostgreSQL does not support removing a value from an enum type
+-- without recreating the type (and rewriting every dependent column), so
+-- rolling back this migration is intentionally a no-op. Any "public" rows
+-- created after upgrading would need to be migrated or removed manually
+-- before attempting a destructive downgrade.

--- a/migrations/000016_add_public_client_type.up.sql
+++ b/migrations/000016_add_public_client_type.up.sql
@@ -1,0 +1,6 @@
+-- 000016_add_public_client_type.up.sql
+-- Adds the "public" client type for OAuth2 public clients (e.g. SPAs, mobile
+-- apps) that cannot securely hold a client secret and instead authenticate
+-- via registered redirect URIs.
+
+ALTER TYPE client_type ADD VALUE 'public';

--- a/migrations/000017_add_client_redirect_uris.down.sql
+++ b/migrations/000017_add_client_redirect_uris.down.sql
@@ -1,0 +1,2 @@
+-- 000017_add_client_redirect_uris.down.sql
+ALTER TABLE clients DROP COLUMN redirect_uris;

--- a/migrations/000017_add_client_redirect_uris.up.sql
+++ b/migrations/000017_add_client_redirect_uris.up.sql
@@ -1,0 +1,5 @@
+-- 000017_add_client_redirect_uris.up.sql
+-- Adds redirect_uris to clients, used to validate authorization requests for
+-- public OAuth2 clients.
+
+ALTER TABLE clients ADD COLUMN redirect_uris TEXT[] NOT NULL DEFAULT '{}';


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-448.

Closes #448

## Changes

Introduce `ClientTypePublic` in `internal/domain/client.go` (and mirror in the dead `internal/domain/admin.go` / `validation.go` path for consistency). Add migrations `000016_add_public_client_type` (enum `ADD VALUE 'public'`, no-op down) and `000017_add_client_redirect_uris` (`TEXT[] NOT NULL DEFAULT '{}'`, drop-column down). Extend `domain.Client` with `RedirectURIs []string` and thread through `internal/storage/client_repository.go` scans/inserts/updates. Update `internal/api/admin_services.go` `CreateClientRequest` to accept `public` and an optional `redirect_uris` slice (required non-empty for public, absolute http(s) URIs, no fragments). In `internal/admin/client_service.go`, branch `CreateClient` so public clients skip secret generation and store empty `secret_hash`; add a guard rejecting `RotateSecret` on public clients / empty-hash clients with a domain error. Have `internal/api/admin_client_handlers.go` return `AdminClient` (no secret) for public clients and `AdminClientWithSecret` otherwise; populate `RedirectURIs` in `domainClientToAdmin`. Allow updating `redirect_uris` via existing `Update`. Verify: fresh-DB `migrate up` 1→17 passes; POST /admin/clients with `public`+URIs returns 201 without secret, without URIs returns 400; service/agent flow unchanged; rotating a public client's secret returns 4xx.