### PR TITLE
GH-468: feat(oidc): unify issuer from OIDCConfig and add id_token issuance

### DIFF
--- a/.agent/tasks/gh-468.md
+++ b/.agent/tasks/gh-468.md
@@ -1,0 +1,10 @@
+# GH-468
+
+**Created:** 2026-07-26
+
+## Problem
+
+In `internal/token/service.go`, replace the hardcoded `https://auth.qf.studio` constant used for `iss` with a value sourced from `OIDCConfig.IssuerURL`, and add `IssueIDToken(subject, audience/clientID, nonce, authTime, ...)` signed with the existing JWT key/kid and TTL from `OIDCConfig.IDTokenTTL`. In `internal/config/config.go`, change the `OIDC_ISSUER_URL` default from `http://localhost:4000` to `https://auth.qf.studio` so wire behavior is unchanged unless explicitly overridden. Update existing token unit tests; add id_token issuance tests (claims, alg, kid, TTL, aud, nonce). Call out in the PR description that overriding `OIDC_ISSUER_URL` will now actually change `iss` (previously a no-op).
+
+## Acceptance Criteria
+

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ All configuration is via environment variables. See [`internal/config/config.go`
 | `MFA_DIGITS` | `6` | TOTP digits (6 or 8) |
 | `MFA_PERIOD` | `30` | TOTP period in seconds |
 | `MFA_BACKUP_CODE_COUNT` | `10` | Number of backup codes |
-| `OIDC_ISSUER_URL` | `http://localhost:4000` | OIDC issuer URL |
+| `OIDC_ISSUER_URL` | `https://auth.qf.studio` | OIDC issuer URL (also sets the `iss` claim on JWTs) |
 | `OIDC_ID_TOKEN_TTL` | `1h` | ID token lifetime |
 | `OIDC_SUPPORTED_SCOPES` | `openid,profile,email,offline_access` | Supported OIDC scopes |
 | `SAML_ENABLED` | `false` | Enable SAML SSO |

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -86,7 +86,7 @@ func run(log *zap.Logger, cfg *config.Config) error {
 
 	// ── Services ─────────────────────────────────────────────────────────
 	hasher := password.New([]byte(cfg.Argon2.Pepper))
-	tokenSvc, err := token.NewService(cfg.JWT, redisClient, log, auditSvc)
+	tokenSvc, err := token.NewService(cfg.JWT, cfg.OIDC, redisClient, log, auditSvc)
 	if err != nil {
 		return fmt.Errorf("token service init failed: %w", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -685,7 +685,7 @@ func loadOAuthProvider(l *loader, provider string) (OAuthProviderConfig, error) 
 }
 
 func loadOIDC(l *loader) (OIDCConfig, error) {
-	issuerURL := l.optStr("OIDC_ISSUER_URL", "http://localhost:4000")
+	issuerURL := l.optStr("OIDC_ISSUER_URL", "https://auth.qf.studio")
 
 	idTokenTTLStr := l.optStr("OIDC_ID_TOKEN_TTL", "1h")
 	idTokenTTL, err := parseDuration(idTokenTTLStr)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -100,7 +100,7 @@ func TestLoad_AllDefaults(t *testing.T) {
 	assert.False(t, cfg.OAuth.Apple.Enabled)
 
 	// OIDC defaults
-	assert.Equal(t, "http://localhost:4000", cfg.OIDC.IssuerURL)
+	assert.Equal(t, "https://auth.qf.studio", cfg.OIDC.IssuerURL)
 	assert.Equal(t, 1*time.Hour, cfg.OIDC.IDTokenTTL)
 	assert.Equal(t, []string{"openid", "profile", "email", "offline_access"}, cfg.OIDC.SupportedScopes)
 

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -56,7 +56,7 @@ func newTokenService(t *testing.T, rc *redis.Client) *token.Service {
 		RefreshTokenTTL: 7 * 24 * time.Hour,
 		SystemSecrets:   []string{"test-secret"},
 	}
-	svc, err := token.NewServiceFromKey(cfg, key, rc, zap.NewNop(), audit.NopLogger{})
+	svc, err := token.NewServiceFromKey(cfg, config.OIDCConfig{}, key, rc, zap.NewNop(), audit.NopLogger{})
 	require.NoError(t, err)
 	return svc
 }

--- a/internal/middleware/auth_bench_test.go
+++ b/internal/middleware/auth_bench_test.go
@@ -51,7 +51,7 @@ func benchNewES256Service(b *testing.B) (*token.Service, *miniredis.Miniredis) {
 		RefreshTokenTTL: 7 * 24 * time.Hour,
 		SystemSecrets:   []string{"bench-secret"},
 	}
-	svc, err := token.NewServiceFromKey(cfg, key, rc, zap.NewNop(), audit.NopLogger{})
+	svc, err := token.NewServiceFromKey(cfg, config.OIDCConfig{}, key, rc, zap.NewNop(), audit.NopLogger{})
 	require.NoError(b, err)
 	return svc, mr
 }
@@ -71,7 +71,7 @@ func benchNewEdDSAService(b *testing.B) (*token.Service, *miniredis.Miniredis) {
 		RefreshTokenTTL: 7 * 24 * time.Hour,
 		SystemSecrets:   []string{"bench-secret"},
 	}
-	svc, err := token.NewServiceFromKey(cfg, priv, rc, zap.NewNop(), audit.NopLogger{})
+	svc, err := token.NewServiceFromKey(cfg, config.OIDCConfig{}, priv, rc, zap.NewNop(), audit.NopLogger{})
 	require.NoError(b, err)
 	return svc, mr
 }
@@ -208,7 +208,7 @@ func BenchmarkAuthMiddlewareChain_InvalidToken(b *testing.B) {
 	mr2 := miniredis.RunT(b)
 	rc2 := redis.NewClient(&redis.Options{Addr: mr2.Addr()})
 	b.Cleanup(func() { _ = rc2.Close() })
-	otherSvc, err := token.NewServiceFromKey(otherCfg, otherKey, rc2, zap.NewNop(), audit.NopLogger{})
+	otherSvc, err := token.NewServiceFromKey(otherCfg, config.OIDCConfig{}, otherKey, rc2, zap.NewNop(), audit.NopLogger{})
 	require.NoError(b, err)
 	wrongToken := issueToken(b, otherSvc) // signed with different key
 

--- a/internal/token/service.go
+++ b/internal/token/service.go
@@ -48,9 +48,6 @@ const (
 
 	// refreshKeyBytes is the number of random bytes for the refresh token key part.
 	refreshKeyBytes = 32
-
-	// issuer is the JWT issuer claim value.
-	issuer = "https://auth.qf.studio"
 )
 
 // UserLookup abstracts user retrieval for refresh-token role enrichment.
@@ -65,6 +62,7 @@ type Service struct {
 	audit         audit.EventLogger
 	redis         *redis.Client
 	cfg           config.JWTConfig
+	oidc          config.OIDCConfig
 	privateKey    crypto.Signer
 	publicKey     crypto.PublicKey
 	signingMethod jwt.SigningMethod
@@ -73,8 +71,10 @@ type Service struct {
 }
 
 // NewService creates a new token Service, loading the private key from the
-// path specified in cfg.PrivateKeyPath.
-func NewService(cfg config.JWTConfig, redisClient *redis.Client, logger *zap.Logger, auditor audit.EventLogger) (*Service, error) {
+// path specified in cfg.PrivateKeyPath. oidcCfg.IssuerURL is used as the JWT
+// `iss` claim for both access tokens and ID tokens; oidcCfg.IDTokenTTL is the
+// lifetime of tokens minted by IssueIDToken.
+func NewService(cfg config.JWTConfig, oidcCfg config.OIDCConfig, redisClient *redis.Client, logger *zap.Logger, auditor audit.EventLogger) (*Service, error) {
 	keyData, err := os.ReadFile(cfg.PrivateKeyPath)
 	if err != nil {
 		return nil, fmt.Errorf("read private key: %w", err)
@@ -95,6 +95,7 @@ func NewService(cfg config.JWTConfig, redisClient *redis.Client, logger *zap.Log
 		audit:         auditor,
 		redis:         redisClient,
 		cfg:           cfg,
+		oidc:          oidcCfg,
 		privateKey:    signer,
 		publicKey:     pub,
 		signingMethod: method,
@@ -104,7 +105,7 @@ func NewService(cfg config.JWTConfig, redisClient *redis.Client, logger *zap.Log
 
 // NewServiceFromKey creates a token Service from an already-parsed private key.
 // Useful for testing without filesystem access.
-func NewServiceFromKey(cfg config.JWTConfig, privateKey crypto.Signer, redisClient *redis.Client, logger *zap.Logger, auditor audit.EventLogger) (*Service, error) {
+func NewServiceFromKey(cfg config.JWTConfig, oidcCfg config.OIDCConfig, privateKey crypto.Signer, redisClient *redis.Client, logger *zap.Logger, auditor audit.EventLogger) (*Service, error) {
 	pub := privateKey.Public()
 	method, err := signingMethodForKey(privateKey, cfg.Algorithm)
 	if err != nil {
@@ -121,6 +122,7 @@ func NewServiceFromKey(cfg config.JWTConfig, privateKey crypto.Signer, redisClie
 		audit:         auditor,
 		redis:         redisClient,
 		cfg:           cfg,
+		oidc:          oidcCfg,
 		privateKey:    privateKey,
 		publicKey:     pub,
 		signingMethod: method,
@@ -342,7 +344,7 @@ func (s *Service) issueAccessToken(subject string, roles, scopes []string, clien
 	claims := &customClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject:   subject,
-			Issuer:    issuer,
+			Issuer:    s.oidc.IssuerURL,
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(s.cfg.AccessTokenTTL)),
 			ID:        jti,
@@ -368,6 +370,56 @@ func (s *Service) issueAccessToken(subject string, roles, scopes []string, clien
 	}
 
 	return accessTokenPrefix + signed, nil
+}
+
+// ── Internal: ID Token (OIDC) ────────────────────────────────────────────────
+
+// idTokenClaims represents an OpenID Connect ID Token (OIDC Core 1.0 §2).
+// Unlike access tokens, ID tokens carry no roles/scopes/client_type: they
+// identify the authenticated end-user to the relying party (the OIDC client),
+// not authorize resource access.
+type idTokenClaims struct {
+	jwt.RegisteredClaims
+	AuthTime int64  `json:"auth_time,omitempty"`
+	Nonce    string `json:"nonce,omitempty"`
+}
+
+// IssueIDToken mints an OpenID Connect ID Token (OIDC Core 1.0 §2) for the
+// given subject, identifying the relying party as the sole audience via
+// clientID (§2: "aud... MUST contain the OAuth 2.0 client_id of the Relying
+// Party"). nonce is echoed back verbatim if the authorization request
+// included one (§3.1.3.6, mitigates replay attacks); pass "" if absent.
+// authTime records when the end-user authenticated (§2, auth_time claim).
+// The token is signed with the same key/kid as access tokens and expires
+// after cfg.OIDC.IDTokenTTL (OIDC_ID_TOKEN_TTL).
+func (s *Service) IssueIDToken(_ context.Context, subject, clientID, nonce string, authTime time.Time) (string, error) {
+	jti, err := generateRandomID(jtiBytes)
+	if err != nil {
+		return "", fmt.Errorf("generate jti: %w", err)
+	}
+
+	now := time.Now()
+	claims := &idTokenClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   subject,
+			Issuer:    s.oidc.IssuerURL,
+			Audience:  jwt.ClaimStrings{clientID},
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(s.oidc.IDTokenTTL)),
+			ID:        jti,
+		},
+		AuthTime: authTime.Unix(),
+		Nonce:    nonce,
+	}
+
+	token := jwt.NewWithClaims(s.signingMethod, claims)
+	token.Header["kid"] = s.kid
+	signed, err := token.SignedString(s.privateKey)
+	if err != nil {
+		return "", fmt.Errorf("sign id token: %w", err)
+	}
+
+	return signed, nil
 }
 
 func (s *Service) parseAndVerifyJWT(rawToken string) (*customClaims, error) {

--- a/internal/token/service_test.go
+++ b/internal/token/service_test.go
@@ -82,12 +82,22 @@ func defaultCfg() config.JWTConfig {
 	}
 }
 
+// defaultOIDCCfg mirrors config.loadOIDC's defaults (GH-468: OIDC_ISSUER_URL
+// default is "https://auth.qf.studio", matching the value this constant used
+// to be hardcoded to in service.go before iss became config-driven).
+func defaultOIDCCfg() config.OIDCConfig {
+	return config.OIDCConfig{
+		IssuerURL:  "https://auth.qf.studio",
+		IDTokenTTL: 1 * time.Hour,
+	}
+}
+
 func newES256Service(t *testing.T) (*token.Service, *miniredis.Miniredis) {
 	t.Helper()
 	key := generateES256Key(t)
 	mr, rc := newTestRedis(t)
 	cfg := defaultCfg()
-	svc, err := token.NewServiceFromKey(cfg, key, rc, testLogger(), audit.NopLogger{})
+	svc, err := token.NewServiceFromKey(cfg, defaultOIDCCfg(), key, rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 	return svc, mr
 }
@@ -98,7 +108,7 @@ func newEdDSAService(t *testing.T) (*token.Service, *miniredis.Miniredis) {
 	mr, rc := newTestRedis(t)
 	cfg := defaultCfg()
 	cfg.Algorithm = "EdDSA"
-	svc, err := token.NewServiceFromKey(cfg, key, rc, testLogger(), audit.NopLogger{})
+	svc, err := token.NewServiceFromKey(cfg, defaultOIDCCfg(), key, rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 	return svc, mr
 }
@@ -114,7 +124,7 @@ func TestNewService_ES256FromFile(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.PrivateKeyPath = keyPath
 
-	svc, err := token.NewService(cfg, rc, testLogger(), audit.NopLogger{})
+	svc, err := token.NewService(cfg, defaultOIDCCfg(), rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 	require.NotNil(t, svc)
 }
@@ -129,7 +139,7 @@ func TestNewService_EdDSAFromFile(t *testing.T) {
 	cfg.Algorithm = "EdDSA"
 	cfg.PrivateKeyPath = keyPath
 
-	svc, err := token.NewService(cfg, rc, testLogger(), audit.NopLogger{})
+	svc, err := token.NewService(cfg, defaultOIDCCfg(), rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 	require.NotNil(t, svc)
 }
@@ -139,7 +149,7 @@ func TestNewService_InvalidKeyPath(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.PrivateKeyPath = "/nonexistent/key.pem"
 
-	_, err := token.NewService(cfg, rc, testLogger(), audit.NopLogger{})
+	_, err := token.NewService(cfg, defaultOIDCCfg(), rc, testLogger(), audit.NopLogger{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "read private key")
 }
@@ -154,7 +164,7 @@ func TestNewService_AlgorithmMismatch(t *testing.T) {
 	cfg.PrivateKeyPath = keyPath
 	cfg.Algorithm = "EdDSA" // ECDSA key with EdDSA algorithm
 
-	_, err := token.NewService(cfg, rc, testLogger(), audit.NopLogger{})
+	_, err := token.NewService(cfg, defaultOIDCCfg(), rc, testLogger(), audit.NopLogger{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "parse private key")
 }
@@ -262,7 +272,7 @@ func TestValidateToken_ExpiredToken(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.AccessTokenTTL = 1 * time.Millisecond // Very short TTL
 
-	svc, err := token.NewServiceFromKey(cfg, key, rc, testLogger(), audit.NopLogger{})
+	svc, err := token.NewServiceFromKey(cfg, defaultOIDCCfg(), key, rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -321,7 +331,7 @@ func TestIssueAccessToken_Audience(t *testing.T) {
 			cfg := defaultCfg()
 			cfg.Audience = tt.audience
 
-			svc, err := token.NewServiceFromKey(cfg, key, rc, testLogger(), audit.NopLogger{})
+			svc, err := token.NewServiceFromKey(cfg, defaultOIDCCfg(), key, rc, testLogger(), audit.NopLogger{})
 			require.NoError(t, err)
 
 			ctx := context.Background()
@@ -359,7 +369,7 @@ func TestValidateToken_AcceptsAudiencelessTokenWhenAudienceConfigured(t *testing
 	_, rc := newTestRedis(t)
 
 	issuerCfg := defaultCfg() // no Audience set
-	issuerSvc, err := token.NewServiceFromKey(issuerCfg, key, rc, testLogger(), audit.NopLogger{})
+	issuerSvc, err := token.NewServiceFromKey(issuerCfg, defaultOIDCCfg(), key, rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -369,12 +379,174 @@ func TestValidateToken_AcceptsAudiencelessTokenWhenAudienceConfigured(t *testing
 
 	validatorCfg := defaultCfg()
 	validatorCfg.Audience = []string{"https://api.qf.studio"}
-	validatorSvc, err := token.NewServiceFromKey(validatorCfg, key, rc, testLogger(), audit.NopLogger{})
+	validatorSvc, err := token.NewServiceFromKey(validatorCfg, defaultOIDCCfg(), key, rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 
 	claims, err := validatorSvc.ValidateToken(ctx, rawJWT)
 	require.NoError(t, err)
 	assert.Empty(t, claims.Audience)
+}
+
+// ── Issuer (GH-468) ──────────────────────────────────────────────────────────
+
+// TestIssueAccessToken_IssuerFromOIDCConfig verifies the `iss` claim on
+// issued access tokens tracks config.OIDCConfig.IssuerURL. Before GH-468,
+// `iss` was a hardcoded package constant, so overriding OIDC_ISSUER_URL had
+// no effect on issued tokens at all; this asserts that override now works.
+func TestIssueAccessToken_IssuerFromOIDCConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		issuerURL string
+	}{
+		{name: "default issuer", issuerURL: "https://auth.qf.studio"},
+		{name: "overridden issuer", issuerURL: "https://issuer.override.example"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := generateES256Key(t)
+			_, rc := newTestRedis(t)
+			cfg := defaultCfg()
+			oidcCfg := config.OIDCConfig{IssuerURL: tt.issuerURL, IDTokenTTL: time.Hour}
+
+			svc, err := token.NewServiceFromKey(cfg, oidcCfg, key, rc, testLogger(), audit.NopLogger{})
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			result, err := svc.IssueTokenPair(ctx, "user-123", nil, nil, domain.ClientTypeUser)
+			require.NoError(t, err)
+
+			rawJWT := strings.TrimPrefix(result.AccessToken, "qf_at_")
+			parser := jwtv5.NewParser()
+			jwtClaims := jwtv5.MapClaims{}
+			_, _, err = parser.ParseUnverified(rawJWT, jwtClaims)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.issuerURL, jwtClaims["iss"])
+		})
+	}
+}
+
+// ── IssueIDToken (GH-468) ────────────────────────────────────────────────────
+
+// idTokenTestClaims mirrors the (unexported) claims shape IssueIDToken
+// produces. auth_time and nonce aren't surfaced through domain.TokenClaims
+// (that type models access-token claims), so tests decode the raw JWT with
+// this local struct instead of reaching into the token package's internals.
+type idTokenTestClaims struct {
+	jwtv5.RegisteredClaims
+	AuthTime int64  `json:"auth_time,omitempty"`
+	Nonce    string `json:"nonce,omitempty"`
+}
+
+func TestIssueIDToken_ClaimsAndSignature(t *testing.T) {
+	key := generateES256Key(t)
+	_, rc := newTestRedis(t)
+	cfg := defaultCfg()
+	oidcCfg := config.OIDCConfig{IssuerURL: "https://auth.qf.studio", IDTokenTTL: 45 * time.Minute}
+
+	svc, err := token.NewServiceFromKey(cfg, oidcCfg, key, rc, testLogger(), audit.NopLogger{})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	authTime := time.Now().Add(-90 * time.Second).Truncate(time.Second)
+	idToken, err := svc.IssueIDToken(ctx, "user-123", "client-abc", "nonce-xyz", authTime)
+	require.NoError(t, err)
+	require.NotEmpty(t, idToken)
+
+	// Signature/alg verification: the ID token must be signed by the same
+	// key as access tokens. customClaims is a structural superset of the ID
+	// token's claims (both embed jwt.RegisteredClaims), so ValidateToken can
+	// cryptographically verify it directly.
+	claims, err := svc.ValidateToken(ctx, idToken)
+	require.NoError(t, err)
+	assert.Equal(t, "user-123", claims.Subject)
+	assert.Equal(t, []string{"client-abc"}, claims.Audience)
+
+	parser := jwtv5.NewParser()
+	tc := &idTokenTestClaims{}
+	parsedToken, _, err := parser.ParseUnverified(idToken, tc)
+	require.NoError(t, err)
+
+	assert.Equal(t, "ES256", parsedToken.Method.Alg())
+
+	kid, ok := parsedToken.Header["kid"].(string)
+	require.True(t, ok, "id token header must carry a kid")
+	jwks, err := svc.JWKS(ctx)
+	require.NoError(t, err)
+	keyMap, ok := jwks.Keys[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, keyMap["kid"], kid, "id token header kid must match the active JWKS key's kid")
+
+	assert.Equal(t, "https://auth.qf.studio", tc.Issuer)
+	assert.Equal(t, "user-123", tc.Subject)
+	assert.Equal(t, jwtv5.ClaimStrings{"client-abc"}, tc.Audience)
+	assert.Equal(t, "nonce-xyz", tc.Nonce)
+	assert.Equal(t, authTime.Unix(), tc.AuthTime)
+	require.NotNil(t, tc.IssuedAt)
+	require.NotNil(t, tc.ExpiresAt)
+	assert.InDelta(t, 45*time.Minute, tc.ExpiresAt.Sub(tc.IssuedAt.Time), float64(2*time.Second),
+		"id token TTL must come from OIDCConfig.IDTokenTTL")
+}
+
+func TestIssueIDToken_EdDSA(t *testing.T) {
+	key := generateEdDSAKey(t)
+	_, rc := newTestRedis(t)
+	cfg := defaultCfg()
+	cfg.Algorithm = "EdDSA"
+	oidcCfg := config.OIDCConfig{IssuerURL: "https://auth.qf.studio", IDTokenTTL: time.Hour}
+
+	svc, err := token.NewServiceFromKey(cfg, oidcCfg, key, rc, testLogger(), audit.NopLogger{})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	idToken, err := svc.IssueIDToken(ctx, "svc-456", "client-def", "", time.Now())
+	require.NoError(t, err)
+
+	claims, err := svc.ValidateToken(ctx, idToken)
+	require.NoError(t, err)
+	assert.Equal(t, "svc-456", claims.Subject)
+
+	parser := jwtv5.NewParser()
+	tc := &idTokenTestClaims{}
+	parsedToken, _, err := parser.ParseUnverified(idToken, tc)
+	require.NoError(t, err)
+	assert.Equal(t, "EdDSA", parsedToken.Method.Alg())
+}
+
+func TestIssueIDToken_NoNonceOmitsClaim(t *testing.T) {
+	svc, _ := newES256Service(t)
+	ctx := context.Background()
+
+	idToken, err := svc.IssueIDToken(ctx, "user-123", "client-abc", "", time.Now())
+	require.NoError(t, err)
+
+	parser := jwtv5.NewParser()
+	jwtClaims := jwtv5.MapClaims{}
+	_, _, err = parser.ParseUnverified(idToken, jwtClaims)
+	require.NoError(t, err)
+	assert.NotContains(t, jwtClaims, "nonce")
+}
+
+func TestIssueIDToken_UniqueJTIPerToken(t *testing.T) {
+	svc, _ := newES256Service(t)
+	ctx := context.Background()
+
+	first, err := svc.IssueIDToken(ctx, "user-123", "client-abc", "n1", time.Now())
+	require.NoError(t, err)
+	second, err := svc.IssueIDToken(ctx, "user-123", "client-abc", "n2", time.Now())
+	require.NoError(t, err)
+
+	parser := jwtv5.NewParser()
+	c1, c2 := &idTokenTestClaims{}, &idTokenTestClaims{}
+	_, _, err = parser.ParseUnverified(first, c1)
+	require.NoError(t, err)
+	_, _, err = parser.ParseUnverified(second, c2)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, c1.ID)
+	assert.NotEmpty(t, c2.ID)
+	assert.NotEqual(t, c1.ID, c2.ID)
 }
 
 // ── Revoke & IsRevoked ───────────────────────────────────────────────────────
@@ -430,7 +602,7 @@ func TestRevoke_ExpiredTokenNoBlocklist(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.AccessTokenTTL = 1 * time.Millisecond
 
-	svc, err := token.NewServiceFromKey(cfg, key, rc, testLogger(), audit.NopLogger{})
+	svc, err := token.NewServiceFromKey(cfg, defaultOIDCCfg(), key, rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -490,7 +662,7 @@ func TestRefresh_ExpiredRefreshToken(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.RefreshTokenTTL = 1 * time.Second
 
-	svc, err := token.NewServiceFromKey(cfg, key, rc, testLogger(), audit.NopLogger{})
+	svc, err := token.NewServiceFromKey(cfg, defaultOIDCCfg(), key, rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -514,7 +686,7 @@ func TestRefresh_SecretRotation(t *testing.T) {
 	oldCfg := defaultCfg()
 	oldCfg.SystemSecrets = []string{"old-secret"}
 
-	oldSvc, err := token.NewServiceFromKey(oldCfg, key, rc, testLogger(), audit.NopLogger{})
+	oldSvc, err := token.NewServiceFromKey(oldCfg, defaultOIDCCfg(), key, rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -525,7 +697,7 @@ func TestRefresh_SecretRotation(t *testing.T) {
 	newCfg := defaultCfg()
 	newCfg.SystemSecrets = []string{"new-secret", "old-secret"}
 
-	newSvc, err := token.NewServiceFromKey(newCfg, key, rc, testLogger(), audit.NopLogger{})
+	newSvc, err := token.NewServiceFromKey(newCfg, defaultOIDCCfg(), key, rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 
 	// Old refresh token should still validate with the new service.
@@ -786,7 +958,7 @@ func TestNewServiceFromKey_AlgorithmMismatch(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.Algorithm = "EdDSA"
 
-	_, err := token.NewServiceFromKey(cfg, key, rc, testLogger(), audit.NopLogger{})
+	_, err := token.NewServiceFromKey(cfg, defaultOIDCCfg(), key, rc, testLogger(), audit.NopLogger{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ECDSA")
 }
@@ -812,7 +984,7 @@ func TestNewService_ECKeyFile(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.PrivateKeyPath = path
 
-	svc, err := token.NewService(cfg, rc, testLogger(), audit.NopLogger{})
+	svc, err := token.NewService(cfg, defaultOIDCCfg(), rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 	require.NotNil(t, svc)
 }
@@ -878,7 +1050,7 @@ func newBenchES256Service(b *testing.B) *token.Service {
 		RefreshTokenTTL: 7 * 24 * time.Hour,
 		SystemSecrets:   []string{"bench-secret"},
 	}
-	svc, err := token.NewServiceFromKey(cfg, key, rc, zap.NewNop(), audit.NopLogger{})
+	svc, err := token.NewServiceFromKey(cfg, defaultOIDCCfg(), key, rc, zap.NewNop(), audit.NopLogger{})
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -993,7 +1165,7 @@ func TestIssueTokenPair_NoSystemSecretsError(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.SystemSecrets = nil
 
-	svc, err := token.NewServiceFromKey(cfg, key, rc, testLogger(), audit.NopLogger{})
+	svc, err := token.NewServiceFromKey(cfg, defaultOIDCCfg(), key, rc, testLogger(), audit.NopLogger{})
 	require.NoError(t, err)
 
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-468.

Closes #468

## Changes

In `internal/token/service.go`, replace the hardcoded `https://auth.qf.studio` constant used for `iss` with a value sourced from `OIDCConfig.IssuerURL`, and add `IssueIDToken(subject, audience/clientID, nonce, authTime, ...)` signed with the existing JWT key/kid and TTL from `OIDCConfig.IDTokenTTL`. In `internal/config/config.go`, change the `OIDC_ISSUER_URL` default from `http://localhost:4000` to `https://auth.qf.studio` so wire behavior is unchanged unless explicitly overridden. Update existing token unit tests; add id_token issuance tests (claims, alg, kid, TTL, aud, nonce). Call out in the PR description that overriding `OIDC_ISSUER_URL` will now actually change `iss` (previously a no-op).