### PR TITLE
GH-457: ci(release): exercise shipped migrate binary in dry-run job

### DIFF
--- a/.agent/tasks/gh-455.md
+++ b/.agent/tasks/gh-455.md
@@ -1,0 +1,10 @@
+# GH-455
+
+**Created:** 2026-07-26
+
+## Problem
+
+Extend cmd/migrate/main.go to accept `force <N>` alongside the existing up|down|version commands, calling m.Force(N) on the migrate instance. This unblocks in-image recovery from dirty schema_migrations state (per the 2026-07-24 Pointer incident) and must land before the Dockerfile ships the binary so the image includes the full recovery path. Add a table-driven test for argument parsing and update the usage string. All work stays inside cmd/migrate/.
+
+## Acceptance Criteria
+

--- a/.agent/tasks/gh-456.md
+++ b/.agent/tasks/gh-456.md
@@ -1,0 +1,10 @@
+# GH-456
+
+**Created:** 2026-07-26
+
+## Problem
+
+Modify docker/Dockerfile to (a) declare ARG TARGETOS TARGETARCH in the builder stage and replace the hardcoded GOARCH=amd64 with GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} for both binaries, fixing the latent arm64/amd64 mismatch from release.yml:55; (b) add a build step for ./cmd/migrate with the same -trimpath -ldflags="-s -w" flags; (c) copy the resulting binary into the runtime stage as /auth-migrate owned by appuser. Keep ENTRYPOINT ["/auth-service"] unchanged — consumers invoke migrations with --entrypoint /auth-migrate. Verify locally with docker build + docker inspect that both binaries are present and match target arch.
+
+## Acceptance Criteria
+

--- a/.agent/tasks/gh-457.md
+++ b/.agent/tasks/gh-457.md
@@ -1,0 +1,10 @@
+# GH-457
+
+**Created:** 2026-07-26
+
+## Problem
+
+Update .github/workflows/release.yml's migration-dry-run job so that after the image is built and pushed, it pulls the sha-tagged image and runs docker run --rm --entrypoint /auth-migrate -e DATABASE_URL=... <image> up against the job's Postgres service (either replacing or in addition to go run cmd/migrate/main.go). Also exercise version and force to prove the recovery path. Ensure job ordering still works with the existing needs: release. This proves on every release that the shipped tool actually works — the whole point of the epic.
+
+## Acceptance Criteria
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,9 @@ jobs:
           file: docker/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -62,6 +64,9 @@ jobs:
     name: Migration Dry-Run Check
     runs-on: ubuntu-latest
     needs: release
+    env:
+      IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+      DATABASE_URL: postgres://auth:auth@localhost:5432/auth_test?sslmode=disable
     services:
       postgres:
         image: postgres:16-alpine
@@ -80,21 +85,58 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          go-version-file: go.mod
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run migration dry-run
-        env:
-          DATABASE_URL: postgres://auth:auth@localhost:5432/auth_test?sslmode=disable
+      - name: Pull release image
+        # Pulls the exact image the "release" job just built and pushed
+        # (tagged with the commit sha), so this job proves the shipped
+        # /auth-migrate binary works — not a locally rebuilt copy.
+        run: docker pull "$IMAGE"
+
+      - name: Migrate up
+        # Runs the in-image migrate tool against the job's Postgres
+        # service to prove the shipped binary actually applies migrations.
         run: |
-          # Build the binary
-          go build -o bin/auth-service ./cmd/server
+          docker run --rm --network host --entrypoint /auth-migrate \
+            -e DATABASE_URL \
+            "$IMAGE" up
 
-          # Verify migrations directory exists and contains SQL files
-          if [ -d "migrations" ] && ls migrations/*.sql 1>/dev/null 2>&1; then
-            echo "Migration files found — dry-run validation passed."
-          else
-            echo "No migration files found — skipping dry-run."
+      - name: Migrate version (expect clean state)
+        id: version
+        run: |
+          OUTPUT=$(docker run --rm --network host --entrypoint /auth-migrate \
+            -e DATABASE_URL \
+            "$IMAGE" version)
+          echo "$OUTPUT"
+          if [[ "$OUTPUT" == *dirty* ]]; then
+            echo "schema reported dirty immediately after a clean 'up'" >&2
+            exit 1
+          fi
+          echo "version=$OUTPUT" >> "$GITHUB_OUTPUT"
+
+      - name: Migrate force (exercise dirty-state recovery path)
+        # Decision: force the schema to its own current version. This
+        # doesn't need a real failure to inject — it proves the shipped
+        # binary can clear a dirty flag and re-pin schema_migrations
+        # in-image, which is the exact recovery path operators need
+        # after a failed migration (2026-07-24 Pointer incident).
+        run: |
+          docker run --rm --network host --entrypoint /auth-migrate \
+            -e DATABASE_URL \
+            "$IMAGE" force "${{ steps.version.outputs.version }}"
+
+      - name: Migrate version (confirm force cleared dirty state)
+        run: |
+          OUTPUT=$(docker run --rm --network host --entrypoint /auth-migrate \
+            -e DATABASE_URL \
+            "$IMAGE" version)
+          echo "$OUTPUT"
+          if [[ "$OUTPUT" == *dirty* ]]; then
+            echo "schema still dirty after force recovery" >&2
+            exit 1
           fi

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -15,7 +15,7 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: migrate <up|down|version>")
+		fmt.Fprintln(os.Stderr, "usage: migrate <up|down|version|force <N>>")
 		os.Exit(1)
 	}
 
@@ -31,7 +31,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := run(m, os.Args[1]); err != nil {
+	if err := run(m, os.Args[1:]); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
@@ -88,8 +88,14 @@ func newMigrate(dsn string) (*migrate.Migrate, error) {
 	return m, nil
 }
 
-// run executes the given subcommand against the migrate instance.
-func run(m *migrate.Migrate, cmd string) error {
+// run executes the given subcommand (and any trailing arguments) against the
+// migrate instance.
+func run(m *migrate.Migrate, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("no command given (use up, down, version, or force)")
+	}
+
+	cmd := args[0]
 	switch cmd {
 	case "up":
 		if err := m.Up(); err != nil && err != migrate.ErrNoChange {
@@ -117,7 +123,25 @@ func run(m *migrate.Migrate, cmd string) error {
 		fmt.Println(strconv.FormatUint(uint64(version), 10) + dirtyStr)
 		return nil
 
+	case "force":
+		// Decision: force takes an explicit target version so operators can
+		// recover from a dirty schema_migrations row (e.g. after a failed
+		// migration) without hand-editing the database, per the 2026-07-24
+		// Pointer incident.
+		if len(args) < 2 {
+			return fmt.Errorf("force requires a version argument, e.g. force 3")
+		}
+		version, err := strconv.Atoi(args[1])
+		if err != nil {
+			return fmt.Errorf("invalid version %q for force: %w", args[1], err)
+		}
+		if err := m.Force(version); err != nil {
+			return fmt.Errorf("migrate force: %w", err)
+		}
+		fmt.Printf("forced schema_migrations version to %d\n", version)
+		return nil
+
 	default:
-		return fmt.Errorf("unknown command %q (use up, down, or version)", cmd)
+		return fmt.Errorf("unknown command %q (use up, down, version, or force)", cmd)
 	}
 }

--- a/cmd/migrate/main_test.go
+++ b/cmd/migrate/main_test.go
@@ -63,10 +63,41 @@ func TestDatabaseURLFromEnv(t *testing.T) {
 	})
 }
 
-func TestRunUnknownCommand(t *testing.T) {
-	// We can't create a real *migrate.Migrate without a DB, but we can verify
-	// that an unknown command returns the expected error.
-	err := run(nil, "bogus")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unknown command")
+func TestRunArgumentParsing(t *testing.T) {
+	// We can't create a real *migrate.Migrate without a DB, so these cases
+	// only cover argument validation paths that return before touching m.
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "no arguments",
+			args:    []string{},
+			wantErr: "no command given",
+		},
+		{
+			name:    "unknown command",
+			args:    []string{"bogus"},
+			wantErr: "unknown command",
+		},
+		{
+			name:    "force missing version argument",
+			args:    []string{"force"},
+			wantErr: "force requires a version argument",
+		},
+		{
+			name:    "force non-numeric version argument",
+			args:    []string{"force", "abc"},
+			wantErr: "invalid version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := run(nil, tt.args)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,9 @@
 # ---------- builder ----------
 FROM golang:1.25-alpine AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 RUN apk add --no-cache git ca-certificates tzdata
 
 WORKDIR /src
@@ -15,8 +18,10 @@ RUN go mod download
 
 # Copy source and build
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
     go build -trimpath -ldflags="-s -w" -o /bin/auth-service ./cmd/server
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+    go build -trimpath -ldflags="-s -w" -o /bin/auth-migrate ./cmd/migrate
 
 # ---------- runtime ----------
 FROM alpine:3.21
@@ -26,6 +31,7 @@ RUN apk add --no-cache ca-certificates tzdata \
     && adduser -u 1000 -G appuser -D -h /home/appuser appuser
 
 COPY --from=builder /bin/auth-service /auth-service
+COPY --from=builder --chown=appuser:appuser /bin/auth-migrate /auth-migrate
 
 # Public API + Admin API
 EXPOSE 4000 4001


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-457.

Closes #457

## Changes

Update .github/workflows/release.yml's migration-dry-run job so that after the image is built and pushed, it pulls the sha-tagged image and runs docker run --rm --entrypoint /auth-migrate -e DATABASE_URL=... <image> up against the job's Postgres service (either replacing or in addition to go run cmd/migrate/main.go). Also exercise version and force to prove the recovery path. Ensure job ordering still works with the existing needs: release. This proves on every release that the shipped tool actually works — the whole point of the epic.