### PR TITLE
GH-450: docs(auth): document jwt_audience and public client type

### DIFF
--- a/.agent/system/client-model.md
+++ b/.agent/system/client-model.md
@@ -80,10 +80,11 @@ type User struct {
 type Client struct {
     ID                    uuid.UUID
     Name                  string     // human-readable identifier
-    ClientType            string     // "service" | "agent"
+    ClientType            string     // "service" | "agent" | "public"
     TokenEndpointAuthMethod string   // "client_secret_basic" | "client_secret_post" | "private_key_jwt" | "none"
-    SecretHash            string     // Argon2id hashed
+    SecretHash            string     // Argon2id hashed; empty for public clients
     Scopes                []string   // allowed scopes
+    RedirectURIs          []string   // required (non-empty) for public clients; authenticates in place of a secret
     Roles                 []string   // ["service", "agent"]
     Owner                 string     // owning entity/team
     SkipConsent           bool       // true for first-party
@@ -94,6 +95,12 @@ type Client struct {
     LastUsedAt            *time.Time
 }
 ```
+
+> **Public clients** (e.g. SPAs, mobile apps) are `ClientType: "public"`. They
+> cannot securely hold a client secret, so `CreateClient` skips secret
+> generation for them (`SecretHash` stored empty) and they authenticate via
+> their registered `RedirectURIs` instead. `RotateSecret` rejects rotation
+> attempts on public clients (409 — no secret to rotate).
 
 ---
 

--- a/.agent/tasks/gh-450.md
+++ b/.agent/tasks/gh-450.md
@@ -1,0 +1,25 @@
+# GH-450
+
+**Created:** 2026-07-25
+
+## Problem
+
+GitHub Issue GH-450: docs(auth): document jwt_audience and public client type
+
+<!--autopilot-meta
+parent: GH-436
+inherited-spec: true
+-->
+
+Parent: GH-436
+
+Update `deployments/README.md` and any env example files to document the new `JWT_AUDIENCE` variable (semantics, comma-separated, empty=disabled). Note the new `public` `client_type` value and `redirect_uris` field in admin API docs / OpenAPI spec if present. Flag the pre-existing `OIDC_ISSUER_URL` vs hardcoded `https://auth.qf.studio` disconnect (`internal/token/service.go:53`) in the PR description for a follow-up, but do not change it here.
+
+## Scope fence
+
+Implement ONLY the slice described above. The parent issue GH-436 is decomposed
+into sibling sub-issues that cover the rest of its spec — consult the parent
+for context, but do NOT implement parts of it that fall outside this subtask.
+
+## Acceptance Criteria
+

--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,7 @@ JWT_ALGORITHM=ES256                     # ES256 | EdDSA
 ACCESS_TOKEN_TTL=15m
 REFRESH_TOKEN_TTL=7d
 SYSTEM_SECRETS=change-me-secret-1       # Comma-separated; newest first for rotation
+JWT_AUDIENCE=                           # Comma-separated aud values for access tokens; empty = no aud claim (disabled)
 
 # ── Argon2id Password Hashing ──────────────────────────────────────
 PASSWORD_PEPPER=change-me-pepper        # CHANGE in production (HMAC pepper)

--- a/.env.production.example
+++ b/.env.production.example
@@ -29,6 +29,9 @@ JWT_PRIVATE_KEY_PATH=/run/secrets/jwt_private_key
 JWT_ALGORITHM=ES256
 ACCESS_TOKEN_TTL=15m
 REFRESH_TOKEN_TTL=7d
+# Comma-separated `aud` values for issued access tokens. Leave empty/unset to
+# disable — no aud claim is added and audience validation stays off.
+JWT_AUDIENCE=
 
 # ── System Secrets ──────────────────────────────────
 # Comma-separated; newest first for rotation

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -28,6 +28,9 @@ JWT_PRIVATE_KEY_PATH=/run/secrets/jwt_private_key
 JWT_ALGORITHM=ES256
 ACCESS_TOKEN_TTL=15m
 REFRESH_TOKEN_TTL=24h
+# Comma-separated `aud` values for issued access tokens. Leave empty/unset to
+# disable — no aud claim is added and audience validation stays off.
+JWT_AUDIENCE=
 
 # ── System Secrets ──────────────────────────────────
 # Comma-separated; newest first for rotation

--- a/api/admin.openapi.yaml
+++ b/api/admin.openapi.yaml
@@ -219,7 +219,11 @@ paths:
               $ref: "#/components/schemas/CreateClientRequest"
       responses:
         "201":
-          description: Client created (includes plaintext secret — shown only once)
+          description: >
+            Client created. For service/agent clients, includes the plaintext
+            secret (shown only once) as AdminClientResponseWithSecret. Public
+            clients cannot hold a secret, so the response is a plain
+            AdminClientResponse instead — no client_secret field is present.
           content:
             application/json:
               schema:
@@ -297,7 +301,9 @@ paths:
       summary: Rotate a client secret
       description: >
         Generates a new secret for the client and invalidates the old one.
-        The new plaintext secret is returned only once.
+        The new plaintext secret is returned only once. Rejected with 409 for
+        public clients (and any client with no stored secret), since they
+        never have a secret to rotate.
       tags: [Clients]
       responses:
         "200":
@@ -308,6 +314,12 @@ paths:
                 $ref: "#/components/schemas/AdminClientResponseWithSecret"
         "404":
           $ref: "#/components/responses/NotFound"
+        "409":
+          description: Client is a public client (or has no stored secret) and has no secret to rotate
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "500":
           $ref: "#/components/responses/InternalError"
 
@@ -607,12 +619,22 @@ components:
           description: Human-readable client name
         client_type:
           type: string
-          enum: [service, agent]
+          enum: [service, agent, public]
         scopes:
           type: array
           items:
             type: string
           description: Allowed OAuth2 scopes
+        redirect_uris:
+          type: array
+          items:
+            type: string
+            format: uri
+          description: >
+            Registered redirect URIs used to authenticate the client instead
+            of a client secret. Required (non-empty) when client_type is
+            "public"; optional for service/agent clients. Each URI must be
+            absolute (http or https) with no fragment component.
         owner:
           type: string
           description: Owning entity or team
@@ -640,6 +662,14 @@ components:
           type: array
           items:
             type: string
+        redirect_uris:
+          type: array
+          items:
+            type: string
+            format: uri
+          description: >
+            Replaces the client's registered redirect URIs. Each URI must be
+            absolute (http or https) with no fragment component.
         owner:
           type: string
         token_endpoint_auth_method:
@@ -663,11 +693,19 @@ components:
           type: string
         client_type:
           type: string
-          enum: [service, agent]
+          enum: [service, agent, public]
         scopes:
           type: array
           items:
             type: string
+        redirect_uris:
+          type: array
+          items:
+            type: string
+            format: uri
+          description: >
+            Registered redirect URIs. Empty for service/agent clients unless
+            explicitly set; always present for public clients.
         roles:
           type: array
           items:

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -619,6 +619,7 @@ Full list of configuration variables. See `.env.staging.example` and `.env.produ
 | `ACCESS_TOKEN_TTL` | Access token lifetime | `15m` | `15m` |
 | `REFRESH_TOKEN_TTL` | Refresh token lifetime | `24h` | `7d` |
 | `SYSTEM_SECRETS` | Client credential secrets (comma-separated) | *(required)* | *(required)* |
+| `JWT_AUDIENCE` | Comma-separated list of `aud` values to set on issued access tokens. Empty/unset (default) means no `aud` claim is added and audience validation is disabled — `ValidateToken` accepts audience-less tokens regardless of this setting, to avoid a rotation hazard when the value is first configured. | *(empty)* | *(empty)* |
 
 ### Security
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-450.

Closes #450

## Changes

GitHub Issue GH-450: docs(auth): document jwt_audience and public client type

<!--autopilot-meta
parent: GH-436
inherited-spec: true
-->

Parent: GH-436

Update `deployments/README.md` and any env example files to document the new `JWT_AUDIENCE` variable (semantics, comma-separated, empty=disabled). Note the new `public` `client_type` value and `redirect_uris` field in admin API docs / OpenAPI spec if present. Flag the pre-existing `OIDC_ISSUER_URL` vs hardcoded `https://auth.qf.studio` disconnect (`internal/token/service.go:53`) in the PR description for a follow-up, but do not change it here.

## Scope fence

Implement ONLY the slice described above. The parent issue GH-436 is decomposed
into sibling sub-issues that cover the rest of its spec — consult the parent
for context, but do NOT implement parts of it that fall outside this subtask.