### PR TITLE
docs(nav): refresh navigator index to current project state

### DIFF
--- a/.agent/DEVELOPMENT-README.md
+++ b/.agent/DEVELOPMENT-README.md
@@ -3,7 +3,7 @@
 **Project**: Authentication service for QuantFlow Studio ecosystem
 **Tech Stack**: Go 1.24+, Gin, PostgreSQL (pgx/v5), Redis (go-redis/v9), JWT (ES256/EdDSA)
 **Repo**: github.com/qf-studio/auth-service
-**Updated**: 2026-02-24
+**Updated**: 2026-07-26
 
 ---
 
@@ -13,19 +13,19 @@
 1. [Architecture Diagrams](./system/architecture-diagrams.md) - Visual system overview, flows, DB schema
 2. [Project Architecture](./system/project-architecture.md) - Tech stack, structure, patterns
 3. [Security Profile](./system/security-profile.md) - NIST SP 800-63-4, AAL2, crypto requirements
-4. [Client Model](./system/client-model.md) - Users vs Systems (incl. AI agents)
+4. [Client Model](./system/client-model.md) - Users vs Systems (incl. AI agents), public/PKCE clients
 5. [Tech Decisions](./system/tech-decisions.md) - Technology choices with rationale
 
 ### Starting a Feature?
 1. Check [`tasks/`](#task-documentation) for existing plans
 2. Read relevant system docs from [`system/`](#system-documentation)
-3. Check SOPs in [`sops/`](#standard-operating-procedures)
-4. Pick a GitHub issue or create one for Pilot execution
+3. Pick a GitHub issue or create one for Pilot execution
 
 ### Execution Model
 - **Navigator** (ClaudeCode): Research, planning, issue creation
-- **Pilot**: Executes GitHub issues labeled `pilot`, opens PRs
+- **Pilot**: Executes GitHub issues labeled `pilot`, opens PRs. May decompose large issues into children (watch for post-PR state loss — see gh-436.md note)
 - Issues use nav-task template (Context, Implementation Plan, Technical Decisions, Dependencies, Verify, Done)
+- **Downstream consumer**: Pointer (getpointer.app) deploys pinned release tags to its own AWS env — see Deployment below
 
 ---
 
@@ -34,107 +34,44 @@
 ```
 .agent/
 ├── DEVELOPMENT-README.md          <- You are here (navigator)
-│
 ├── tasks/                         <- Implementation plans
-│   └── TASK-00-research-and-plan.md   # Full research & architecture plan
-│
+│   ├── TASK-00-research-and-plan.md   # Original research & architecture plan
+│   ├── gh-NN.md                       # Per-issue specs (nav-task format)
+│   └── archive/                       # Completed task docs
 ├── system/                        <- Architecture & design docs
 │   ├── architecture-diagrams.md       # 8 visual diagrams (overview, flows, schema)
 │   ├── project-architecture.md        # Tech stack, patterns, API surface
 │   ├── security-profile.md            # NIST AAL2, crypto, session, audit
-│   ├── client-model.md               # Users vs Systems, Go types, comparison
-│   └── tech-decisions.md             # All choices with rationale + rejected alts
-│
-├── sops/                          <- Standard Operating Procedures
-│   ├── integrations/
-│   ├── debugging/
-│   ├── development/
-│   └── deployment/
-│
+│   ├── client-model.md                # Users vs Systems, public clients, token policies
+│   └── tech-decisions.md              # All choices with rationale + rejected alts
 └── grafana/                       <- Navigator metrics dashboards
 ```
+
+(No `sops/` yet — create on first SOP.)
 
 ---
 
 ## Current Focus
 
-### Active Phase
-**Phase 1 — MVP**: First-party ecosystem authentication
+### Status (2026-07)
+The original 3-phase plan (41 issues) is **fully delivered** — all phase-1/2/3 issues closed. The service is at **v0.68.x**, deployed and consumed by Pointer (auth.getpointer.app, first deploy 2026-07-24). Work is now issue-driven: gaps found by consumers become `pilot`-labeled issues with `tasks/gh-NN.md` specs.
 
-### GitHub Issues (41 total)
+**Recently landed**:
+- GH-444: fresh-install migration fix (UUID/TEXT FK mismatch) — v0.68.1
+- GH-436: public/PKCE client type (`client_type=public`, `redirect_uris`, migrations 000016/000017) + `aud` claim via `JWT_AUDIENCE` (PRs #451-#453, on main, untagged)
 
-**Phase 1 — MVP** (20 issues, label: `phase-1`):
-
-Core:
-| # | Title | Depends On |
+**Open issues**:
+| # | Title | Notes |
 |---|---|---|
-| #1 | Project scaffold: Go module, Docker, docker-compose | — |
-| #2 | Config management and structured logging | #1 |
-| #3 | Database layer: PostgreSQL, migrations, repositories | #1, #2 |
-| #4 | Domain types: User, Client, Token, Role | #1 |
-| #5 | JWT token system: creation, validation, JWKS | #2, #4 |
+| #431 | OIDC provider unimplemented (authorize/token/discovery/userinfo) | Largest gap; blocks PKCE enforcement; needed for Pointer SPA login |
+| #435 | Migrations not shipped in the Docker image | Consumers vendor SQL as workaround; from-scratch breakage half already fixed (#445) |
+| #447 | Move Pointer AWS deploy workflow to private infra repo | Security: self-hosted runner on public repo |
 
-Auth flows:
-| # | Title | Depends On |
-|---|---|---|
-| #6 | User registration with Argon2id password hashing | #3, #4 |
-| #7 | User login and token pair generation | #5, #6 |
-| #8 | Client credentials flow for systems and AI agents | #3, #4, #5 |
-| #14 | Password reset flow | #2, #3, #6 |
-
-Middleware & API:
-| # | Title | Depends On |
-|---|---|---|
-| #9 | Basic RBAC middleware | #4, #5 |
-| #10 | Security middleware: rate limiting, headers, CORS | #2 |
-| #11 | Observability: health checks, metrics, correlation IDs | #2, #3 |
-| #12 | Public REST API: routes, validation, error responses | #5-#11 |
-| #13 | Admin API: separate port, management, introspection | #3, #5, #6, #8 |
-| #15 | Main server bootstrap and integration | #1-#14 |
-
-Infrastructure:
-| # | Title | Depends On |
-|---|---|---|
-| #36 | CI/CD pipeline: GitHub Actions | #1, #3 |
-| #37 | golangci-lint configuration | #1 |
-| #38 | Integration test infrastructure: testcontainers | #1, #3 |
-| #39 | OpenAPI specification and API documentation | #12, #13 |
-| #40 | Deployment strategy and infrastructure | #1, #36 |
-
-**Phase 2 — Production** (13 issues, label: `phase-2`):
-| # | Title |
-|---|---|
-| #16 | MFA: TOTP enrollment and verification |
-| #17 | WebAuthn / Passkeys support |
-| #18 | OAuth2 social login: Google, GitHub, Apple |
-| #19 | DPoP: demonstration of proof-of-possession |
-| #20 | Token exchange: RFC 8693 delegation chains |
-| #21 | Casbin RBAC: policy engine with PostgreSQL |
-| #22 | API key management |
-| #23 | Audit logging: NIST SP 800-53 compliant |
-| #24 | Session management |
-| #25 | gRPC internal API |
-| #26 | Email service integration |
-| #27 | OAuth2/OIDC provider: consent flows and discovery |
-| #41 | Load testing and benchmarking |
-
-**Phase 3 — Enterprise** (8 issues, label: `phase-3`):
-| # | Title |
-|---|---|
-| #28 | Multi-tenancy: NID-based isolation |
-| #29 | RAR: rich authorization requests (RFC 9396) |
-| #30 | SAML SSO: enterprise IdP integration |
-| #31 | Webhooks: auth event notifications |
-| #32 | Admin dashboard API |
-| #33 | GDPR compliance: data export, deletion, consent |
-| #34 | Agent credential broker |
-| #35 | Advanced password policies |
-
-### Completed Research
-- Email-service pattern extraction (see TASK-00)
-- Ory Hydra architecture analysis (see TASK-00)
-- NIST SP 800-63-4 requirements mapping (see TASK-00)
-- AI agent authentication patterns (see TASK-00)
+### Deployment
+- **Own strategy** (issue #40): Docker Compose on VPS, Caddy auto-TLS, `scripts/deploy.sh` / `rollback.sh`, manual `deploy-production.yml` (SSH). Staging disabled until infra exists (GH-416).
+- **Release**: push to main / `v*` tag → GHCR image (multi-arch, version tags) + **migration dry-run gate** on fresh Postgres 16. Never break this gate.
+- **Consumers** (Pointer): pin a `vX.Y.Z` tag, run `migrations/` from that same tag, deploy the image. `deploy-pointer-aws.yml` does this (temporarily in this repo — #447).
+- Migrations run via CLI before deploy, never at startup (runtime DB user has no ALTER).
 
 ---
 
@@ -143,6 +80,8 @@ Infrastructure:
 | Task | Description | Status |
 |---|---|---|
 | [TASK-00](./tasks/TASK-00-research-and-plan.md) | Research & architecture plan (Hydra, NIST, agent auth) | ✅ Complete |
+| [gh-436](./tasks/gh-436.md) | Public/PKCE client type + `aud` claim | ✅ Complete |
+| `tasks/gh-NN.md` | Per-issue specs; active ones match open `pilot`-labeled issues | Various |
 
 ---
 
@@ -153,55 +92,40 @@ Infrastructure:
 | [Architecture Diagrams](./system/architecture-diagrams.md) | 8 visual diagrams: overview, auth flows, DB schema, deployment | Starting work, onboarding |
 | [Project Architecture](./system/project-architecture.md) | Tech stack, patterns, API surface, testing strategy | Implementing features |
 | [Security Profile](./system/security-profile.md) | NIST AAL2, crypto params, session rules, audit requirements | Any security-related work |
-| [Client Model](./system/client-model.md) | Users vs Systems, Go types, token policies, agent considerations | Client/auth design work |
+| [Client Model](./system/client-model.md) | Users vs Systems, public clients, token policies, agent considerations | Client/auth design work |
 | [Tech Decisions](./system/tech-decisions.md) | All tech choices with rationale, deps list, rejected alternatives | Understanding "why" |
 
 ---
 
-## Standard Operating Procedures
-
-No SOPs created yet. Will be added as patterns emerge during implementation.
-
----
-
-## Project Structure (Target)
+## Project Structure (Actual)
 
 ```
 auth-service/
 ├── cmd/
-│   ├── server/main.go            # Bootstrap, DI, dual-port server
-│   └── migrate/main.go           # Migration runner
+│   ├── server/main.go     # Bootstrap, DI, dual-port server (4000 public / 4001 admin)
+│   └── migrate/main.go    # Migration runner (DATABASE_URL or POSTGRES_* env)
 ├── internal/
-│   ├── config/                   # Env-based config
-│   ├── domain/                   # Core types: User, Client, Token, Role, Errors
-│   ├── auth/                     # Login, register, password hashing, password reset
-│   ├── user/                     # User CRUD
-│   ├── client/                   # OAuth2 client management (service + agent)
-│   ├── token/                    # JWT creation, validation, revocation, JWKS, DPoP
-│   ├── rbac/                     # Role enforcement (Phase 1), Casbin (Phase 2)
-│   ├── mfa/                      # TOTP, WebAuthn, backup codes (Phase 2)
-│   ├── oauth/                    # Social login, OIDC provider (Phase 2)
-│   ├── audit/                    # Audit logging (Phase 2)
-│   ├── session/                  # Session management (Phase 2)
-│   ├── middleware/               # Auth, rate limit, CORS, security headers, metrics
-│   ├── storage/                  # PostgreSQL + Redis repositories
-│   ├── testutil/                 # Test containers, fixtures, helpers
-│   └── logger/                   # zap singleton
-├── pkg/authclient/               # Go SDK for service token verification
-├── proto/                        # gRPC protobuf definitions (Phase 2)
-├── migrations/                   # SQL migrations (separate from runtime)
-├── api/                          # OpenAPI specs
-├── tests/load/                   # Load testing scripts
-├── scripts/                      # Deploy, key generation, pre-deploy validation
-├── deployments/                  # Docker Compose for staging/production
-├── docker/Dockerfile             # Multi-stage, non-root, Alpine
-├── docker-compose.yml            # Dev environment (PostgreSQL + Redis)
-├── .github/workflows/            # CI/CD pipelines
-├── .golangci.yml                 # Linter configuration
-├── Makefile                      # Build automation
-├── .agent/                       # Navigator docs
-└── go.mod
+│   ├── config/            # Env-based config (JWTConfig, OIDCConfig, ...)
+│   ├── domain/            # Core types: User, Client (service|agent|public), Token, Role, Claims
+│   ├── auth/              # Login, register, password hashing, reset
+│   ├── admin/             # Admin services incl. client management (NOT internal/client)
+│   ├── api/               # Routers + handlers, public & admin; request DTOs + validation
+│   ├── token/             # JWT creation/validation, JWKS, refresh; aud via JWT_AUDIENCE
+│   ├── oauth/             # Social login (outbound PKCE helpers in pkce.go)
+│   ├── mfa/ rbac/ session/ audit/ dpop/ webhook/ email/ grpc/
+│   ├── middleware/ metrics/ health/ httpserver/ logger/ password/ hibp/
+│   ├── storage/           # PostgreSQL + Redis repositories
+│   └── testutil/          # Test containers, fixtures
+├── pkg/authclient/        # Go SDK for token verification
+├── migrations/            # SQL (embedded); highest: 000017. FKs to users.id are TEXT
+├── api/                   # OpenAPI specs
+├── deployments/           # Compose staging/production, Caddyfile, README
+├── scripts/               # deploy.sh, rollback.sh, key generation
+└── .github/workflows/     # test, release, spectral, deploy-{staging,production,pointer-aws}
 ```
+
+⚠️ Known trap: `internal/domain/admin.go` has a **dead** `CreateClientRequest`/validator path; the live one is `internal/api/admin_services.go` (see gh-436.md).
+⚠️ Issuer discrepancy: hardcoded `https://auth.qf.studio` in `token/service.go` vs unused `OIDC_ISSUER_URL` config — do not "fix" casually, downstream verifiers pin `iss`.
 
 ---
 
@@ -214,21 +138,10 @@ auth-service/
 | Security question | `security-profile.md` |
 | Client type / auth flow design | `client-model.md` |
 | "Why did we choose X?" | `tech-decisions.md` |
+| Deploying / releases | Deployment section above + `deployments/README.md` |
 | Full research context | `tasks/TASK-00-research-and-plan.md` |
-| Debugging | `sops/debugging/` (when available) |
-| Deploying | `sops/deployment/` (when available) |
 
 ---
 
-## Token Optimization
-
-- Navigator: ~2k tokens (always)
-- Current task: ~3k tokens (as needed)
-- System docs: ~5k tokens (when relevant)
-- SOPs: ~2k tokens (if required)
-- **Total**: ~12k vs ~150k loading everything
-
----
-
-**Last Updated**: 2026-02-24
+**Last Updated**: 2026-07-26
 **Powered By**: Navigator 6.2.1

--- a/.agent/tasks/gh-436.md
+++ b/.agent/tasks/gh-436.md
@@ -1,0 +1,102 @@
+# GH-436: Public/PKCE client type + `aud` claim on access tokens
+
+**Status**: ✅ Complete
+**Created**: 2026-07-25
+**Last Updated**: 2026-07-26
+**Issue**: https://github.com/qf-studio/auth-service/issues/436 (closed)
+
+## Refs
+- Pilot issue: https://github.com/qf-studio/auth-service/issues/436 (dispatched 2026-07-25; Pilot decomposed into #448/#449/#450)
+- Merged: PR #451 (public client type, migrations 000016/000017), PR #452 (`JWT_AUDIENCE` → `aud` claim), PR #453 (docs)
+- Note: Pilot hit its repick hard cap after PR creation (state bookkeeping bug, work was complete); PRs merged manually 2026-07-26
+
+---
+
+## Context
+
+**Problem** (from #436, raised by the Pointer integration):
+1. `CreateClientRequest` accepts only `client_type: service|agent`. Browser SPAs are OAuth 2.1 public clients (secret-less, PKCE-required) — Pointer registers its SPA as `service` as a workaround.
+2. Access tokens carry no `aud` claim, so resource servers can't verify a token was minted for them. Pointer's verifier currently skips audience validation and wants to turn it on.
+
+**Scope boundary**: The OIDC authorize/token endpoints don't exist yet (#431), so PKCE *enforcement* is out of scope. This task lands the domain model, storage, admin API shape for public clients, and config-driven `aud` emission.
+
+**Codebase facts** (verified 2026-07-25):
+- ⚠️ Two parallel client-creation paths exist. The **live** one is `internal/api/admin_services.go:163` (`CreateClientRequest`, validated `oneof=service agent` via bare `validator.New()` at `internal/api/admin_router.go:17`) → handler `internal/api/admin_client_handlers.go:53` → `internal/admin/client_service.go:94` (`CreateClient`). The copy in `internal/domain/admin.go:38` + custom validator in `internal/domain/validation.go:89` is dead for the admin API — update it for consistency but the live path is canonical.
+- `domain.ClientType` at `internal/domain/client.go:9-22` is the canonical type (stored on `domain.Client`, embedded in JWT claims at `internal/token/service.go:352`).
+- DB: `client_type` is a Postgres ENUM `('service','agent')` and `secret_hash` is `TEXT NOT NULL` (`migrations/000001_create_clients_table.up.sql:4,10`). Highest migration is `000015`; next is `000016`.
+- `internal/admin/client_service.go:95-127` unconditionally generates + hashes a `qf_cs_` secret; no branch for secret-less clients.
+- `AdminClient` DTO already has an aspirational `RedirectURIs []string` field (`internal/api/admin_services.go:40`) with **no backing column** — never populated.
+- All access tokens pass through `issueAccessToken` (`internal/token/service.go:335-367`); `customClaims` embeds `jwt.RegisteredClaims` whose `Audience` field is never set.
+- Config: `JWTConfig` (`internal/config/config.go:139`, loaded at `:401`) uses `JWT_*` / `*_TOKEN_TTL` env vars — home for the new audience setting.
+- Client-credentials grant is a stub (`internal/token/service.go:224-235`) — per-client audience derivation is explicitly out of scope.
+
+---
+
+## Implementation Plan
+
+### Phase 1: `public` client type — model + storage
+- [ ] `internal/domain/client.go`: add `ClientTypePublic ClientType = "public"`, include in `IsValid()`.
+- [ ] `internal/domain/admin.go` `ValidClientTypes` + `internal/domain/validation.go`: add `public` (consistency with the dead path; do not refactor the duplication in this task).
+- [ ] Migration `000016_add_public_client_type.up.sql`:
+  - `ALTER TYPE client_type ADD VALUE IF NOT EXISTS 'public';` (sole statement in the file — PG16 allows ADD VALUE in a transaction only if the value isn't used in the same transaction).
+  - `000016_*.down.sql`: no-op with a comment (Postgres cannot drop enum values; removing requires type recreation, not worth it for a down path).
+- [ ] Migration `000017_add_client_redirect_uris.up.sql`: `ALTER TABLE clients ADD COLUMN redirect_uris TEXT[] NOT NULL DEFAULT '{}';` — down: drop column. Backs the existing DTO field; public clients need registered redirect URIs before #431 ships.
+- [ ] Secret storage decision (see Technical Decisions): public clients store `secret_hash = ''` (empty string, keeps `NOT NULL`, zero scan changes). Add an explicit guard: any secret-verification path must reject clients with empty `secret_hash` / `client_type = public` **before** hash comparison (`internal/admin/client_service.go` secret rotation, and the client-credentials stub's future path — leave a guard in `RotateSecret` and reject rotation for public clients with a domain error).
+- [ ] `internal/domain/client.go` `Client` struct: add `RedirectURIs []string`; thread through `internal/storage/client_repository.go` (`Create`, `Update`, `FindByID`, `FindByName`, `List` scans — pgx maps `TEXT[]` ↔ `[]string` natively).
+
+### Phase 2: `public` client type — admin API
+- [ ] `internal/api/admin_services.go` `CreateClientRequest`: `oneof=service agent public`; add `RedirectURIs []string` input (optional; each entry validated as absolute http(s) URI; **required non-empty when `client_type=public`**; reject fragments per OAuth 2.1 §2.3).
+- [ ] `internal/admin/client_service.go` `CreateClient`: when `public` — skip secret generation/hashing, store empty `secret_hash`, persist redirect URIs. Return type without secret material.
+- [ ] `internal/api/admin_client_handlers.go` `Create`: respond with `AdminClient` (no secret) for public clients, `AdminClientWithSecret` otherwise; populate `RedirectURIs` in `domainClientToAdmin` (`internal/admin/client_service.go:279`).
+- [ ] Update endpoint: allow updating `redirect_uris` for any client type via the existing `Update` path.
+
+### Phase 3: `aud` claim
+- [ ] `internal/config/config.go` `JWTConfig`: add `Audience []string`, env `JWT_AUDIENCE` (comma-separated, optional, default empty). Empty ⇒ no `aud` emitted (backwards compatible).
+- [ ] `internal/token/service.go`: thread audience into the service (constructor param or setter — follow the `SetUserLookup` precedent from GH-432/#439 if constructor churn is large). In `issueAccessToken` set `RegisteredClaims.Audience = jwt.ClaimStrings(audience)` when non-empty.
+- [ ] `internal/domain/claims.go` `TokenClaims`: add `Audience []string`; map it in `claimsToDomain` (`internal/token/service.go:403`) so introspection/middleware can see it later.
+- [ ] `cmd/server/main.go`: wire `cfg.JWT.Audience` into the token service.
+- [ ] Do **not** add audience *validation* to `ValidateToken` in this task (would reject in-flight tokens on deploy; resource servers own their own aud checks).
+
+### Phase 4: Docs
+- [ ] `deployments/README.md` / env examples: document `JWT_AUDIENCE`.
+- [ ] Note in the admin API docs (if OpenAPI spec exists by then) the new client type + redirect_uris.
+
+---
+
+## Technical Decisions
+
+| Decision | Options | Chosen | Reasoning |
+|---|---|---|---|
+| Secret-less storage | nullable `secret_hash`, empty-string sentinel, separate flag column | Empty-string sentinel | Keeps `NOT NULL`, zero pgx scan changes; `000002` already uses `NOT NULL DEFAULT ''` for `previous_secret_hash`. Guard against empty-hash auth explicitly. |
+| PKCE flag | dedicated `require_pkce` column vs derive from type | Derive from `client_type = public` | OAuth 2.1 mandates PKCE for public clients; a column adds state that can contradict the type. Enforcement lands with #431. |
+| `aud` source | per-client column, resource indicators (RFC 8707), static config | Static config `JWT_AUDIENCE` | Client-credentials is a stub; no resource-indicator machinery exists. Config unblocks Pointer's verifier now; per-client audience arrives with client-credentials/#431. |
+| `aud` validation on our side | validate in `ValidateToken` now vs later | Later | Deploy-time rotation hazard: in-flight tokens lack `aud`. Emit-only is forward-compatible. |
+| Enum vs text | migrate `client_type` to TEXT+CHECK vs `ADD VALUE` | `ADD VALUE` | Minimal, non-breaking; type recreation is not worth it for one value. |
+
+**Known issue to leave alone**: the hardcoded issuer `https://auth.qf.studio` (`internal/token/service.go:53`) and `OIDC_ISSUER_URL` config are disconnected. Do not unify in this task — changing `iss` breaks downstream verifiers. Flag it in the PR description.
+
+---
+
+## Dependencies
+
+**Requires**: nothing open.
+**Blocks**: #431 (OIDC provider will consume public clients + PKCE), Pointer enabling audience validation.
+**Related precedent**: #439 / commit `1af3eac` (adding token-service behavior via setter), `ab03f14` (claims-shape change).
+
+---
+
+## Verify
+
+- [ ] `go test -race ./...` green; table-driven tests per repo convention (`package token_test`, testify, miniredis, storage mocks).
+- [ ] Fresh-DB `migrate up` passes 000001→000017 (CI migration dry-run job gates this; do not break it — see GH-444 history).
+- [ ] Admin API: `POST /admin/clients` with `client_type=public` + redirect URIs → 201, response contains **no secret**; with `public` and no redirect URIs → 400; `service`/`agent` behavior unchanged (secret still returned once).
+- [ ] Secret rotation on a public client → 4xx domain error, not a new secret.
+- [ ] With `JWT_AUDIENCE=https://api.getpointer.app`: issued access token contains `aud: ["https://api.getpointer.app"]`; with unset `JWT_AUDIENCE`, `aud` absent (assert both in token service tests).
+- [ ] `ValidateToken` still accepts tokens minted without `aud`.
+
+## Done
+
+- [ ] Public clients creatable via admin API, secret-less, with registered redirect URIs
+- [ ] `aud` emitted on all access tokens when `JWT_AUDIENCE` is set
+- [ ] No behavior change for existing service/agent clients or when `JWT_AUDIENCE` unset
+- [ ] Migrations clean on fresh DB


### PR DESCRIPTION
- 3-phase plan (41 issues) delivered; status is now issue-driven
- Document deployment reality: VPS strategy, release/migration gate,
  Pointer consumer contract
- Correct project structure (internal/admin not internal/client),
  flag dead CreateClientRequest path and issuer discrepancy
- Record gh-436 completion in task index
