### PR TITLE
GH-449: feat(auth): emit configurable aud claim on access tokens

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -142,6 +142,7 @@ type JWTConfig struct {
 	AccessTokenTTL  time.Duration
 	RefreshTokenTTL time.Duration
 	SystemSecrets   []string // Comma-separated in env; newest first for rotation.
+	Audience        []string // JWT_AUDIENCE: comma-separated aud values for access tokens; empty means no aud claim.
 }
 
 // Argon2Config holds Argon2id password hashing parameters.
@@ -417,6 +418,9 @@ func loadJWT(l *loader) (JWTConfig, error) {
 	secretsRaw := l.requireStr("SYSTEM_SECRETS")
 	secrets := splitCSV(secretsRaw)
 
+	audienceRaw := l.optStr("JWT_AUDIENCE", "")
+	audience := splitCSV(audienceRaw)
+
 	if jwtAlg != "ES256" && jwtAlg != "EdDSA" {
 		return JWTConfig{}, fmt.Errorf("JWT_ALGORITHM: unsupported algorithm %q (must be ES256 or EdDSA)", jwtAlg)
 	}
@@ -427,6 +431,7 @@ func loadJWT(l *loader) (JWTConfig, error) {
 		AccessTokenTTL:  accessTTL,
 		RefreshTokenTTL: refreshTTL,
 		SystemSecrets:   secrets,
+		Audience:        audience,
 	}, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -65,6 +65,7 @@ func TestLoad_AllDefaults(t *testing.T) {
 	assert.Equal(t, 15*time.Minute, cfg.JWT.AccessTokenTTL)
 	assert.Equal(t, 7*24*time.Hour, cfg.JWT.RefreshTokenTTL)
 	assert.Equal(t, []string{"secret1", "secret2"}, cfg.JWT.SystemSecrets)
+	assert.Empty(t, cfg.JWT.Audience)
 
 	// Argon2 defaults
 	assert.Equal(t, uint32(19456), cfg.Argon2.Memory)
@@ -332,6 +333,32 @@ func TestLoad_SystemSecretsTrimsWhitespace(t *testing.T) {
 	cfg, err := Load()
 	require.NoError(t, err)
 	assert.Equal(t, []string{"secret1", "secret2", "secret3"}, cfg.JWT.SystemSecrets)
+}
+
+func TestLoad_JWTAudience(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want []string
+	}{
+		{name: "unset", env: "", want: nil},
+		{name: "single", env: "https://api.qf.studio", want: []string{"https://api.qf.studio"}},
+		{name: "multiple with whitespace", env: " qf-api , qf-billing ", want: []string{"qf-api", "qf-billing"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := requiredEnv()
+			if tt.env != "" {
+				env["JWT_AUDIENCE"] = tt.env
+			}
+			setEnv(t, env)
+
+			cfg, err := Load()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, cfg.JWT.Audience)
+		})
+	}
 }
 
 func TestLoad_CORSMultipleOrigins(t *testing.T) {

--- a/internal/domain/claims.go
+++ b/internal/domain/claims.go
@@ -49,4 +49,10 @@ type TokenClaims struct {
 	// AuthorizationDetails holds RFC 9396 Rich Authorization Request entries.
 	// Non-nil when the token was issued with authorization_details; nil otherwise.
 	AuthorizationDetails []AuthorizationDetail
+
+	// Audience is the JWT aud claim, listing the intended recipients of the
+	// token. Empty when JWT_AUDIENCE is unset (GH-449). Not validated by
+	// ValidateToken to avoid breaking tokens issued before an audience was
+	// configured.
+	Audience []string
 }

--- a/internal/token/service.go
+++ b/internal/token/service.go
@@ -352,6 +352,10 @@ func (s *Service) issueAccessToken(subject string, roles, scopes []string, clien
 		ClientType: string(clientType),
 	}
 
+	if len(s.cfg.Audience) > 0 {
+		claims.Audience = jwt.ClaimStrings(s.cfg.Audience)
+	}
+
 	if jktThumbprint != "" {
 		claims.Confirmation = &Confirmation{JKT: jktThumbprint}
 	}
@@ -411,6 +415,7 @@ func claimsToDomain(c *customClaims) (*domain.TokenClaims, error) {
 		Scopes:     c.Scopes,
 		ClientType: domain.ClientType(c.ClientType),
 		TokenID:    c.ID,
+		Audience:   c.Audience,
 	}
 
 	if c.ExpiresAt != nil {

--- a/internal/token/service_test.go
+++ b/internal/token/service_test.go
@@ -301,6 +301,82 @@ func TestValidateToken_WrongSigningKey(t *testing.T) {
 	require.Error(t, err)
 }
 
+// ── Audience (GH-449) ────────────────────────────────────────────────────────
+
+func TestIssueAccessToken_Audience(t *testing.T) {
+	tests := []struct {
+		name     string
+		audience []string
+		wantAud  []string
+	}{
+		{name: "configured audience is set on issued token", audience: []string{"https://api.qf.studio"}, wantAud: []string{"https://api.qf.studio"}},
+		{name: "multiple audiences are all set", audience: []string{"qf-api", "qf-billing"}, wantAud: []string{"qf-api", "qf-billing"}},
+		{name: "unset audience produces no aud claim", audience: nil, wantAud: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := generateES256Key(t)
+			_, rc := newTestRedis(t)
+			cfg := defaultCfg()
+			cfg.Audience = tt.audience
+
+			svc, err := token.NewServiceFromKey(cfg, key, rc, testLogger(), audit.NopLogger{})
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			result, err := svc.IssueTokenPair(ctx, "user-123", nil, nil, domain.ClientTypeUser)
+			require.NoError(t, err)
+
+			rawJWT := strings.TrimPrefix(result.AccessToken, "qf_at_")
+
+			// Verify via the parsed domain claims.
+			claims, err := svc.ValidateToken(ctx, rawJWT)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAud, claims.Audience)
+
+			// Verify directly against the raw JWT payload so we assert on the
+			// wire format, not just the domain mapping.
+			parser := jwtv5.NewParser()
+			jwtClaims := jwtv5.MapClaims{}
+			_, _, err = parser.ParseUnverified(rawJWT, jwtClaims)
+			require.NoError(t, err)
+			if len(tt.wantAud) == 0 {
+				assert.NotContains(t, jwtClaims, "aud")
+			} else {
+				assert.Contains(t, jwtClaims, "aud")
+			}
+		})
+	}
+}
+
+func TestValidateToken_AcceptsAudiencelessTokenWhenAudienceConfigured(t *testing.T) {
+	// A token issued before JWT_AUDIENCE was configured (or by another
+	// service instance without it set) carries no aud claim. ValidateToken
+	// must still accept it: audience validation is deliberately not enforced
+	// here to avoid an in-flight rotation hazard (GH-449).
+	key := generateES256Key(t)
+	_, rc := newTestRedis(t)
+
+	issuerCfg := defaultCfg() // no Audience set
+	issuerSvc, err := token.NewServiceFromKey(issuerCfg, key, rc, testLogger(), audit.NopLogger{})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	result, err := issuerSvc.IssueTokenPair(ctx, "user-123", nil, nil, domain.ClientTypeUser)
+	require.NoError(t, err)
+	rawJWT := strings.TrimPrefix(result.AccessToken, "qf_at_")
+
+	validatorCfg := defaultCfg()
+	validatorCfg.Audience = []string{"https://api.qf.studio"}
+	validatorSvc, err := token.NewServiceFromKey(validatorCfg, key, rc, testLogger(), audit.NopLogger{})
+	require.NoError(t, err)
+
+	claims, err := validatorSvc.ValidateToken(ctx, rawJWT)
+	require.NoError(t, err)
+	assert.Empty(t, claims.Audience)
+}
+
 // ── Revoke & IsRevoked ───────────────────────────────────────────────────────
 
 func TestRevoke_AccessToken(t *testing.T) {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-449.

Closes #449

## Changes

GitHub Issue GH-449: feat(auth): emit configurable aud claim on access tokens

<!--autopilot-meta
parent: GH-436
inherited-spec: true
-->

Parent: GH-436

Add `Audience []string` to `internal/config/config.go` `JWTConfig`, loaded from `JWT_AUDIENCE` (comma-separated, optional, empty default). Extend `internal/token.Service` to hold the audience (constructor param or setter following the `SetUserLookup` precedent from GH-432/#439) and set `RegisteredClaims.Audience = jwt.ClaimStrings(...)` inside `issueAccessToken` (`internal/token/service.go:335-367`) only when non-empty. Add `Audience []string` to `internal/domain/claims.go` `TokenClaims` and map it in `claimsToDomain` (`internal/token/service.go:403`). Wire `cfg.JWT.Audience` in `cmd/server/main.go`. Do not add audience validation to `ValidateToken` (in-flight rotation hazard). Table-driven tests: with `JWT_AUDIENCE` set, issued tokens carry `aud`; unset ⇒ `aud` absent; `ValidateToken` still accepts audience-less tokens.

## Scope fence

Implement ONLY the slice described above. The parent issue GH-436 is decomposed
into sibling sub-issues that cover the rest of its spec — consult the parent
for context, but do NOT implement parts of it that fall outside this subtask.