### PR TITLE
fix(ci): use github context for IMAGE in migration-dry-run job env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: release
     env:
-      IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+      # env context is unavailable in job-level env; build the ref from the
+      # github context instead (REGISTRY/IMAGE_NAME must stay in sync above).
+      IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
       DATABASE_URL: postgres://auth:auth@localhost:5432/auth_test?sslmode=disable
     services:
       postgres:


### PR DESCRIPTION
env context is not available in job-level env blocks; the 0s workflow
validation failures on the GH-457/GH-458 merges came from this.
