### PR TITLE
GH-473: feat: harden token-type separation: gRPC validation accepts ID tokens as ac...

### DIFF
--- a/internal/domain/sentinel_errors.go
+++ b/internal/domain/sentinel_errors.go
@@ -22,6 +22,11 @@ var (
 	ErrTokenRevoked = errors.New("token revoked")
 	ErrTokenInvalid = errors.New("token invalid")
 
+	// ErrNotAccessToken indicates a token was cryptographically valid but is
+	// not an access token (e.g. an OIDC ID token), identified by the absence
+	// of the client_type claim that every access token carries (GH-473).
+	ErrNotAccessToken = errors.New("token is not an access token")
+
 	// Client errors.
 	ErrClientNotFound  = errors.New("client not found")
 	ErrClientSuspended = errors.New("client suspended")

--- a/internal/grpc/auth_service.go
+++ b/internal/grpc/auth_service.go
@@ -51,7 +51,10 @@ func (s *AuthServiceServer) ValidateToken(ctx context.Context, req *authv1.Valid
 		return nil, status.Error(codes.InvalidArgument, "access_token is required")
 	}
 
-	raw := strings.TrimPrefix(req.GetAccessToken(), accessTokenPrefix)
+	raw, ok := strings.CutPrefix(req.GetAccessToken(), accessTokenPrefix)
+	if !ok {
+		return nil, status.Error(codes.Unauthenticated, "invalid token format")
+	}
 	claims, err := s.tokenSvc.ValidateToken(ctx, raw)
 	if err != nil {
 		return &authv1.ValidateTokenResponse{Valid: false}, nil
@@ -110,7 +113,10 @@ func (s *AuthServiceServer) IntrospectToken(ctx context.Context, req *authv1.Int
 		return nil, status.Error(codes.InvalidArgument, "access_token is required")
 	}
 
-	raw := strings.TrimPrefix(req.GetAccessToken(), accessTokenPrefix)
+	raw, ok := strings.CutPrefix(req.GetAccessToken(), accessTokenPrefix)
+	if !ok {
+		return nil, status.Error(codes.Unauthenticated, "invalid token format")
+	}
 	claims, err := s.tokenSvc.ValidateToken(ctx, raw)
 	if err != nil {
 		return &authv1.IntrospectTokenResponse{Active: false}, nil

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -248,8 +249,11 @@ func TestValidateToken_InvalidToken(t *testing.T) {
 	deps, _ := defaultTestDeps(t)
 	client, _ := setupBufConn(t, deps)
 
+	// Prefixed but not a well-formed JWT: exercises the ValidateToken(claims
+	// parse) failure path, distinct from the qf_at_ prefix gate (GH-473)
+	// covered by TestValidateToken_MissingPrefix_Unauthenticated.
 	resp, err := client.ValidateToken(context.Background(), &authv1.ValidateTokenRequest{
-		AccessToken: "invalid-token",
+		AccessToken: "qf_at_invalid-token",
 	})
 	require.NoError(t, err)
 	assert.False(t, resp.GetValid())
@@ -262,6 +266,42 @@ func TestValidateToken_EmptyToken(t *testing.T) {
 	_, err := client.ValidateToken(context.Background(), &authv1.ValidateTokenRequest{})
 	require.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// TestValidateToken_MissingPrefix_Unauthenticated verifies that a valid
+// access token presented WITHOUT its qf_at_ prefix is rejected outright
+// (GH-473): gRPC must match the HTTP middleware's requirement that the
+// prefix be present, rather than silently accepting a bare JWT.
+func TestValidateToken_MissingPrefix_Unauthenticated(t *testing.T) {
+	deps, tokenSvc := defaultTestDeps(t)
+	client, _ := setupBufConn(t, deps)
+
+	result, err := tokenSvc.IssueTokenPair(context.Background(), "user-123", []string{"user"}, nil, domain.ClientTypeUser)
+	require.NoError(t, err)
+
+	unprefixed := strings.TrimPrefix(result.AccessToken, "qf_at_")
+	_, err = client.ValidateToken(context.Background(), &authv1.ValidateTokenRequest{
+		AccessToken: unprefixed,
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+// TestValidateToken_IDToken_Unauthenticated verifies that an OIDC ID token
+// (which never carries the qf_at_ prefix) cannot be used to authenticate
+// via gRPC token validation (GH-473).
+func TestValidateToken_IDToken_Unauthenticated(t *testing.T) {
+	deps, tokenSvc := defaultTestDeps(t)
+	client, _ := setupBufConn(t, deps)
+
+	idToken, err := tokenSvc.IssueIDToken(context.Background(), "user-123", "client-abc", "", time.Now())
+	require.NoError(t, err)
+
+	_, err = client.ValidateToken(context.Background(), &authv1.ValidateTokenRequest{
+		AccessToken: idToken,
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
 }
 
 // ── GetUser tests ────────────────────────────────────────────────────────────
@@ -357,8 +397,11 @@ func TestIntrospectToken_Invalid(t *testing.T) {
 	deps, _ := defaultTestDeps(t)
 	client, _ := setupBufConn(t, deps)
 
+	// Prefixed but not a well-formed JWT: exercises the ValidateToken(claims
+	// parse) failure path, distinct from the qf_at_ prefix gate (GH-473)
+	// covered by TestIntrospectToken_MissingPrefix_Unauthenticated.
 	resp, err := client.IntrospectToken(context.Background(), &authv1.IntrospectTokenRequest{
-		AccessToken: "bad-token",
+		AccessToken: "qf_at_bad-token",
 	})
 	require.NoError(t, err)
 	assert.False(t, resp.GetActive())
@@ -379,6 +422,40 @@ func TestIntrospectToken_Revoked(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.False(t, resp.GetActive())
+}
+
+// TestIntrospectToken_MissingPrefix_Unauthenticated mirrors
+// TestValidateToken_MissingPrefix_Unauthenticated for the IntrospectToken
+// RPC, which strips the same qf_at_ prefix (GH-473).
+func TestIntrospectToken_MissingPrefix_Unauthenticated(t *testing.T) {
+	deps, tokenSvc := defaultTestDeps(t)
+	client, _ := setupBufConn(t, deps)
+
+	result, err := tokenSvc.IssueTokenPair(context.Background(), "user-123", []string{"user"}, nil, domain.ClientTypeUser)
+	require.NoError(t, err)
+
+	unprefixed := strings.TrimPrefix(result.AccessToken, "qf_at_")
+	_, err = client.IntrospectToken(context.Background(), &authv1.IntrospectTokenRequest{
+		AccessToken: unprefixed,
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+// TestIntrospectToken_IDToken_Unauthenticated verifies that an OIDC ID token
+// is rejected by IntrospectToken as well as ValidateToken (GH-473).
+func TestIntrospectToken_IDToken_Unauthenticated(t *testing.T) {
+	deps, tokenSvc := defaultTestDeps(t)
+	client, _ := setupBufConn(t, deps)
+
+	idToken, err := tokenSvc.IssueIDToken(context.Background(), "user-123", "client-abc", "", time.Now())
+	require.NoError(t, err)
+
+	_, err = client.IntrospectToken(context.Background(), &authv1.IntrospectTokenRequest{
+		AccessToken: idToken,
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
 }
 
 // ── Health tests ─────────────────────────────────────────────────────────────

--- a/internal/token/service.go
+++ b/internal/token/service.go
@@ -293,10 +293,19 @@ func (s *Service) JWKS(_ context.Context) (*api.JWKSResponse, error) {
 
 // ValidateToken parses and cryptographically validates the raw JWT (qf_at_ prefix
 // already stripped), returning its claims. Implements middleware.TokenValidator.
+//
+// Only access tokens are accepted: every access token carries a client_type
+// claim, while OIDC ID tokens (IssueIDToken) never do, so a token lacking it
+// is rejected with domain.ErrNotAccessToken even if its signature is valid
+// (GH-473 defense-in-depth against token-type confusion).
 func (s *Service) ValidateToken(_ context.Context, rawToken string) (*domain.TokenClaims, error) {
 	claims, err := s.parseAndVerifyJWT(rawToken)
 	if err != nil {
 		return nil, err
+	}
+
+	if claims.ClientType == "" {
+		return nil, fmt.Errorf("validate token: %w", domain.ErrNotAccessToken)
 	}
 
 	return claimsToDomain(claims)

--- a/internal/token/service_test.go
+++ b/internal/token/service_test.go
@@ -296,6 +296,40 @@ func TestValidateToken_GarbageInput(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestValidateToken_RejectsIDToken verifies that a cryptographically valid
+// OIDC ID token (IssueIDToken) is rejected by ValidateToken with
+// domain.ErrNotAccessToken, since ID tokens carry no client_type claim
+// (GH-473: gRPC and other ValidateToken callers must not treat an ID token
+// as an authenticated access-token subject).
+func TestValidateToken_RejectsIDToken(t *testing.T) {
+	svc, _ := newES256Service(t)
+	ctx := context.Background()
+
+	idToken, err := svc.IssueIDToken(ctx, "user-123", "client-abc", "", time.Now())
+	require.NoError(t, err)
+
+	_, err = svc.ValidateToken(ctx, idToken)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrNotAccessToken)
+}
+
+// TestValidateToken_AccessTokenOK is a control alongside
+// TestValidateToken_RejectsIDToken: a real access token (which always
+// carries client_type) must continue to validate successfully.
+func TestValidateToken_AccessTokenOK(t *testing.T) {
+	svc, _ := newES256Service(t)
+	ctx := context.Background()
+
+	result, err := svc.IssueTokenPair(ctx, "user-123", []string{"user"}, nil, domain.ClientTypeUser)
+	require.NoError(t, err)
+
+	rawJWT := strings.TrimPrefix(result.AccessToken, "qf_at_")
+	claims, err := svc.ValidateToken(ctx, rawJWT)
+	require.NoError(t, err)
+	assert.Equal(t, "user-123", claims.Subject)
+	assert.Equal(t, domain.ClientTypeUser, claims.ClientType)
+}
+
 func TestValidateToken_WrongSigningKey(t *testing.T) {
 	svc1, _ := newES256Service(t)
 	ctx := context.Background()
@@ -454,19 +488,17 @@ func TestIssueIDToken_ClaimsAndSignature(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, idToken)
 
-	// Signature/alg verification: the ID token must be signed by the same
-	// key as access tokens. customClaims is a structural superset of the ID
-	// token's claims (both embed jwt.RegisteredClaims), so ValidateToken can
-	// cryptographically verify it directly.
-	claims, err := svc.ValidateToken(ctx, idToken)
-	require.NoError(t, err)
-	assert.Equal(t, "user-123", claims.Subject)
-	assert.Equal(t, []string{"client-abc"}, claims.Audience)
-
-	parser := jwtv5.NewParser()
+	// Signature/alg verification: ID tokens carry no client_type claim, so
+	// ValidateToken now rejects them (GH-473). Verify the signature directly
+	// against the service's own key instead, mirroring
+	// internal/oidc/oidc_flow_integration_test.go's idTokenIssuer helper.
 	tc := &idTokenTestClaims{}
-	parsedToken, _, err := parser.ParseUnverified(idToken, tc)
-	require.NoError(t, err)
+	parsedToken, err := jwtv5.ParseWithClaims(idToken, tc, func(*jwtv5.Token) (interface{}, error) {
+		return &key.PublicKey, nil
+	}, jwtv5.WithValidMethods([]string{"ES256"}))
+	require.NoError(t, err, "parse/verify ID token")
+	assert.Equal(t, "user-123", tc.Subject)
+	assert.Equal(t, jwtv5.ClaimStrings{"client-abc"}, tc.Audience)
 
 	assert.Equal(t, "ES256", parsedToken.Method.Alg())
 
@@ -503,14 +535,14 @@ func TestIssueIDToken_EdDSA(t *testing.T) {
 	idToken, err := svc.IssueIDToken(ctx, "svc-456", "client-def", "", time.Now())
 	require.NoError(t, err)
 
-	claims, err := svc.ValidateToken(ctx, idToken)
-	require.NoError(t, err)
-	assert.Equal(t, "svc-456", claims.Subject)
-
-	parser := jwtv5.NewParser()
+	// ID tokens carry no client_type claim, so ValidateToken rejects them
+	// (GH-473); verify the signature directly against the service's key.
 	tc := &idTokenTestClaims{}
-	parsedToken, _, err := parser.ParseUnverified(idToken, tc)
-	require.NoError(t, err)
+	parsedToken, err := jwtv5.ParseWithClaims(idToken, tc, func(*jwtv5.Token) (interface{}, error) {
+		return key.Public(), nil
+	}, jwtv5.WithValidMethods([]string{"EdDSA"}))
+	require.NoError(t, err, "parse/verify ID token")
+	assert.Equal(t, "svc-456", tc.Subject)
 	assert.Equal(t, "EdDSA", parsedToken.Method.Alg())
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-473.

Closes #473

## Changes

GitHub Issue GH-473: Harden token-type separation: gRPC validation accepts ID tokens as access tokens

# GH-473: Harden token-type separation (gRPC + ValidateToken)

**Created:** 2026-07-27
**Issue:** #473

## Context

Since GH-468, `token.Service` mints two JWT types with the same key/kid:

- **Access tokens**: `qf_at_` prefix; claims include roles/scopes/`client_type`; `aud` = `JWT_AUDIENCE` (when set)
- **ID tokens** (`IssueIDToken`): no prefix; no roles/scopes/`client_type`; `aud` = OIDC client_id

HTTP middleware requires the `qf_at_` prefix (`internal/middleware/auth.go:57`), but gRPC validation (`internal/grpc/auth_service.go:54,113`) only `strings.TrimPrefix`es it, and `token.Service.ValidateToken` does not distinguish token types — a valid ID token passes gRPC validation as an authenticated subject with empty roles/scopes. With the OIDC provider live (GH-431), ID tokens now reach relying parties, including future approved third-party clients.

## Implementation Plan

1. `internal/grpc/auth_service.go` (both call sites, ~line 54 and ~113): require the `qf_at_` prefix — return `codes.Unauthenticated` when absent — then strip it. Do not accept bare JWTs.
2. `internal/token/service.go` `ValidateToken`: after parse/verify, reject tokens whose `client_type` claim is empty (every access token carries it; ID tokens never do). New sentinel error (e.g. `ErrNotAccessToken`), wrapped with context.
3. Update existing tests that pass unprefixed or ID tokens through `ValidateToken`:
   - `TestIssueIDToken_ClaimsAndSignature` and `TestIssueIDToken_EdDSA` (`internal/token/service_test.go`) currently verify the ID token signature via `ValidateToken` — switch to `jwt.ParseWithClaims` against the service public key (pattern already in `internal/oidc/oidc_flow_integration_test.go` `idTokenIssuer`).
   - Audit other tests calling `ValidateToken` with raw JWTs lacking `client_type` and update them to mint proper access tokens.
4. New negative tests:
   - gRPC: valid access token WITHOUT prefix → `Unauthenticated`; ID token → `Unauthenticated`; prefixed access token → OK.
   - `ValidateToken`: ID token → rejected with the new sentinel; access token → OK.

## Technical Decisions

- Options considered: (1) RFC 9068 `typ: "at+jwt"` header on access tokens (wire change, consumer migration needed), (2) strict prefix at gRPC, (3) `client_type` claims gate. Chosen: **(2) + (3)** — defense-in-depth without changing the token wire format. (1) deferred to a future issue with a consumer migration window.
- Access tokens have carried `client_type` since the claim's introduction; access-token TTL is 15m, so any rotation hazard window after deploy is ≤15m.
- Auth flows hand out tokens with the prefix intact, so requiring it at gRPC matches HTTP middleware behavior. Breaking only for consumers that manually strip the prefix before gRPC introspection (none known).
- `pkg/authclient` SDK local validation is out of scope: SDK consumers should enforce `aud` (`JWT_AUDIENCE`), which already distinguishes access tokens from ID tokens (`aud` = client_id).

## Dependencies

None. All prerequisite code is on main (GH-431 merged 2026-07-27).

## Verify

- `go test ./internal/token ./internal/grpc ./internal/middleware -race`
- Full suite: `go test ./...` (OIDC integration tests require Docker)
- An ID token produced by the OIDC flow no longer validates via gRPC (covered by the new negative test)

## Done

- gRPC validation rejects unprefixed tokens and ID tokens
- `ValidateToken` rejects tokens lacking `client_type`
- Existing tests updated; new negative tests added
- No changes to token wire format, HTTP middleware behavior for valid tokens, or the SDK