### PR TITLE
GH-456: build(docker): ship migrate binary and honor TARGETOS/TARGETARCH

### DIFF
--- a/.agent/tasks/gh-456.md
+++ b/.agent/tasks/gh-456.md
@@ -1,0 +1,10 @@
+# GH-456
+
+**Created:** 2026-07-26
+
+## Problem
+
+Modify docker/Dockerfile to (a) declare ARG TARGETOS TARGETARCH in the builder stage and replace the hardcoded GOARCH=amd64 with GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} for both binaries, fixing the latent arm64/amd64 mismatch from release.yml:55; (b) add a build step for ./cmd/migrate with the same -trimpath -ldflags="-s -w" flags; (c) copy the resulting binary into the runtime stage as /auth-migrate owned by appuser. Keep ENTRYPOINT ["/auth-service"] unchanged — consumers invoke migrations with --entrypoint /auth-migrate. Verify locally with docker build + docker inspect that both binaries are present and match target arch.
+
+## Acceptance Criteria
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,9 @@
 # ---------- builder ----------
 FROM golang:1.25-alpine AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 RUN apk add --no-cache git ca-certificates tzdata
 
 WORKDIR /src
@@ -15,8 +18,10 @@ RUN go mod download
 
 # Copy source and build
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
     go build -trimpath -ldflags="-s -w" -o /bin/auth-service ./cmd/server
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+    go build -trimpath -ldflags="-s -w" -o /bin/auth-migrate ./cmd/migrate
 
 # ---------- runtime ----------
 FROM alpine:3.21
@@ -26,6 +31,7 @@ RUN apk add --no-cache ca-certificates tzdata \
     && adduser -u 1000 -G appuser -D -h /home/appuser appuser
 
 COPY --from=builder /bin/auth-service /auth-service
+COPY --from=builder --chown=appuser:appuser /bin/auth-migrate /auth-migrate
 
 # Public API + Admin API
 EXPOSE 4000 4001


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-456.

Closes #456

## Changes

Modify docker/Dockerfile to (a) declare ARG TARGETOS TARGETARCH in the builder stage and replace the hardcoded GOARCH=amd64 with GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} for both binaries, fixing the latent arm64/amd64 mismatch from release.yml:55; (b) add a build step for ./cmd/migrate with the same -trimpath -ldflags="-s -w" flags; (c) copy the resulting binary into the runtime stage as /auth-migrate owned by appuser. Keep ENTRYPOINT ["/auth-service"] unchanged — consumers invoke migrations with --entrypoint /auth-migrate. Verify locally with docker build + docker inspect that both binaries are present and match target arch.