### PR TITLE
GH-478: feat(auth): signup email-verification — token issuance in Register + POST /auth/verify-email

### DIFF
--- a/.agent/tasks/gh-478.md
+++ b/.agent/tasks/gh-478.md
@@ -1,0 +1,37 @@
+# GH-478
+
+**Created:** 2026-07-29
+
+## Problem
+
+GitHub Issue GH-478: feat(auth): signup email-verification — token issuance in Register + POST /auth/verify-email
+
+## Context
+
+Signup email-verification is dead scaffolding today: the `users` table has `email_verified`/`email_verify_token`/`email_verify_token_expires_at`, the repository has `SetEmailVerifyToken` (`internal/storage/user_repository.go:149`) and `VerifyEmail` (`:166-174`), and `domain.VerifyEmailRequest` exists (`internal/domain/validation.go:82`) — but `Register` (`internal/auth/service.go:100-149`) never issues a token and no route or handler exists in `internal/api/router.go`.
+
+Depends on #477 (EmailSender wiring) — must merge first.
+
+## Task
+
+- `Register`: generate a token (32-byte random hex, same idiom as the reset token), persist via `SetEmailVerifyToken` with 24h expiry, send the verification link `${EMAIL_VERIFY_URL_BASE}?token=<token>` — new env `EMAIL_VERIFY_URL_BASE`, validated when `EMAIL_ENABLED=true`. Send failure logs + audits and does **not** fail registration.
+- `POST /auth/verify-email` `{token}` → `VerifyEmail`; 200 on success, idempotent 200 if already verified, 400 on invalid/expired.
+- Login is **not** gated on verification in v1 (informational only — must not block dogfood or design-partner flows). State this in a code comment where tempting to enforce.
+
+## Acceptance criteria
+
+- Register issues a token and triggers exactly one send (fake sender); registration succeeds when the sender errors.
+- Verify endpoint table-tested: happy, expired, invalid, already-verified.
+- `EMAIL_ENABLED=false`: ConsoleSender logs, registration flow unchanged.
+- Existing register/login tests stay green.
+
+## Non-goals
+
+Resend-verification endpoint, verification enforcement/gating, frontend, changing MFA.
+
+## Refs
+
+#477 · qf-studio/pilot `.agent/system/saas-asset-research.md` § auth-service-email-wiring
+
+## Acceptance Criteria
+

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ All configuration is via environment variables. See [`internal/config/config.go`
 | `EMAIL_API_KEY` | _(empty)_ | Email service API key (required when `EMAIL_ENABLED=true`) |
 | `EMAIL_SENDER_ADDRESS` | _(empty)_ | From address for outgoing mail (required when `EMAIL_ENABLED=true`) |
 | `PASSWORD_RESET_URL_BASE` | _(empty)_ | Base URL password reset links are built from: `<base>?token=<token>` (required when `EMAIL_ENABLED=true`) |
+| `EMAIL_VERIFY_URL_BASE` | _(empty)_ | Base URL email verification links are built from: `<base>?token=<token>` (required when `EMAIL_ENABLED=true`) |
 | `DPOP_ENABLED` | `false` | Enable DPoP proof binding |
 | `DPOP_NONCE_TTL` | `5m` | DPoP nonce lifetime |
 | `DPOP_JTI_WINDOW` | `1m` | DPoP replay window |

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -107,16 +107,17 @@ func run(log *zap.Logger, cfg *config.Config) error {
 	}
 
 	authSvc := auth.NewService(auth.ServiceDeps{
-		Redis:        redisClient,
-		Logger:       log,
-		Auditor:      auditSvc,
-		Users:        userRepo,
-		Tokens:       refreshTokenRepo,
-		Issuer:       tokenSvc,
-		Hasher:       hasher,
-		Breaches:     hibpClient,
-		Email:        emailSender,
-		ResetURLBase: cfg.Email.PasswordResetURLBase,
+		Redis:         redisClient,
+		Logger:        log,
+		Auditor:       auditSvc,
+		Users:         userRepo,
+		Tokens:        refreshTokenRepo,
+		Issuer:        tokenSvc,
+		Hasher:        hasher,
+		Breaches:      hibpClient,
+		Email:         emailSender,
+		ResetURLBase:  cfg.Email.PasswordResetURLBase,
+		VerifyURLBase: cfg.Email.EmailVerifyURLBase,
 	})
 
 	// ── Session ──────────────────────────────────────────────────────────

--- a/internal/api/auth_handlers.go
+++ b/internal/api/auth_handlers.go
@@ -84,6 +84,21 @@ func (h *AuthHandlers) ConfirmPasswordReset(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "Password has been reset"})
 }
 
+// VerifyEmail handles POST /auth/verify-email.
+func (h *AuthHandlers) VerifyEmail(c *gin.Context) {
+	req := c.MustGet("validated_request").(*domain.VerifyEmailRequest)
+
+	// Any failure (unknown, expired) maps to 400 — verification tokens aren't
+	// an enumeration risk the way password reset is, so there's no need to
+	// mask the outcome. Success is idempotent: already-verified users also get 200.
+	if err := h.auth.VerifyEmail(c.Request.Context(), req.Token); err != nil {
+		domain.RespondWithError(c, http.StatusBadRequest, domain.CodeBadRequest, "invalid or expired verification token")
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Email verified"})
+}
+
 // Me handles GET /auth/me.
 func (h *AuthHandlers) Me(c *gin.Context) {
 	userID := c.GetString("user_id")

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -92,6 +92,7 @@ func NewPublicRouter(svc *Services, mw *MiddlewareStack, healthSvc *health.Servi
 		auth.POST("/login", ValidateReq(v, &domain.LoginRequest{}), authH.Login)
 		auth.POST("/token", ValidateReq(v, &domain.TokenRequest{}), tokenH.Token)
 		auth.POST("/revoke", ValidateReq(v, &domain.RevokeRequest{}), tokenH.Revoke)
+		auth.POST("/verify-email", ValidateReq(v, &domain.VerifyEmailRequest{}), authH.VerifyEmail)
 
 		pw := auth.Group("/password")
 		pw.POST("/reset", ValidateReq(v, &domain.PasswordResetRequest{}), authH.ResetPassword)
@@ -191,6 +192,8 @@ func ValidateReq(v *validator.Validate, zero interface{}) gin.HandlerFunc {
 		return domain.ValidateRequest(v, func() interface{} { return &domain.PasswordResetConfirmRequest{} })
 	case *domain.PasswordChangeRequest:
 		return domain.ValidateRequest(v, func() interface{} { return &domain.PasswordChangeRequest{} })
+	case *domain.VerifyEmailRequest:
+		return domain.ValidateRequest(v, func() interface{} { return &domain.VerifyEmailRequest{} })
 	default:
 		log.Printf("ERROR: unsupported request type for validation middleware: %T", zero)
 		return func(c *gin.Context) {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -29,6 +29,7 @@ type mockAuthService struct {
 	loginFn                func(ctx context.Context, email, password string) (*api.AuthResult, error)
 	resetPasswordFn        func(ctx context.Context, email string) error
 	confirmPasswordResetFn func(ctx context.Context, token, newPassword string) error
+	verifyEmailFn          func(ctx context.Context, token string) error
 	getMeFn                func(ctx context.Context, userID string) (*api.UserInfo, error)
 	changePasswordFn       func(ctx context.Context, userID, oldPassword, newPassword string) error
 	logoutFn               func(ctx context.Context, userID, token string) error
@@ -64,6 +65,13 @@ func (m *mockAuthService) ResetPassword(ctx context.Context, email string) error
 func (m *mockAuthService) ConfirmPasswordReset(ctx context.Context, token, newPassword string) error {
 	if m.confirmPasswordResetFn != nil {
 		return m.confirmPasswordResetFn(ctx, token, newPassword)
+	}
+	return nil
+}
+
+func (m *mockAuthService) VerifyEmail(ctx context.Context, token string) error {
+	if m.verifyEmailFn != nil {
+		return m.verifyEmailFn(ctx, token)
 	}
 	return nil
 }
@@ -345,6 +353,70 @@ func TestPasswordResetConfirm_InvalidToken(t *testing.T) {
 	w := doRequest(router, http.MethodPost, "/auth/password/reset/confirm", body)
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// --- Email verification tests ---
+
+func TestVerifyEmail_Success(t *testing.T) {
+	router := newTestRouter(&mockAuthService{}, &mockTokenService{})
+
+	body := map[string]string{"token": "valid-verify-token"}
+	w := doRequest(router, http.MethodPost, "/auth/verify-email", body)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestVerifyEmail_AlreadyVerified_StillOK(t *testing.T) {
+	authSvc := &mockAuthService{
+		verifyEmailFn: func(_ context.Context, _ string) error {
+			return nil // already-verified is idempotent success at the service layer.
+		},
+	}
+	router := newTestRouter(authSvc, &mockTokenService{})
+
+	body := map[string]string{"token": "already-used-token"}
+	w := doRequest(router, http.MethodPost, "/auth/verify-email", body)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestVerifyEmail_ExpiredToken(t *testing.T) {
+	authSvc := &mockAuthService{
+		verifyEmailFn: func(_ context.Context, _ string) error {
+			return fmt.Errorf("verify email: token expired")
+		},
+	}
+	router := newTestRouter(authSvc, &mockTokenService{})
+
+	body := map[string]string{"token": "expired-token"}
+	w := doRequest(router, http.MethodPost, "/auth/verify-email", body)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestVerifyEmail_InvalidToken(t *testing.T) {
+	authSvc := &mockAuthService{
+		verifyEmailFn: func(_ context.Context, _ string) error {
+			return fmt.Errorf("verify email: not found")
+		},
+	}
+	router := newTestRouter(authSvc, &mockTokenService{})
+
+	body := map[string]string{"token": "bogus-token"}
+	w := doRequest(router, http.MethodPost, "/auth/verify-email", body)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestVerifyEmail_MissingToken(t *testing.T) {
+	router := newTestRouter(&mockAuthService{}, &mockTokenService{})
+
+	body := map[string]string{}
+	w := doRequest(router, http.MethodPost, "/auth/verify-email", body)
+
+	// Request-level validation (missing required field) is a 422, distinct
+	// from the service-level "invalid/expired token" 400s above.
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
 }
 
 // --- Token endpoint tests ---

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -41,6 +41,7 @@ type AuthService interface {
 	Login(ctx context.Context, email, password string) (*AuthResult, error)
 	ResetPassword(ctx context.Context, email string) error
 	ConfirmPasswordReset(ctx context.Context, token, newPassword string) error
+	VerifyEmail(ctx context.Context, token string) error
 	GetMe(ctx context.Context, userID string) (*UserInfo, error)
 	ChangePassword(ctx context.Context, userID, oldPassword, newPassword string) error
 	Logout(ctx context.Context, userID, token string) error

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -21,6 +21,8 @@ const (
 	EventPasswordReset            = "password_reset"
 	EventPasswordResetConfm       = "password_reset_confirm"
 	EventPasswordResetEmailFailed = "password_reset_email_failed"
+	EventEmailVerifyEmailFailed   = "email_verify_email_failed"
+	EventEmailVerified            = "email_verified"
 	EventPasswordExpired          = "password_expired"
 	EventHashUpgraded             = "hash_upgraded"
 	EventPasswordReused           = "password_reused"

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 
@@ -31,6 +32,9 @@ const (
 
 	// resetTokenBytes is the number of random bytes in a reset token (32 bytes = 64 hex chars).
 	resetTokenBytes = 32
+
+	// verifyTokenTTL is how long an email verification token remains valid.
+	verifyTokenTTL = 24 * time.Hour
 )
 
 // TokenIssuer abstracts token pair creation for the auth service.
@@ -50,50 +54,53 @@ type MFAChecker interface {
 // Service implements api.AuthService with Redis-backed password reset tokens
 // and PostgreSQL-backed user authentication.
 type Service struct {
-	redis        *redis.Client
-	logger       *zap.Logger
-	audit        audit.EventLogger
-	users        storage.UserRepository
-	tokens       storage.RefreshTokenRepository
-	issuer       TokenIssuer
-	hasher       password.Hasher
-	breaches     hibp.BreachChecker
-	mfa          MFAChecker
-	policy       *password.PolicyValidator
-	email        email.EmailSender
-	resetURLBase string
+	redis         *redis.Client
+	logger        *zap.Logger
+	audit         audit.EventLogger
+	users         storage.UserRepository
+	tokens        storage.RefreshTokenRepository
+	issuer        TokenIssuer
+	hasher        password.Hasher
+	breaches      hibp.BreachChecker
+	mfa           MFAChecker
+	policy        *password.PolicyValidator
+	email         email.EmailSender
+	resetURLBase  string
+	verifyURLBase string
 }
 
 // ServiceDeps groups the dependencies needed to construct a Service. Using a
 // struct here keeps NewService's call sites readable now that email delivery
 // has been added on top of the existing 8 constructor parameters.
 type ServiceDeps struct {
-	Redis        *redis.Client
-	Logger       *zap.Logger
-	Auditor      audit.EventLogger
-	Users        storage.UserRepository
-	Tokens       storage.RefreshTokenRepository
-	Issuer       TokenIssuer
-	Hasher       password.Hasher
-	Breaches     hibp.BreachChecker
-	Email        email.EmailSender
-	ResetURLBase string // base URL password-reset links are built from: "<ResetURLBase>?token=<token>"
+	Redis         *redis.Client
+	Logger        *zap.Logger
+	Auditor       audit.EventLogger
+	Users         storage.UserRepository
+	Tokens        storage.RefreshTokenRepository
+	Issuer        TokenIssuer
+	Hasher        password.Hasher
+	Breaches      hibp.BreachChecker
+	Email         email.EmailSender
+	ResetURLBase  string // base URL password-reset links are built from: "<ResetURLBase>?token=<token>"
+	VerifyURLBase string // base URL email-verification links are built from: "<VerifyURLBase>?token=<token>"
 }
 
 // NewService creates a new auth Service.
 func NewService(deps ServiceDeps) *Service {
 	return &Service{
-		redis:        deps.Redis,
-		logger:       deps.Logger,
-		audit:        deps.Auditor,
-		users:        deps.Users,
-		tokens:       deps.Tokens,
-		issuer:       deps.Issuer,
-		hasher:       deps.Hasher,
-		breaches:     deps.Breaches,
-		email:        deps.Email,
-		resetURLBase: deps.ResetURLBase,
-		policy:       password.NewPolicyValidator(password.DefaultPolicy(), deps.Hasher),
+		redis:         deps.Redis,
+		logger:        deps.Logger,
+		audit:         deps.Auditor,
+		users:         deps.Users,
+		tokens:        deps.Tokens,
+		issuer:        deps.Issuer,
+		hasher:        deps.Hasher,
+		breaches:      deps.Breaches,
+		email:         deps.Email,
+		resetURLBase:  deps.ResetURLBase,
+		verifyURLBase: deps.VerifyURLBase,
+		policy:        password.NewPolicyValidator(password.DefaultPolicy(), deps.Hasher),
 	}
 }
 
@@ -146,6 +153,11 @@ func (s *Service) Register(ctx context.Context, email, pwd, name string) (*api.U
 		}
 	}
 
+	// Issue an email-verification token and send the link. This is best-effort:
+	// a failure to generate, persist, or send the token must not fail
+	// registration — the account is fully usable unverified (see Login).
+	s.issueEmailVerification(ctx, tenantID, created)
+
 	info := &api.UserInfo{
 		ID:    created.ID,
 		Email: created.Email,
@@ -158,6 +170,65 @@ func (s *Service) Register(ctx context.Context, email, pwd, name string) (*api.U
 		Metadata: map[string]string{"email": email},
 	})
 	return info, nil
+}
+
+// issueEmailVerification generates a verification token, persists it with a
+// 24h expiry, and emails the verification link. Every failure mode (token
+// generation, persistence, or delivery) is logged and audited but swallowed —
+// registration must succeed regardless, per GH-478.
+func (s *Service) issueEmailVerification(ctx context.Context, tenantID uuid.UUID, user *domain.User) {
+	token, err := generateResetToken()
+	if err != nil {
+		s.logger.Error("failed to generate email verify token", zap.String("user_id", user.ID), zap.Error(err))
+		return
+	}
+
+	expiresAt := time.Now().UTC().Add(verifyTokenTTL)
+	if err := s.users.SetEmailVerifyToken(ctx, tenantID, user.ID, token, expiresAt); err != nil {
+		s.logger.Error("failed to persist email verify token", zap.String("user_id", user.ID), zap.Error(err))
+		return
+	}
+
+	if s.email == nil {
+		return
+	}
+
+	link := s.verifyURLBase + "?token=" + token
+	msg := email.Message{
+		To:      user.Email,
+		Subject: "Verify your email",
+		Body:    fmt.Sprintf("Use the link below to verify your email address:\n\n%s\n\nThis link expires in %s.", link, verifyTokenTTL),
+	}
+	if sendErr := s.email.Send(ctx, msg); sendErr != nil {
+		s.logger.Error("failed to send email verification email", zap.String("user_id", user.ID), zap.Error(sendErr))
+		s.audit.LogEvent(ctx, audit.Event{
+			Type:     audit.EventEmailVerifyEmailFailed,
+			ActorID:  user.ID,
+			TargetID: user.ID,
+			Metadata: map[string]string{"email": user.Email},
+		})
+	}
+}
+
+// VerifyEmail marks a user's email as verified using the token from the
+// verification link. Idempotent: calling it again after success (e.g. the
+// user double-clicks the link) still returns nil. Returns an error for any
+// invalid or expired token; the handler maps all errors here to 400.
+func (s *Service) VerifyEmail(ctx context.Context, token string) error {
+	tenantID := domain.TenantIDFromContext(ctx)
+
+	user, err := s.users.ConsumeEmailVerifyToken(ctx, tenantID, token)
+	if err != nil {
+		return fmt.Errorf("verify email: %w", err)
+	}
+
+	s.audit.LogEvent(ctx, audit.Event{
+		Type:     audit.EventEmailVerified,
+		ActorID:  user.ID,
+		TargetID: user.ID,
+	})
+
+	return nil
 }
 
 // Login authenticates a user by email and password.
@@ -179,6 +250,10 @@ func (s *Service) Login(ctx context.Context, email, pwd string) (*api.AuthResult
 	}
 
 	// Check account status before verifying password.
+	// Note: user.EmailVerified is intentionally NOT checked here. In v1, email
+	// verification is informational only (GH-478) — gating login on it would
+	// block dogfood and design-partner signups whose links may go unclicked.
+	// Do not add an EmailVerified check without a product decision to enforce it.
 	if user.DeletedAt != nil {
 		s.audit.LogEvent(ctx, audit.Event{
 			Type:     audit.EventLoginFailure,

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -23,13 +23,15 @@ import (
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
 type mockUserRepository struct {
-	findByEmailFn        func(ctx context.Context, email string) (*domain.User, error)
-	findByIDFn           func(ctx context.Context, id string) (*domain.User, error)
-	createFn             func(ctx context.Context, user *domain.User) (*domain.User, error)
-	updateLastLogin      func(ctx context.Context, userID string, ts time.Time) error
-	updatePasswordHashFn func(ctx context.Context, userID, newHash string) error
-	getPasswordHistoryFn func(ctx context.Context, userID string, limit int) ([]domain.PasswordHistoryEntry, error)
-	addPasswordHistoryFn func(ctx context.Context, userID, hash string) error
+	findByEmailFn             func(ctx context.Context, email string) (*domain.User, error)
+	findByIDFn                func(ctx context.Context, id string) (*domain.User, error)
+	createFn                  func(ctx context.Context, user *domain.User) (*domain.User, error)
+	updateLastLogin           func(ctx context.Context, userID string, ts time.Time) error
+	updatePasswordHashFn      func(ctx context.Context, userID, newHash string) error
+	getPasswordHistoryFn      func(ctx context.Context, userID string, limit int) ([]domain.PasswordHistoryEntry, error)
+	addPasswordHistoryFn      func(ctx context.Context, userID, hash string) error
+	setEmailVerifyTokenFn     func(ctx context.Context, userID, token string, expiresAt time.Time) error
+	consumeEmailVerifyTokenFn func(ctx context.Context, token string) (*domain.User, error)
 }
 
 func (m *mockUserRepository) Create(ctx context.Context, user *domain.User) (*domain.User, error) {
@@ -60,11 +62,17 @@ func (m *mockUserRepository) UpdateLastLogin(ctx context.Context, _ uuid.UUID, u
 	return nil
 }
 
-func (m *mockUserRepository) SetEmailVerifyToken(_ context.Context, _ uuid.UUID, _ string, _ string, _ time.Time) error {
+func (m *mockUserRepository) SetEmailVerifyToken(ctx context.Context, _ uuid.UUID, userID string, token string, expiresAt time.Time) error {
+	if m.setEmailVerifyTokenFn != nil {
+		return m.setEmailVerifyTokenFn(ctx, userID, token, expiresAt)
+	}
 	return nil
 }
 
-func (m *mockUserRepository) ConsumeEmailVerifyToken(_ context.Context, _ uuid.UUID, _ string) (*domain.User, error) {
+func (m *mockUserRepository) ConsumeEmailVerifyToken(ctx context.Context, _ uuid.UUID, token string) (*domain.User, error) {
+	if m.consumeEmailVerifyTokenFn != nil {
+		return m.consumeEmailVerifyTokenFn(ctx, token)
+	}
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -208,6 +216,26 @@ func newUnitService(t *testing.T, users *mockUserRepository, tokens *mockRefresh
 		Hasher:   hasher,
 		Breaches: &mockBreachChecker{},
 		Email:    &mockEmailSender{},
+	})
+}
+
+// newUnitServiceWithEmail creates a Service with a nil Redis client and a
+// caller-supplied user repository / email sender / verify URL base, for
+// register and verify-email unit tests that don't touch Redis.
+func newUnitServiceWithEmail(t *testing.T, users *mockUserRepository, sender email.EmailSender, verifyURLBase string) *Service {
+	t.Helper()
+	logger, _ := zap.NewDevelopment()
+	return NewService(ServiceDeps{
+		Redis:         nil,
+		Logger:        logger,
+		Auditor:       audit.NopLogger{},
+		Users:         users,
+		Tokens:        &mockRefreshTokenRepository{},
+		Issuer:        &mockTokenIssuer{},
+		Hasher:        &mockHasher{},
+		Breaches:      &mockBreachChecker{},
+		Email:         sender,
+		VerifyURLBase: verifyURLBase,
 	})
 }
 
@@ -937,6 +965,144 @@ func TestRegister_CreatesUser(t *testing.T) {
 	require.NotNil(t, createdUser)
 	assert.NotEmpty(t, createdUser.PasswordHash)
 	assert.NotNil(t, createdUser.PasswordChangedAt)
+}
+
+func TestRegister_IssuesEmailVerificationTokenAndSendsLink(t *testing.T) {
+	var (
+		tokenUserID string
+		tokenValue  string
+		expiresAt   time.Time
+	)
+	users := &mockUserRepository{
+		createFn: func(_ context.Context, u *domain.User) (*domain.User, error) {
+			u.ID = "user-1"
+			return u, nil
+		},
+		setEmailVerifyTokenFn: func(_ context.Context, userID, token string, expiry time.Time) error {
+			tokenUserID = userID
+			tokenValue = token
+			expiresAt = expiry
+			return nil
+		},
+	}
+	sender := &mockEmailSender{}
+	svc := newUnitServiceWithEmail(t, users, sender, "https://app.example.com/verify-email")
+
+	before := time.Now().UTC()
+	info, err := svc.Register(context.Background(), "test@example.com", "valid-password-12345", "Test User")
+	require.NoError(t, err)
+
+	assert.Equal(t, "user-1", tokenUserID)
+	assert.Len(t, tokenValue, resetTokenBytes*2, "hex-encoded 32-byte token")
+	assert.WithinDuration(t, before.Add(verifyTokenTTL), expiresAt, 2*time.Second)
+
+	require.Len(t, sender.sent, 1, "expected exactly one verification email to be sent")
+	msg := sender.sent[0]
+	assert.Equal(t, info.Email, msg.To)
+	assert.Contains(t, msg.Body, "https://app.example.com/verify-email?token="+tokenValue)
+}
+
+func TestRegister_EmailSendFailure_RegistrationStillSucceeds(t *testing.T) {
+	users := &mockUserRepository{
+		createFn: func(_ context.Context, u *domain.User) (*domain.User, error) {
+			u.ID = "user-1"
+			return u, nil
+		},
+	}
+	sender := &mockEmailSender{
+		sendFn: func(_ context.Context, _ email.Message) error {
+			return fmt.Errorf("email service unreachable")
+		},
+	}
+	svc := newUnitServiceWithEmail(t, users, sender, "https://app.example.com/verify-email")
+
+	info, err := svc.Register(context.Background(), "test@example.com", "valid-password-12345", "Test User")
+	require.NoError(t, err, "a verification email delivery failure must not fail registration")
+	assert.Equal(t, "test@example.com", info.Email)
+	assert.Len(t, sender.sent, 1, "send should still have been attempted")
+}
+
+func TestRegister_ConsoleSenderPath_RegistrationUnchanged(t *testing.T) {
+	users := &mockUserRepository{
+		createFn: func(_ context.Context, u *domain.User) (*domain.User, error) {
+			u.ID = "user-1"
+			return u, nil
+		},
+	}
+	logger, _ := zap.NewDevelopment()
+	svc := newUnitServiceWithEmail(t, users, email.NewConsoleSender(logger), "")
+
+	info, err := svc.Register(context.Background(), "test@example.com", "valid-password-12345", "Test User")
+	require.NoError(t, err, "ConsoleSender path (EMAIL_ENABLED=false) must not error")
+	assert.Equal(t, "test@example.com", info.Email)
+}
+
+// ── VerifyEmail Tests ────────────────────────────────────────────────────────
+
+func TestVerifyEmail(t *testing.T) {
+	verifiedUser := &domain.User{ID: "user-1", Email: "alice@example.com", EmailVerified: true}
+
+	tests := []struct {
+		name    string
+		token   string
+		users   *mockUserRepository
+		wantErr bool
+	}{
+		{
+			name:  "happy path",
+			token: "valid-token",
+			users: &mockUserRepository{
+				consumeEmailVerifyTokenFn: func(_ context.Context, token string) (*domain.User, error) {
+					assert.Equal(t, "valid-token", token)
+					return verifiedUser, nil
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "already verified is idempotent",
+			token: "already-used-token",
+			users: &mockUserRepository{
+				consumeEmailVerifyTokenFn: func(_ context.Context, _ string) (*domain.User, error) {
+					return verifiedUser, nil
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "expired token",
+			token: "expired-token",
+			users: &mockUserRepository{
+				consumeEmailVerifyTokenFn: func(_ context.Context, _ string) (*domain.User, error) {
+					return nil, fmt.Errorf("email verify token: %w", storage.ErrTokenExpired)
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:  "invalid token",
+			token: "bogus-token",
+			users: &mockUserRepository{
+				consumeEmailVerifyTokenFn: func(_ context.Context, _ string) (*domain.User, error) {
+					return nil, fmt.Errorf("email verify token: %w", storage.ErrNotFound)
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newUnitService(t, tt.users, &mockRefreshTokenRepository{}, &mockTokenIssuer{}, &mockHasher{})
+
+			err := svc.VerifyEmail(context.Background(), tt.token)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }
 
 // ── ChangePassword Tests ────────────────────────────────────────────────────

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -95,6 +95,7 @@ type EmailConfig struct {
 	SenderAddress        string // EMAIL_SENDER_ADDRESS: the From address on outgoing mail
 	Enabled              bool   // EMAIL_ENABLED: false → skip delivery (useful in dev/test)
 	PasswordResetURLBase string // PASSWORD_RESET_URL_BASE: base URL the reset token is appended to (?token=<token>); required when Enabled
+	EmailVerifyURLBase   string // EMAIL_VERIFY_URL_BASE: base URL the verify token is appended to (?token=<token>); required when Enabled
 }
 
 // AppConfig holds server-level settings.
@@ -565,18 +566,21 @@ func loadEmail(l *loader) (EmailConfig, error) {
 	}
 
 	// When email delivery is enabled, every downstream field is required so
-	// startup fails fast instead of silently dropping password-reset emails.
-	var serviceURL, apiKey, senderAddress, resetURLBase string
+	// startup fails fast instead of silently dropping password-reset or
+	// verification emails.
+	var serviceURL, apiKey, senderAddress, resetURLBase, verifyURLBase string
 	if enabled {
 		serviceURL = l.requireStr("EMAIL_SERVICE_URL")
 		apiKey = l.requireStr("EMAIL_API_KEY")
 		senderAddress = l.requireStr("EMAIL_SENDER_ADDRESS")
 		resetURLBase = l.requireStr("PASSWORD_RESET_URL_BASE")
+		verifyURLBase = l.requireStr("EMAIL_VERIFY_URL_BASE")
 	} else {
 		serviceURL = l.optStr("EMAIL_SERVICE_URL", "")
 		apiKey = l.optStr("EMAIL_API_KEY", "")
 		senderAddress = l.optStr("EMAIL_SENDER_ADDRESS", "")
 		resetURLBase = l.optStr("PASSWORD_RESET_URL_BASE", "")
+		verifyURLBase = l.optStr("EMAIL_VERIFY_URL_BASE", "")
 	}
 
 	return EmailConfig{
@@ -585,6 +589,7 @@ func loadEmail(l *loader) (EmailConfig, error) {
 		SenderAddress:        senderAddress,
 		Enabled:              enabled,
 		PasswordResetURLBase: resetURLBase,
+		EmailVerifyURLBase:   verifyURLBase,
 	}, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -159,6 +159,7 @@ func TestLoad_EmailConfig(t *testing.T) {
 	env["EMAIL_SENDER_ADDRESS"] = "noreply@example.com"
 	env["EMAIL_ENABLED"] = "true"
 	env["PASSWORD_RESET_URL_BASE"] = "https://app.example.com/reset-password"
+	env["EMAIL_VERIFY_URL_BASE"] = "https://app.example.com/verify-email"
 	setEnv(t, env)
 
 	cfg, err := Load()
@@ -169,12 +170,13 @@ func TestLoad_EmailConfig(t *testing.T) {
 	assert.Equal(t, "noreply@example.com", cfg.Email.SenderAddress)
 	assert.True(t, cfg.Email.Enabled)
 	assert.Equal(t, "https://app.example.com/reset-password", cfg.Email.PasswordResetURLBase)
+	assert.Equal(t, "https://app.example.com/verify-email", cfg.Email.EmailVerifyURLBase)
 }
 
 func TestLoad_EmailEnabledMissingFields(t *testing.T) {
 	env := requiredEnv()
 	env["EMAIL_ENABLED"] = "true"
-	// Missing EMAIL_SERVICE_URL, EMAIL_API_KEY, EMAIL_SENDER_ADDRESS, PASSWORD_RESET_URL_BASE.
+	// Missing EMAIL_SERVICE_URL, EMAIL_API_KEY, EMAIL_SENDER_ADDRESS, PASSWORD_RESET_URL_BASE, EMAIL_VERIFY_URL_BASE.
 	setEnv(t, env)
 
 	_, err := Load()
@@ -183,6 +185,7 @@ func TestLoad_EmailEnabledMissingFields(t *testing.T) {
 	assert.Contains(t, err.Error(), "EMAIL_API_KEY")
 	assert.Contains(t, err.Error(), "EMAIL_SENDER_ADDRESS")
 	assert.Contains(t, err.Error(), "PASSWORD_RESET_URL_BASE")
+	assert.Contains(t, err.Error(), "EMAIL_VERIFY_URL_BASE")
 }
 
 func TestLoad_EmailDisabled_FieldsNotRequired(t *testing.T) {
@@ -193,6 +196,7 @@ func TestLoad_EmailDisabled_FieldsNotRequired(t *testing.T) {
 
 	assert.False(t, cfg.Email.Enabled)
 	assert.Empty(t, cfg.Email.PasswordResetURLBase)
+	assert.Empty(t, cfg.Email.EmailVerifyURLBase)
 }
 
 func TestLoad_CustomValues(t *testing.T) {

--- a/internal/storage/repository_integration_test.go
+++ b/internal/storage/repository_integration_test.go
@@ -310,6 +310,81 @@ func TestPostgresUserRepository_UpdateLastLogin_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, storage.ErrNotFound)
 }
 
+func TestPostgresUserRepository_ConsumeEmailVerifyToken_Valid(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresUserRepository(pool)
+	ctx := context.Background()
+
+	user := newTestUser()
+	_, err := repo.Create(ctx, user)
+	require.NoError(t, err)
+
+	err = repo.SetEmailVerifyToken(ctx, domain.DefaultTenantID, user.ID, "valid-token", time.Now().UTC().Add(24*time.Hour))
+	require.NoError(t, err)
+
+	verified, err := repo.ConsumeEmailVerifyToken(ctx, domain.DefaultTenantID, "valid-token")
+	require.NoError(t, err)
+	assert.Equal(t, user.ID, verified.ID)
+	assert.True(t, verified.EmailVerified)
+
+	found, err := repo.FindByID(ctx, domain.DefaultTenantID, user.ID)
+	require.NoError(t, err)
+	assert.True(t, found.EmailVerified)
+}
+
+func TestPostgresUserRepository_ConsumeEmailVerifyToken_Expired(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresUserRepository(pool)
+	ctx := context.Background()
+
+	user := newTestUser()
+	_, err := repo.Create(ctx, user)
+	require.NoError(t, err)
+
+	err = repo.SetEmailVerifyToken(ctx, domain.DefaultTenantID, user.ID, "expired-token", time.Now().UTC().Add(-1*time.Hour))
+	require.NoError(t, err)
+
+	_, err = repo.ConsumeEmailVerifyToken(ctx, domain.DefaultTenantID, "expired-token")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrTokenExpired)
+
+	found, err := repo.FindByID(ctx, domain.DefaultTenantID, user.ID)
+	require.NoError(t, err)
+	assert.False(t, found.EmailVerified, "expired token must not verify the user")
+}
+
+func TestPostgresUserRepository_ConsumeEmailVerifyToken_Invalid(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresUserRepository(pool)
+	ctx := context.Background()
+
+	_, err := repo.ConsumeEmailVerifyToken(ctx, domain.DefaultTenantID, "bogus-token-nobody-has")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresUserRepository_ConsumeEmailVerifyToken_AlreadyVerified_Idempotent(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresUserRepository(pool)
+	ctx := context.Background()
+
+	user := newTestUser()
+	_, err := repo.Create(ctx, user)
+	require.NoError(t, err)
+
+	err = repo.SetEmailVerifyToken(ctx, domain.DefaultTenantID, user.ID, "reused-token", time.Now().UTC().Add(24*time.Hour))
+	require.NoError(t, err)
+
+	// First click verifies the account.
+	_, err = repo.ConsumeEmailVerifyToken(ctx, domain.DefaultTenantID, "reused-token")
+	require.NoError(t, err)
+
+	// Second click with the same link must still succeed (idempotent), not 404.
+	verified, err := repo.ConsumeEmailVerifyToken(ctx, domain.DefaultTenantID, "reused-token")
+	require.NoError(t, err)
+	assert.True(t, verified.EmailVerified)
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // RefreshTokenRepository tests
 // ────────────────────────────────────────────────────────────────────────────

--- a/internal/storage/user_repository.go
+++ b/internal/storage/user_repository.go
@@ -163,21 +163,23 @@ func (r *PostgresUserRepository) SetEmailVerifyToken(ctx context.Context, tenant
 }
 
 // ConsumeEmailVerifyToken marks the email as verified if the token matches and hasn't expired.
+// Returns ErrNotFound if the token doesn't match any user, or ErrTokenExpired if it matched
+// but expired. Idempotent: if the user is already verified, it returns the user with no error
+// so a repeated click on the same verification link still succeeds (GH-478). The token is
+// intentionally left in place after verification (not nulled) to preserve that idempotency —
+// unlike a password-reset token, a spent verification token isn't a bearer credential, so
+// leaving it resolvable after use isn't a meaningful security regression.
 func (r *PostgresUserRepository) ConsumeEmailVerifyToken(ctx context.Context, tenantID uuid.UUID, token string) (*domain.User, error) {
-	query := `UPDATE users
-		SET email_verified = TRUE,
-		    email_verify_token = NULL,
-		    email_verify_token_expires_at = NULL,
-		    updated_at = $1
-		WHERE email_verify_token = $2 AND tenant_id = $3 AND deleted_at IS NULL
-		RETURNING id, tenant_id, email, password_hash, name, roles, locked, locked_at, locked_reason,
-		          email_verified, email_verify_token, email_verify_token_expires_at,
-		          last_login_at, force_password_change, password_changed_at,
-		          created_at, updated_at, deleted_at`
+	selectQuery := `
+		SELECT id, tenant_id, email, password_hash, name, roles, locked, locked_at, locked_reason,
+		       email_verified, email_verify_token, email_verify_token_expires_at,
+		       last_login_at, force_password_change, password_changed_at,
+		       created_at, updated_at, deleted_at
+		FROM users
+		WHERE email_verify_token = $1 AND tenant_id = $2 AND deleted_at IS NULL`
 
-	now := time.Now().UTC()
 	user := &domain.User{}
-	err := r.pool.QueryRow(ctx, query, now, token, tenantID).Scan(
+	err := r.pool.QueryRow(ctx, selectQuery, token, tenantID).Scan(
 		&user.ID, &user.TenantID, &user.Email, &user.PasswordHash, &user.Name, &user.Roles,
 		&user.Locked, &user.LockedAt, &user.LockedReason,
 		&user.EmailVerified, &user.EmailVerifyToken, &user.EmailVerifyTokenExpiresAt,
@@ -191,6 +193,22 @@ func (r *PostgresUserRepository) ConsumeEmailVerifyToken(ctx context.Context, te
 		return nil, fmt.Errorf("consume email verify token: %w", err)
 	}
 
+	if user.EmailVerified {
+		return user, nil
+	}
+
+	now := time.Now().UTC()
+	if user.EmailVerifyTokenExpiresAt == nil || now.After(*user.EmailVerifyTokenExpiresAt) {
+		return nil, fmt.Errorf("email verify token: %w", ErrTokenExpired)
+	}
+
+	updateQuery := `UPDATE users SET email_verified = TRUE, updated_at = $1 WHERE id = $2 AND tenant_id = $3`
+	if _, err := r.pool.Exec(ctx, updateQuery, now, user.ID, tenantID); err != nil {
+		return nil, fmt.Errorf("mark email verified: %w", err)
+	}
+
+	user.EmailVerified = true
+	user.UpdatedAt = now
 	return user, nil
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-478.

Closes #478

## Changes

GitHub Issue GH-478: feat(auth): signup email-verification — token issuance in Register + POST /auth/verify-email

## Context

Signup email-verification is dead scaffolding today: the `users` table has `email_verified`/`email_verify_token`/`email_verify_token_expires_at`, the repository has `SetEmailVerifyToken` (`internal/storage/user_repository.go:149`) and `VerifyEmail` (`:166-174`), and `domain.VerifyEmailRequest` exists (`internal/domain/validation.go:82`) — but `Register` (`internal/auth/service.go:100-149`) never issues a token and no route or handler exists in `internal/api/router.go`.

Depends on #477 (EmailSender wiring) — must merge first.

## Task

- `Register`: generate a token (32-byte random hex, same idiom as the reset token), persist via `SetEmailVerifyToken` with 24h expiry, send the verification link `${EMAIL_VERIFY_URL_BASE}?token=<token>` — new env `EMAIL_VERIFY_URL_BASE`, validated when `EMAIL_ENABLED=true`. Send failure logs + audits and does **not** fail registration.
- `POST /auth/verify-email` `{token}` → `VerifyEmail`; 200 on success, idempotent 200 if already verified, 400 on invalid/expired.
- Login is **not** gated on verification in v1 (informational only — must not block dogfood or design-partner flows). State this in a code comment where tempting to enforce.

## Acceptance criteria

- Register issues a token and triggers exactly one send (fake sender); registration succeeds when the sender errors.
- Verify endpoint table-tested: happy, expired, invalid, already-verified.
- `EMAIL_ENABLED=false`: ConsoleSender logs, registration flow unchanged.
- Existing register/login tests stay green.

## Non-goals

Resend-verification endpoint, verification enforcement/gating, frontend, changing MFA.

## Refs

#477 · qf-studio/pilot `.agent/system/saas-asset-research.md` § auth-service-email-wiring