### PR TITLE
GH-481: fix(storage): ConsumeEmailVerifyToken ignores email_verify_token_expires_at — expired verification links still verify

### DIFF
--- a/.agent/tasks/gh-481.md
+++ b/.agent/tasks/gh-481.md
@@ -1,0 +1,100 @@
+# GH-481
+
+**Created:** 2026-07-29
+
+## Problem
+
+GitHub Issue GH-481: fix(storage): ConsumeEmailVerifyToken ignores email_verify_token_expires_at — expired verification links still verify
+
+## Problem
+
+`PostgresUserRepository.ConsumeEmailVerifyToken` (`internal/storage/user_repository.go`) matches on token only:
+
+```sql
+WHERE email_verify_token = $2 AND tenant_id = $3 AND deleted_at IS NULL
+```
+
+`email_verify_token_expires_at` is written by `SetEmailVerifyToken` (24h TTL per GH-478) but **never read** — an arbitrarily old verification link still verifies. The service-level tests (PR #480) mock the repo returning `storage.ErrTokenExpired`, an error the real implementation can never produce, so the gap is invisible to the suite.
+
+Found in operator review of PR #480; pre-existing scaffolding defect, out of that PR's wiring scope. Low urgency: verification is informational-only in v1 (login not gated), but the advertised TTL must be real before anything enforces verification.
+
+## Task
+
+1. Add the expiry predicate to the UPDATE: `AND email_verify_token_expires_at > $now`.
+2. On no-rows, distinguish expired from invalid: follow-up SELECT by token — row exists with past expiry → return `storage.ErrTokenExpired`; no row → `ErrNotFound` (service already wraps both, handler maps both to 400 — the split is for audit/log fidelity and the existing service tests' mocked contract).
+3. Decide/settle already-verified semantics: GH-478 spec said "idempotent 200 if already verified", but consuming NULLs the token, so a double-click is currently 400. Either implement true idempotency (e.g. on `ErrNotFound`, no signal exists — simplest honest option: keep 400 and update the service comment + GH-478 task doc to match), or keep the consumed token value in a column to recognize re-clicks. Pick one; do not leave the comment claiming idempotency the storage layer doesn't provide.
+4. Repository-level tests against real Postgres: valid token verifies once; expired token → `ErrTokenExpired`; bogus token → `ErrNotFound`; second consume of a used token behaves per the decision in (3).
+
+## Acceptance criteria
+
+- Expired links cannot verify.
+- `storage.ErrTokenExpired` is reachable from the real implementation.
+- `VerifyEmail` service doc comment matches actual double-click behavior.
+
+## Refs
+
+GH-478 · PR #480 (review finding)
+
+## Resolution: NO-OP (already fixed in the PR #480 merge commit)
+
+Investigated 2026-07-29. The defect this issue describes does **not** exist in
+current `main`/HEAD. `git log -p -1 -- internal/storage/user_repository.go`
+on commit `905c4b8` ("feat(auth): add email verification on register GH-478
+(#480)") shows the exact fix already landed as part of that same merge, whose
+commit message states: *"Also fixes ConsumeEmailVerifyToken, which never
+checked expiry and nulled the token on success, breaking the idempotency the
+endpoint depends on."* This issue was evidently filed from an earlier
+revision of the PR #480 branch (the operator review finding) that was
+resolved before merge, and the issue text was never reconciled against the
+final merged diff.
+
+Current implementation (`internal/storage/user_repository.go:172-213`,
+`ConsumeEmailVerifyToken`) uses SELECT-then-check-then-UPDATE rather than the
+single `UPDATE ... WHERE email_verify_token_expires_at > $now` suggested in
+the task, but is functionally equivalent and satisfies every acceptance
+criterion:
+
+- **Expired links cannot verify**: after SELECT, `now.After(*ExpiresAt)` is
+  checked before the UPDATE fires; expired tokens return early without
+  mutating `email_verified` (`user_repository.go:200-203`).
+- **`storage.ErrTokenExpired` is reachable from the real implementation**:
+  confirmed by running
+  `TestPostgresUserRepository_ConsumeEmailVerifyToken_Expired` against a real
+  Postgres instance (`docker` container on `localhost:5432`) — PASS.
+- **Bogus token → `ErrNotFound`**: confirmed by
+  `TestPostgresUserRepository_ConsumeEmailVerifyToken_Invalid` — PASS.
+- **Valid token verifies once**: confirmed by
+  `TestPostgresUserRepository_ConsumeEmailVerifyToken_Valid` — PASS.
+- **Already-verified semantics settled**: item 3's two options were "keep
+  400" or "keep the consumed token value to recognize re-clicks." The merged
+  code chose the latter — it never nulls `email_verify_token` on success, so
+  a second click still resolves the same row and short-circuits on
+  `user.EmailVerified == true` (`user_repository.go:196-198`). Confirmed by
+  `TestPostgresUserRepository_ConsumeEmailVerifyToken_AlreadyVerified_Idempotent`
+  — PASS.
+- **`VerifyEmail` service doc comment matches actual double-click behavior**:
+  `internal/auth/service.go:213-216` already says *"Idempotent: calling it
+  again after success (e.g. the user double-clicks the link) still returns
+  nil."* This matches the true-idempotency implementation above — no edit
+  needed.
+- **Repository-level tests against real Postgres**: all four scenarios
+  required by task item 4 already exist in
+  `internal/storage/repository_integration_test.go:313-386` and were run
+  against a live Postgres container (`TEST_DATABASE_URL` set) — all 4 PASS.
+
+`go build ./...` is clean. `go test ./internal/storage/... ./internal/auth/...`
+against real Postgres shows the four target tests plus all of
+`internal/auth` passing; the only failures are pre-existing and unrelated to
+email verification (`TestPostgresRARRepository_ClientTypeAssociations` —
+ambiguous `tenant_id` column in an unrelated query; `TestPostgresUserRepository_UpdateLastLogin`,
+`TestPostgresRefreshTokenRepository_StoreAndFind`,
+`TestPostgresClientRepository_RotateSecret` — UTC-vs-Local timezone
+assertion mismatch caused by the shared test Postgres container's timezone
+config, not by this change).
+
+**No code change made.** Reopening/relabeling this issue against a stale PR
+revision is the likely root cause; recommend closing GH-481 with a
+reference to commit `905c4b8`.
+
+## Acceptance Criteria
+


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-481.

Closes #481

## Changes

GitHub Issue GH-481: fix(storage): ConsumeEmailVerifyToken ignores email_verify_token_expires_at — expired verification links still verify

## Problem

`PostgresUserRepository.ConsumeEmailVerifyToken` (`internal/storage/user_repository.go`) matches on token only:

```sql
WHERE email_verify_token = $2 AND tenant_id = $3 AND deleted_at IS NULL
```

`email_verify_token_expires_at` is written by `SetEmailVerifyToken` (24h TTL per GH-478) but **never read** — an arbitrarily old verification link still verifies. The service-level tests (PR #480) mock the repo returning `storage.ErrTokenExpired`, an error the real implementation can never produce, so the gap is invisible to the suite.

Found in operator review of PR #480; pre-existing scaffolding defect, out of that PR's wiring scope. Low urgency: verification is informational-only in v1 (login not gated), but the advertised TTL must be real before anything enforces verification.

## Task

1. Add the expiry predicate to the UPDATE: `AND email_verify_token_expires_at > $now`.
2. On no-rows, distinguish expired from invalid: follow-up SELECT by token — row exists with past expiry → return `storage.ErrTokenExpired`; no row → `ErrNotFound` (service already wraps both, handler maps both to 400 — the split is for audit/log fidelity and the existing service tests' mocked contract).
3. Decide/settle already-verified semantics: GH-478 spec said "idempotent 200 if already verified", but consuming NULLs the token, so a double-click is currently 400. Either implement true idempotency (e.g. on `ErrNotFound`, no signal exists — simplest honest option: keep 400 and update the service comment + GH-478 task doc to match), or keep the consumed token value in a column to recognize re-clicks. Pick one; do not leave the comment claiming idempotency the storage layer doesn't provide.
4. Repository-level tests against real Postgres: valid token verifies once; expired token → `ErrTokenExpired`; bogus token → `ErrNotFound`; second consume of a used token behaves per the decision in (3).

## Acceptance criteria

- Expired links cannot verify.
- `storage.ErrTokenExpired` is reachable from the real implementation.
- `VerifyEmail` service doc comment matches actual double-click behavior.

## Refs

GH-478 · PR #480 (review finding)