### PR TITLE
GH-455: feat(migrate): add force subcommand for dirty-state recovery

### DIFF
--- a/.agent/tasks/gh-455.md
+++ b/.agent/tasks/gh-455.md
@@ -1,0 +1,10 @@
+# GH-455
+
+**Created:** 2026-07-26
+
+## Problem
+
+Extend cmd/migrate/main.go to accept `force <N>` alongside the existing up|down|version commands, calling m.Force(N) on the migrate instance. This unblocks in-image recovery from dirty schema_migrations state (per the 2026-07-24 Pointer incident) and must land before the Dockerfile ships the binary so the image includes the full recovery path. Add a table-driven test for argument parsing and update the usage string. All work stays inside cmd/migrate/.
+
+## Acceptance Criteria
+

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -15,7 +15,7 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: migrate <up|down|version>")
+		fmt.Fprintln(os.Stderr, "usage: migrate <up|down|version|force <N>>")
 		os.Exit(1)
 	}
 
@@ -31,7 +31,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := run(m, os.Args[1]); err != nil {
+	if err := run(m, os.Args[1:]); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
@@ -88,8 +88,14 @@ func newMigrate(dsn string) (*migrate.Migrate, error) {
 	return m, nil
 }
 
-// run executes the given subcommand against the migrate instance.
-func run(m *migrate.Migrate, cmd string) error {
+// run executes the given subcommand (and any trailing arguments) against the
+// migrate instance.
+func run(m *migrate.Migrate, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("no command given (use up, down, version, or force)")
+	}
+
+	cmd := args[0]
 	switch cmd {
 	case "up":
 		if err := m.Up(); err != nil && err != migrate.ErrNoChange {
@@ -117,7 +123,25 @@ func run(m *migrate.Migrate, cmd string) error {
 		fmt.Println(strconv.FormatUint(uint64(version), 10) + dirtyStr)
 		return nil
 
+	case "force":
+		// Decision: force takes an explicit target version so operators can
+		// recover from a dirty schema_migrations row (e.g. after a failed
+		// migration) without hand-editing the database, per the 2026-07-24
+		// Pointer incident.
+		if len(args) < 2 {
+			return fmt.Errorf("force requires a version argument, e.g. force 3")
+		}
+		version, err := strconv.Atoi(args[1])
+		if err != nil {
+			return fmt.Errorf("invalid version %q for force: %w", args[1], err)
+		}
+		if err := m.Force(version); err != nil {
+			return fmt.Errorf("migrate force: %w", err)
+		}
+		fmt.Printf("forced schema_migrations version to %d\n", version)
+		return nil
+
 	default:
-		return fmt.Errorf("unknown command %q (use up, down, or version)", cmd)
+		return fmt.Errorf("unknown command %q (use up, down, version, or force)", cmd)
 	}
 }

--- a/cmd/migrate/main_test.go
+++ b/cmd/migrate/main_test.go
@@ -63,10 +63,41 @@ func TestDatabaseURLFromEnv(t *testing.T) {
 	})
 }
 
-func TestRunUnknownCommand(t *testing.T) {
-	// We can't create a real *migrate.Migrate without a DB, but we can verify
-	// that an unknown command returns the expected error.
-	err := run(nil, "bogus")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unknown command")
+func TestRunArgumentParsing(t *testing.T) {
+	// We can't create a real *migrate.Migrate without a DB, so these cases
+	// only cover argument validation paths that return before touching m.
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "no arguments",
+			args:    []string{},
+			wantErr: "no command given",
+		},
+		{
+			name:    "unknown command",
+			args:    []string{"bogus"},
+			wantErr: "unknown command",
+		},
+		{
+			name:    "force missing version argument",
+			args:    []string{"force"},
+			wantErr: "force requires a version argument",
+		},
+		{
+			name:    "force non-numeric version argument",
+			args:    []string{"force", "abc"},
+			wantErr: "invalid version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := run(nil, tt.args)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-455.

Closes #455

## Changes

Extend cmd/migrate/main.go to accept `force <N>` alongside the existing up|down|version commands, calling m.Force(N) on the migrate instance. This unblocks in-image recovery from dirty schema_migrations state (per the 2026-07-24 Pointer incident) and must land before the Dockerfile ships the binary so the image includes the full recovery path. Add a table-driven test for argument parsing and update the usage string. All work stays inside cmd/migrate/.