### PR TITLE
GH-467: feat(oidc): add Redis-backed ephemeral stores and consent_grants migration

### DIFF
--- a/.agent/tasks/gh-467.md
+++ b/.agent/tasks/gh-467.md
@@ -1,0 +1,10 @@
+# GH-467
+
+**Created:** 2026-07-26
+
+## Problem
+
+Create a new `internal/oidc/` (or `internal/oauth/provider/`) package with domain types for `LoginRequest`, `ConsentRequest`, and `AuthorizationCode` (subject, client_id, redirect_uri, scopes, nonce, code_challenge, code_challenge_method, auth_time, expiry). Implement Redis-backed stores with TTL and one-time-use semantics (GETDEL or Lua) — code TTL 60s, challenge TTL 10m as unexported constants. Add migration `000018_consent_grants.up.sql` creating `(id, tenant_id, user_id TEXT REFERENCES users(id), client_id, scopes TEXT[], granted_at, revoked_at)` — `user_id` MUST be TEXT, not UUID (per GH-444 history) — with a matching down migration that drops the table. Unit-test store TTL, GETDEL semantics, and migration up/down.
+
+## Acceptance Criteria
+

--- a/internal/oidc/errors.go
+++ b/internal/oidc/errors.go
@@ -1,0 +1,18 @@
+package oidc
+
+import "errors"
+
+// Sentinel errors returned by the Redis-backed stores in this package.
+var (
+	// ErrLoginRequestNotFound indicates the login request does not exist,
+	// has expired, or has already been consumed.
+	ErrLoginRequestNotFound = errors.New("oidc: login request not found")
+
+	// ErrConsentRequestNotFound indicates the consent request does not
+	// exist, has expired, or has already been consumed.
+	ErrConsentRequestNotFound = errors.New("oidc: consent request not found")
+
+	// ErrAuthorizationCodeNotFound indicates the authorization code does not
+	// exist, has expired, or has already been redeemed.
+	ErrAuthorizationCodeNotFound = errors.New("oidc: authorization code not found")
+)

--- a/internal/oidc/redis_store.go
+++ b/internal/oidc/redis_store.go
@@ -1,0 +1,210 @@
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	// loginRequestPrefix namespaces login request keys in Redis.
+	loginRequestPrefix = "oidc:login:"
+
+	// consentRequestPrefix namespaces consent request keys in Redis.
+	consentRequestPrefix = "oidc:consent:"
+
+	// authorizationCodePrefix namespaces authorization code keys in Redis.
+	authorizationCodePrefix = "oidc:code:"
+
+	// defaultChallengeTTL is the lifetime of login and consent challenges (10 minutes).
+	defaultChallengeTTL = 10 * time.Minute
+
+	// defaultCodeTTL is the lifetime of an authorization code (60 seconds).
+	defaultCodeTTL = 60 * time.Second
+)
+
+// RedisStore is a Redis-backed store for the ephemeral OIDC provider state:
+// login requests, consent requests, and authorization codes.
+//
+// Authorization codes are always single-use, retrieved via GETDEL. Login and
+// consent requests support both a non-destructive Get (for repeated reads by
+// the login/consent UI while the challenge is pending) and a one-time
+// Consume (GETDEL) for the accept/reject transition.
+type RedisStore struct {
+	client       redis.Cmdable
+	challengeTTL time.Duration
+	codeTTL      time.Duration
+}
+
+// RedisStoreOption configures a RedisStore.
+type RedisStoreOption func(*RedisStore)
+
+// WithChallengeTTL overrides the default login/consent challenge TTL.
+func WithChallengeTTL(d time.Duration) RedisStoreOption {
+	return func(s *RedisStore) { s.challengeTTL = d }
+}
+
+// WithCodeTTL overrides the default authorization code TTL.
+func WithCodeTTL(d time.Duration) RedisStoreOption {
+	return func(s *RedisStore) { s.codeTTL = d }
+}
+
+// NewRedisStore creates a new Redis-backed OIDC provider store.
+func NewRedisStore(client redis.Cmdable, opts ...RedisStoreOption) *RedisStore {
+	s := &RedisStore{
+		client:       client,
+		challengeTTL: defaultChallengeTTL,
+		codeTTL:      defaultCodeTTL,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Login requests
+// ────────────────────────────────────────────────────────────────────────────
+
+// SaveLoginRequest stores a login request keyed by its challenge, expiring
+// after the configured challenge TTL.
+func (s *RedisStore) SaveLoginRequest(ctx context.Context, lr *LoginRequest) error {
+	data, err := json.Marshal(lr)
+	if err != nil {
+		return fmt.Errorf("marshal login request: %w", err)
+	}
+	if err := s.client.Set(ctx, loginRequestPrefix+lr.Challenge, data, s.challengeTTL).Err(); err != nil {
+		return fmt.Errorf("save login request: %w", err)
+	}
+	return nil
+}
+
+// GetLoginRequest returns the login request for the given challenge without
+// consuming it. Returns ErrLoginRequestNotFound if it does not exist or has
+// expired.
+func (s *RedisStore) GetLoginRequest(ctx context.Context, challenge string) (*LoginRequest, error) {
+	data, err := s.client.Get(ctx, loginRequestPrefix+challenge).Bytes()
+	if err != nil {
+		if err == redis.Nil {
+			return nil, ErrLoginRequestNotFound
+		}
+		return nil, fmt.Errorf("get login request: %w", err)
+	}
+	var lr LoginRequest
+	if err := json.Unmarshal(data, &lr); err != nil {
+		return nil, fmt.Errorf("unmarshal login request: %w", err)
+	}
+	return &lr, nil
+}
+
+// ConsumeLoginRequest atomically retrieves and deletes the login request for
+// the given challenge (GETDEL), enforcing one-time use for the accept/reject
+// transition. Returns ErrLoginRequestNotFound if it does not exist, has
+// expired, or was already consumed.
+func (s *RedisStore) ConsumeLoginRequest(ctx context.Context, challenge string) (*LoginRequest, error) {
+	data, err := s.client.GetDel(ctx, loginRequestPrefix+challenge).Bytes()
+	if err != nil {
+		if err == redis.Nil {
+			return nil, ErrLoginRequestNotFound
+		}
+		return nil, fmt.Errorf("consume login request: %w", err)
+	}
+	var lr LoginRequest
+	if err := json.Unmarshal(data, &lr); err != nil {
+		return nil, fmt.Errorf("unmarshal login request: %w", err)
+	}
+	return &lr, nil
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Consent requests
+// ────────────────────────────────────────────────────────────────────────────
+
+// SaveConsentRequest stores a consent request keyed by its challenge,
+// expiring after the configured challenge TTL.
+func (s *RedisStore) SaveConsentRequest(ctx context.Context, cr *ConsentRequest) error {
+	data, err := json.Marshal(cr)
+	if err != nil {
+		return fmt.Errorf("marshal consent request: %w", err)
+	}
+	if err := s.client.Set(ctx, consentRequestPrefix+cr.Challenge, data, s.challengeTTL).Err(); err != nil {
+		return fmt.Errorf("save consent request: %w", err)
+	}
+	return nil
+}
+
+// GetConsentRequest returns the consent request for the given challenge
+// without consuming it. Returns ErrConsentRequestNotFound if it does not
+// exist or has expired.
+func (s *RedisStore) GetConsentRequest(ctx context.Context, challenge string) (*ConsentRequest, error) {
+	data, err := s.client.Get(ctx, consentRequestPrefix+challenge).Bytes()
+	if err != nil {
+		if err == redis.Nil {
+			return nil, ErrConsentRequestNotFound
+		}
+		return nil, fmt.Errorf("get consent request: %w", err)
+	}
+	var cr ConsentRequest
+	if err := json.Unmarshal(data, &cr); err != nil {
+		return nil, fmt.Errorf("unmarshal consent request: %w", err)
+	}
+	return &cr, nil
+}
+
+// ConsumeConsentRequest atomically retrieves and deletes the consent request
+// for the given challenge (GETDEL), enforcing one-time use for the
+// accept/reject transition. Returns ErrConsentRequestNotFound if it does not
+// exist, has expired, or was already consumed.
+func (s *RedisStore) ConsumeConsentRequest(ctx context.Context, challenge string) (*ConsentRequest, error) {
+	data, err := s.client.GetDel(ctx, consentRequestPrefix+challenge).Bytes()
+	if err != nil {
+		if err == redis.Nil {
+			return nil, ErrConsentRequestNotFound
+		}
+		return nil, fmt.Errorf("consume consent request: %w", err)
+	}
+	var cr ConsentRequest
+	if err := json.Unmarshal(data, &cr); err != nil {
+		return nil, fmt.Errorf("unmarshal consent request: %w", err)
+	}
+	return &cr, nil
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Authorization codes
+// ────────────────────────────────────────────────────────────────────────────
+
+// SaveAuthorizationCode stores an authorization code, expiring after the
+// configured code TTL.
+func (s *RedisStore) SaveAuthorizationCode(ctx context.Context, ac *AuthorizationCode) error {
+	data, err := json.Marshal(ac)
+	if err != nil {
+		return fmt.Errorf("marshal authorization code: %w", err)
+	}
+	if err := s.client.Set(ctx, authorizationCodePrefix+ac.Code, data, s.codeTTL).Err(); err != nil {
+		return fmt.Errorf("save authorization code: %w", err)
+	}
+	return nil
+}
+
+// ConsumeAuthorizationCode atomically retrieves and deletes the
+// authorization code (GETDEL), enforcing single-use redemption at the token
+// endpoint. Returns ErrAuthorizationCodeNotFound if it does not exist, has
+// expired, or was already redeemed.
+func (s *RedisStore) ConsumeAuthorizationCode(ctx context.Context, code string) (*AuthorizationCode, error) {
+	data, err := s.client.GetDel(ctx, authorizationCodePrefix+code).Bytes()
+	if err != nil {
+		if err == redis.Nil {
+			return nil, ErrAuthorizationCodeNotFound
+		}
+		return nil, fmt.Errorf("consume authorization code: %w", err)
+	}
+	var ac AuthorizationCode
+	if err := json.Unmarshal(data, &ac); err != nil {
+		return nil, fmt.Errorf("unmarshal authorization code: %w", err)
+	}
+	return &ac, nil
+}

--- a/internal/oidc/redis_store_test.go
+++ b/internal/oidc/redis_store_test.go
@@ -1,0 +1,256 @@
+package oidc_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/internal/oidc"
+)
+
+func newTestRedis(t *testing.T) (*miniredis.Miniredis, redis.Cmdable) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return mr, client
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Login request tests
+// ────────────────────────────────────────────────────────────────────────────
+
+func TestRedisStore_SaveAndGetLoginRequest(t *testing.T) {
+	_, client := newTestRedis(t)
+	store := oidc.NewRedisStore(client)
+	ctx := context.Background()
+
+	lr := &oidc.LoginRequest{
+		Challenge:           "login-chal-1",
+		ClientID:            "client-1",
+		RedirectURI:         "https://app.example.com/callback",
+		Scopes:              []string{"openid", "profile"},
+		State:               "state-1",
+		Nonce:               "nonce-1",
+		CodeChallenge:       "challenge-1",
+		CodeChallengeMethod: "S256",
+		RequestedAt:         time.Now().UTC().Truncate(time.Second),
+		ExpiresAt:           time.Now().UTC().Add(10 * time.Minute).Truncate(time.Second),
+	}
+
+	require.NoError(t, store.SaveLoginRequest(ctx, lr))
+
+	got, err := store.GetLoginRequest(ctx, "login-chal-1")
+	require.NoError(t, err)
+	assert.Equal(t, lr, got)
+
+	// Non-destructive: a second Get should still succeed.
+	got2, err := store.GetLoginRequest(ctx, "login-chal-1")
+	require.NoError(t, err)
+	assert.Equal(t, lr, got2)
+}
+
+func TestRedisStore_GetLoginRequest_NotFound(t *testing.T) {
+	_, client := newTestRedis(t)
+	store := oidc.NewRedisStore(client)
+	ctx := context.Background()
+
+	_, err := store.GetLoginRequest(ctx, "nonexistent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, oidc.ErrLoginRequestNotFound)
+}
+
+func TestRedisStore_ConsumeLoginRequest(t *testing.T) {
+	_, client := newTestRedis(t)
+	store := oidc.NewRedisStore(client)
+	ctx := context.Background()
+
+	lr := &oidc.LoginRequest{Challenge: "login-chal-consume", ClientID: "client-1"}
+	require.NoError(t, store.SaveLoginRequest(ctx, lr))
+
+	got, err := store.ConsumeLoginRequest(ctx, "login-chal-consume")
+	require.NoError(t, err)
+	assert.Equal(t, "client-1", got.ClientID)
+
+	// GETDEL semantics: second consume must fail (single-use).
+	_, err = store.ConsumeLoginRequest(ctx, "login-chal-consume")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, oidc.ErrLoginRequestNotFound)
+}
+
+func TestRedisStore_LoginRequest_TTLExpires(t *testing.T) {
+	mr, client := newTestRedis(t)
+	store := oidc.NewRedisStore(client, oidc.WithChallengeTTL(1*time.Second))
+	ctx := context.Background()
+
+	lr := &oidc.LoginRequest{Challenge: "login-chal-expire", ClientID: "client-1"}
+	require.NoError(t, store.SaveLoginRequest(ctx, lr))
+
+	mr.FastForward(2 * time.Second)
+
+	_, err := store.GetLoginRequest(ctx, "login-chal-expire")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, oidc.ErrLoginRequestNotFound)
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Consent request tests
+// ────────────────────────────────────────────────────────────────────────────
+
+func TestRedisStore_SaveAndGetConsentRequest(t *testing.T) {
+	_, client := newTestRedis(t)
+	store := oidc.NewRedisStore(client)
+	ctx := context.Background()
+
+	cr := &oidc.ConsentRequest{
+		Challenge:           "consent-chal-1",
+		Subject:             "user-1",
+		ClientID:            "client-1",
+		RedirectURI:         "https://app.example.com/callback",
+		Scopes:              []string{"openid", "email"},
+		Nonce:               "nonce-1",
+		CodeChallenge:       "challenge-1",
+		CodeChallengeMethod: "S256",
+		AuthTime:            time.Now().UTC().Truncate(time.Second),
+		ExpiresAt:           time.Now().UTC().Add(10 * time.Minute).Truncate(time.Second),
+	}
+
+	require.NoError(t, store.SaveConsentRequest(ctx, cr))
+
+	got, err := store.GetConsentRequest(ctx, "consent-chal-1")
+	require.NoError(t, err)
+	assert.Equal(t, cr, got)
+}
+
+func TestRedisStore_GetConsentRequest_NotFound(t *testing.T) {
+	_, client := newTestRedis(t)
+	store := oidc.NewRedisStore(client)
+	ctx := context.Background()
+
+	_, err := store.GetConsentRequest(ctx, "nonexistent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, oidc.ErrConsentRequestNotFound)
+}
+
+func TestRedisStore_ConsumeConsentRequest(t *testing.T) {
+	_, client := newTestRedis(t)
+	store := oidc.NewRedisStore(client)
+	ctx := context.Background()
+
+	cr := &oidc.ConsentRequest{Challenge: "consent-chal-consume", Subject: "user-1"}
+	require.NoError(t, store.SaveConsentRequest(ctx, cr))
+
+	got, err := store.ConsumeConsentRequest(ctx, "consent-chal-consume")
+	require.NoError(t, err)
+	assert.Equal(t, "user-1", got.Subject)
+
+	// GETDEL semantics: second consume must fail (single-use).
+	_, err = store.ConsumeConsentRequest(ctx, "consent-chal-consume")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, oidc.ErrConsentRequestNotFound)
+}
+
+func TestRedisStore_ConsentRequest_TTLExpires(t *testing.T) {
+	mr, client := newTestRedis(t)
+	store := oidc.NewRedisStore(client, oidc.WithChallengeTTL(1*time.Second))
+	ctx := context.Background()
+
+	cr := &oidc.ConsentRequest{Challenge: "consent-chal-expire", Subject: "user-1"}
+	require.NoError(t, store.SaveConsentRequest(ctx, cr))
+
+	mr.FastForward(2 * time.Second)
+
+	_, err := store.GetConsentRequest(ctx, "consent-chal-expire")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, oidc.ErrConsentRequestNotFound)
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Authorization code tests
+// ────────────────────────────────────────────────────────────────────────────
+
+func TestRedisStore_SaveAndConsumeAuthorizationCode(t *testing.T) {
+	_, client := newTestRedis(t)
+	store := oidc.NewRedisStore(client)
+	ctx := context.Background()
+
+	ac := &oidc.AuthorizationCode{
+		Code:                "auth-code-1",
+		Subject:             "user-1",
+		ClientID:            "client-1",
+		RedirectURI:         "https://app.example.com/callback",
+		Scopes:              []string{"openid"},
+		Nonce:               "nonce-1",
+		CodeChallenge:       "challenge-1",
+		CodeChallengeMethod: "S256",
+		AuthTime:            time.Now().UTC().Truncate(time.Second),
+		ExpiresAt:           time.Now().UTC().Add(60 * time.Second).Truncate(time.Second),
+	}
+
+	require.NoError(t, store.SaveAuthorizationCode(ctx, ac))
+
+	got, err := store.ConsumeAuthorizationCode(ctx, "auth-code-1")
+	require.NoError(t, err)
+	assert.Equal(t, ac, got)
+}
+
+func TestRedisStore_ConsumeAuthorizationCode_SingleUse(t *testing.T) {
+	_, client := newTestRedis(t)
+	store := oidc.NewRedisStore(client)
+	ctx := context.Background()
+
+	ac := &oidc.AuthorizationCode{Code: "auth-code-reuse", Subject: "user-1"}
+	require.NoError(t, store.SaveAuthorizationCode(ctx, ac))
+
+	_, err := store.ConsumeAuthorizationCode(ctx, "auth-code-reuse")
+	require.NoError(t, err)
+
+	// GETDEL semantics: reusing an authorization code must fail.
+	_, err = store.ConsumeAuthorizationCode(ctx, "auth-code-reuse")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, oidc.ErrAuthorizationCodeNotFound)
+}
+
+func TestRedisStore_ConsumeAuthorizationCode_NotFound(t *testing.T) {
+	_, client := newTestRedis(t)
+	store := oidc.NewRedisStore(client)
+	ctx := context.Background()
+
+	_, err := store.ConsumeAuthorizationCode(ctx, "nonexistent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, oidc.ErrAuthorizationCodeNotFound)
+}
+
+func TestRedisStore_AuthorizationCode_TTLExpires(t *testing.T) {
+	mr, client := newTestRedis(t)
+	store := oidc.NewRedisStore(client, oidc.WithCodeTTL(1*time.Second))
+	ctx := context.Background()
+
+	ac := &oidc.AuthorizationCode{Code: "auth-code-expire", Subject: "user-1"}
+	require.NoError(t, store.SaveAuthorizationCode(ctx, ac))
+
+	mr.FastForward(2 * time.Second)
+
+	_, err := store.ConsumeAuthorizationCode(ctx, "auth-code-expire")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, oidc.ErrAuthorizationCodeNotFound)
+}
+
+func TestRedisStore_DefaultTTLs(t *testing.T) {
+	mr, client := newTestRedis(t)
+	store := oidc.NewRedisStore(client)
+	ctx := context.Background()
+
+	require.NoError(t, store.SaveLoginRequest(ctx, &oidc.LoginRequest{Challenge: "ttl-login"}))
+	require.NoError(t, store.SaveConsentRequest(ctx, &oidc.ConsentRequest{Challenge: "ttl-consent"}))
+	require.NoError(t, store.SaveAuthorizationCode(ctx, &oidc.AuthorizationCode{Code: "ttl-code"}))
+
+	assert.InDelta(t, 10*time.Minute, mr.TTL("oidc:login:ttl-login"), float64(time.Second))
+	assert.InDelta(t, 10*time.Minute, mr.TTL("oidc:consent:ttl-consent"), float64(time.Second))
+	assert.InDelta(t, 60*time.Second, mr.TTL("oidc:code:ttl-code"), float64(time.Second))
+}

--- a/internal/oidc/types.go
+++ b/internal/oidc/types.go
@@ -1,0 +1,59 @@
+// Package oidc provides domain types and Redis-backed ephemeral stores for
+// the OIDC/OAuth2 authorization code flow: login challenge -> consent
+// challenge -> one-time authorization code. See GH-431 for the full provider
+// design (Hydra-style external login/consent UI); this package covers the
+// storage building blocks consumed by that provider implementation.
+package oidc
+
+import "time"
+
+// LoginRequest represents a pending authorization request waiting for the
+// login UI to authenticate a subject. It is created when GET /oauth/authorize
+// is hit by an unauthenticated caller and resolved (accepted or rejected)
+// via the admin login-request API.
+type LoginRequest struct {
+	Challenge           string
+	ClientID            string
+	RedirectURI         string
+	Scopes              []string
+	State               string
+	Nonce               string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	RequestedAt         time.Time
+	ExpiresAt           time.Time
+}
+
+// ConsentRequest represents a pending authorization request waiting for the
+// consent UI to approve the requested scopes on behalf of an already
+// authenticated subject. It is created once the corresponding LoginRequest
+// has been accepted.
+type ConsentRequest struct {
+	Challenge           string
+	Subject             string
+	ClientID            string
+	RedirectURI         string
+	Scopes              []string
+	State               string
+	Nonce               string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	AuthTime            time.Time
+	ExpiresAt           time.Time
+}
+
+// AuthorizationCode represents a one-time authorization code issued after
+// consent has been granted. It is exchanged exactly once for a token pair at
+// POST /oauth/token.
+type AuthorizationCode struct {
+	Code                string
+	Subject             string
+	ClientID            string
+	RedirectURI         string
+	Scopes              []string
+	Nonce               string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	AuthTime            time.Time
+	ExpiresAt           time.Time
+}

--- a/migrations/000018_consent_grants.down.sql
+++ b/migrations/000018_consent_grants.down.sql
@@ -1,0 +1,2 @@
+-- 000018_consent_grants.down.sql
+DROP TABLE IF EXISTS consent_grants;

--- a/migrations/000018_consent_grants.up.sql
+++ b/migrations/000018_consent_grants.up.sql
@@ -1,0 +1,34 @@
+-- 000018_consent_grants.up.sql
+-- Durable remembered-consent grants for the OIDC provider: records which
+-- scopes a user has approved for a client so future authorization requests
+-- can skip the consent screen when the user asked to be remembered
+-- (see GH-431, GH-467). Ephemeral login/consent challenges and one-time
+-- authorization codes live in Redis (internal/oidc), not here.
+--
+-- Decision: user_id is TEXT (not UUID) to match users.id (000003). 000010
+-- and 000014 originally got this wrong and had to be fixed post-hoc
+-- (GH-444) because Postgres rejects FKs on type mismatch.
+
+CREATE TABLE consent_grants (
+    id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id  UUID        NOT NULL REFERENCES tenants (id),
+    user_id    TEXT        NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    client_id  UUID        NOT NULL REFERENCES clients (id) ON DELETE CASCADE,
+    scopes     TEXT[]      NOT NULL DEFAULT '{}',
+    granted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    revoked_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_consent_grants_tenant_id ON consent_grants (tenant_id);
+CREATE INDEX idx_consent_grants_user_id ON consent_grants (user_id);
+CREATE INDEX idx_consent_grants_client_id ON consent_grants (client_id);
+
+-- Only one active (non-revoked) grant per tenant+user+client; re-granting
+-- after revocation inserts a new row rather than updating the old one, per
+-- the auditable/revocable design in tech-decisions.md.
+CREATE UNIQUE INDEX idx_consent_grants_tenant_user_client_active
+    ON consent_grants (tenant_id, user_id, client_id) WHERE revoked_at IS NULL;
+
+ALTER TABLE consent_grants ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_consent_grants ON consent_grants
+    USING (tenant_id = current_setting('app.current_tenant_id', true)::uuid);

--- a/migrations/consent_grants_migration_test.go
+++ b/migrations/consent_grants_migration_test.go
@@ -1,0 +1,92 @@
+package migrations_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/golang-migrate/migrate/v4"
+	_ "github.com/golang-migrate/migrate/v4/database/postgres"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qf-studio/auth-service/migrations"
+)
+
+// testMigrate returns a *migrate.Migrate wired to the embedded migration
+// source and TEST_DATABASE_URL. Skips the test if TEST_DATABASE_URL is not
+// set, matching the convention used by internal/storage integration tests.
+func testMigrate(t *testing.T) (*migrate.Migrate, string) {
+	t.Helper()
+
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set, skipping migration integration test")
+	}
+
+	src, err := iofs.New(migrations.FS, ".")
+	require.NoError(t, err)
+
+	m, err := migrate.NewWithSourceInstance("iofs", src, dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = m.Close() })
+
+	return m, dsn
+}
+
+// tableExists reports whether the given table exists in the public schema.
+func tableExists(t *testing.T, dsn, table string) bool {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pool, err := pgxpool.New(ctx, dsn)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	var exists bool
+	err = pool.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = $1)`,
+		table,
+	).Scan(&exists)
+	require.NoError(t, err)
+
+	return exists
+}
+
+// TestMigration_ConsentGrantsUpDown proves 000018_consent_grants applies and
+// reverts cleanly: after `up` the table exists, after reverting exactly this
+// one migration (`steps -1`) it is dropped, matching the down migration's
+// contract. Restores the schema to head afterward so other integration
+// tests sharing TEST_DATABASE_URL see a fully-migrated database.
+func TestMigration_ConsentGrantsUpDown(t *testing.T) {
+	m, dsn := testMigrate(t)
+
+	err := m.Up()
+	if err != nil && err != migrate.ErrNoChange {
+		require.NoError(t, err, "migrate up")
+	}
+	t.Cleanup(func() {
+		if err := m.Up(); err != nil && err != migrate.ErrNoChange {
+			t.Errorf("failed to restore schema to head after test: %v", err)
+		}
+	})
+
+	version, dirty, err := m.Version()
+	require.NoError(t, err)
+	require.False(t, dirty, "schema should not be dirty after a clean up")
+	require.Equal(t, uint(18), version, "expected embedded migrations to be at head version 18")
+
+	require.True(t, tableExists(t, dsn, "consent_grants"), "consent_grants table should exist after migrate up")
+
+	require.NoError(t, m.Steps(-1), "migrate down one step (000018 down)")
+	require.False(t, tableExists(t, dsn, "consent_grants"), "consent_grants table should be dropped after reverting 000018")
+
+	version, dirty, err = m.Version()
+	require.NoError(t, err)
+	require.False(t, dirty)
+	require.Equal(t, uint(17), version, "expected version 17 after reverting 000018")
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-467.

Closes #467

## Changes

Create a new `internal/oidc/` (or `internal/oauth/provider/`) package with domain types for `LoginRequest`, `ConsentRequest`, and `AuthorizationCode` (subject, client_id, redirect_uri, scopes, nonce, code_challenge, code_challenge_method, auth_time, expiry). Implement Redis-backed stores with TTL and one-time-use semantics (GETDEL or Lua) — code TTL 60s, challenge TTL 10m as unexported constants. Add migration `000018_consent_grants.up.sql` creating `(id, tenant_id, user_id TEXT REFERENCES users(id), client_id, scopes TEXT[], granted_at, revoked_at)` — `user_id` MUST be TEXT, not UUID (per GH-444 history) — with a matching down migration that drops the table. Unit-test store TTL, GETDEL semantics, and migration up/down.