### PR TITLE
GH-485: fix(admin): API-key auth structurally broken — no api_keys migration + salted-hash equality lookup always 401s

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -224,7 +224,7 @@ func run(log *zap.Logger, cfg *config.Config) error {
 	adminUserSvc := admin.NewUserService(adminUserRepo, hasher, log, auditSvc)
 	adminClientSvc := admin.NewClientService(clientRepo, hasher, log, auditSvc)
 	adminTokenSvc := admin.NewTokenService(tokenSvc, refreshTokenRepo, "auth-service", log, auditSvc)
-	adminAPIKeySvc := admin.NewAPIKeyService(apiKeyRepo, hasher, log, auditSvc)
+	adminAPIKeySvc := admin.NewAPIKeyService(apiKeyRepo, log, auditSvc)
 	adminWebhookSvc := admin.NewWebhookService(webhookRepo, webhookDeliveryRepo, webhookDispatcher, log, auditSvc)
 
 	// ── Middleware ─────────────────────────────────────────────────────────

--- a/internal/admin/apikey_service.go
+++ b/internal/admin/apikey_service.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -15,7 +16,6 @@ import (
 	"github.com/qf-studio/auth-service/internal/audit"
 	"github.com/qf-studio/auth-service/internal/domain"
 	"github.com/qf-studio/auth-service/internal/middleware"
-	"github.com/qf-studio/auth-service/internal/password"
 	"github.com/qf-studio/auth-service/internal/storage"
 )
 
@@ -33,16 +33,14 @@ const (
 // APIKeyService implements api.AdminAPIKeyService.
 type APIKeyService struct {
 	repo   storage.APIKeyRepository
-	hasher password.Hasher
 	logger *zap.Logger
 	audit  audit.EventLogger
 }
 
 // NewAPIKeyService creates a new admin API key service.
-func NewAPIKeyService(repo storage.APIKeyRepository, hasher password.Hasher, logger *zap.Logger, auditor audit.EventLogger) *APIKeyService {
+func NewAPIKeyService(repo storage.APIKeyRepository, logger *zap.Logger, auditor audit.EventLogger) *APIKeyService {
 	return &APIKeyService{
 		repo:   repo,
-		hasher: hasher,
 		logger: logger,
 		audit:  auditor,
 	}
@@ -108,11 +106,7 @@ func (s *APIKeyService) CreateAPIKey(ctx context.Context, req *api.CreateAPIKeyR
 		return nil, fmt.Errorf("create api key: %w", api.ErrInternalError)
 	}
 
-	hash, err := s.hasher.Hash(rawKey)
-	if err != nil {
-		s.logger.Error("hash api key failed", zap.Error(err))
-		return nil, fmt.Errorf("create api key: %w", api.ErrInternalError)
-	}
+	hash := hashAPIKey(rawKey)
 
 	now := time.Now().UTC()
 	scopes := req.Scopes
@@ -256,11 +250,7 @@ func (s *APIKeyService) RotateAPIKey(ctx context.Context, keyID string) (*api.Ad
 		return nil, fmt.Errorf("rotate api key: %w", api.ErrInternalError)
 	}
 
-	hash, err := s.hasher.Hash(rawKey)
-	if err != nil {
-		s.logger.Error("hash api key failed", zap.Error(err))
-		return nil, fmt.Errorf("rotate api key: %w", api.ErrInternalError)
-	}
+	hash := hashAPIKey(rawKey)
 
 	graceEnd := time.Now().UTC().Add(apiKeyGracePeriod)
 
@@ -294,11 +284,7 @@ func (s *APIKeyService) RotateAPIKey(ctx context.Context, keyID string) (*api.Ad
 // This method satisfies middleware.APIKeyValidator.
 func (s *APIKeyService) ValidateAPIKey(ctx context.Context, rawKey string) (*middleware.APIKeyInfo, error) {
 	tenantID := domain.TenantIDFromContext(ctx)
-	hash, err := s.hasher.Hash(rawKey)
-	if err != nil {
-		s.logger.Error("hash api key for validation failed", zap.Error(err))
-		return nil, fmt.Errorf("validate api key: %w", err)
-	}
+	hash := hashAPIKey(rawKey)
 
 	key, err := s.repo.FindByKeyHash(ctx, tenantID, hash)
 	if err != nil {
@@ -326,6 +312,21 @@ func generateAPIKey() (string, error) {
 		return "", fmt.Errorf("generate random bytes: %w", err)
 	}
 	return apiKeyPrefix + hex.EncodeToString(b), nil
+}
+
+// hashAPIKey returns the SHA-256 hex digest of a raw API key.
+//
+// Decision: API keys are 256-bit random secrets, not human passwords, so
+// they don't need Argon2id's slow, salted hashing — brute-forcing the
+// digest is infeasible. A deterministic digest also enables an O(1) indexed
+// lookup (key_hash unique index) instead of a full-table Argon2id re-hash
+// comparison per candidate row, which is both impossible with per-call
+// random salts (see internal/password/hasher.go) and would be prohibitively
+// slow. Mirrors the service's existing "store only token signatures"
+// pattern used for refresh tokens.
+func hashAPIKey(rawKey string) string {
+	sum := sha256.Sum256([]byte(rawKey))
+	return hex.EncodeToString(sum[:])
 }
 
 // domainAPIKeyToAdmin converts a domain.APIKey to an api.AdminAPIKey response DTO.

--- a/internal/admin/apikey_service_test.go
+++ b/internal/admin/apikey_service_test.go
@@ -52,7 +52,7 @@ func (m *mockAPIKeyRepo) List(_ context.Context, _ uuid.UUID, _, _ int, _ string
 	return out, len(out), nil
 }
 
-func (m *mockAPIKeyRepo) FindByID(_ context.Context, _ uuid.UUID, id uuid.UUID) (*domain.APIKey, error) {
+func (m *mockAPIKeyRepo) FindByID(_ context.Context, _, id uuid.UUID) (*domain.APIKey, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	k, ok := m.keys[id]
@@ -100,7 +100,7 @@ func (m *mockAPIKeyRepo) Update(_ context.Context, key *domain.APIKey) (*domain.
 	return &out, nil
 }
 
-func (m *mockAPIKeyRepo) Revoke(_ context.Context, _ uuid.UUID, id uuid.UUID) error {
+func (m *mockAPIKeyRepo) Revoke(_ context.Context, _, id uuid.UUID) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	k, ok := m.keys[id]
@@ -114,7 +114,7 @@ func (m *mockAPIKeyRepo) Revoke(_ context.Context, _ uuid.UUID, id uuid.UUID) er
 	return nil
 }
 
-func (m *mockAPIKeyRepo) RotateKey(_ context.Context, _ uuid.UUID, id uuid.UUID, newKeyHash string, gracePeriodEnds time.Time) error {
+func (m *mockAPIKeyRepo) RotateKey(_ context.Context, _, id uuid.UUID, newKeyHash string, gracePeriodEnds time.Time) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	k, ok := m.keys[id]
@@ -128,7 +128,7 @@ func (m *mockAPIKeyRepo) RotateKey(_ context.Context, _ uuid.UUID, id uuid.UUID,
 	return nil
 }
 
-func (m *mockAPIKeyRepo) UpdateLastUsed(_ context.Context, _ uuid.UUID, id uuid.UUID) error {
+func (m *mockAPIKeyRepo) UpdateLastUsed(_ context.Context, _, id uuid.UUID) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	k, ok := m.keys[id]

--- a/internal/admin/apikey_service_test.go
+++ b/internal/admin/apikey_service_test.go
@@ -1,0 +1,278 @@
+package admin
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/api"
+	"github.com/qf-studio/auth-service/internal/audit"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/storage"
+)
+
+// --- stateful mock APIKeyRepository ---
+//
+// Unlike the other admin mocks in this package (which return canned
+// fixtures), this one keeps real state so it can reproduce the grace-window
+// lookup semantics that PostgresAPIKeyRepository.FindByKeyHash implements in
+// SQL (key_hash = $1 OR (previous_key_hash = $1 AND previous_key_expires_at
+// > NOW())) — needed to exercise rotate/grace-period behavior end to end.
+
+type mockAPIKeyRepo struct {
+	mu   sync.Mutex
+	keys map[uuid.UUID]*domain.APIKey
+}
+
+func newMockAPIKeyRepo() *mockAPIKeyRepo {
+	return &mockAPIKeyRepo{keys: make(map[uuid.UUID]*domain.APIKey)}
+}
+
+func (m *mockAPIKeyRepo) put(k *domain.APIKey) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *k
+	m.keys[k.ID] = &cp
+}
+
+func (m *mockAPIKeyRepo) List(_ context.Context, _ uuid.UUID, _, _ int, _ string) ([]*domain.APIKey, int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*domain.APIKey, 0, len(m.keys))
+	for _, k := range m.keys {
+		cp := *k
+		out = append(out, &cp)
+	}
+	return out, len(out), nil
+}
+
+func (m *mockAPIKeyRepo) FindByID(_ context.Context, _ uuid.UUID, id uuid.UUID) (*domain.APIKey, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	k, ok := m.keys[id]
+	if !ok {
+		return nil, storage.ErrNotFound
+	}
+	cp := *k
+	return &cp, nil
+}
+
+func (m *mockAPIKeyRepo) FindByKeyHash(_ context.Context, _ uuid.UUID, keyHash string) (*domain.APIKey, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, k := range m.keys {
+		if k.KeyHash == keyHash {
+			cp := *k
+			return &cp, nil
+		}
+		if k.PreviousKeyHash == keyHash && k.PreviousKeyExpiresAt != nil && k.PreviousKeyExpiresAt.After(time.Now()) {
+			cp := *k
+			return &cp, nil
+		}
+	}
+	return nil, storage.ErrNotFound
+}
+
+func (m *mockAPIKeyRepo) Create(_ context.Context, key *domain.APIKey) (*domain.APIKey, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *key
+	m.keys[key.ID] = &cp
+	out := *key
+	return &out, nil
+}
+
+func (m *mockAPIKeyRepo) Update(_ context.Context, key *domain.APIKey) (*domain.APIKey, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.keys[key.ID]; !ok {
+		return nil, storage.ErrNotFound
+	}
+	cp := *key
+	m.keys[key.ID] = &cp
+	out := *key
+	return &out, nil
+}
+
+func (m *mockAPIKeyRepo) Revoke(_ context.Context, _ uuid.UUID, id uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	k, ok := m.keys[id]
+	if !ok {
+		return storage.ErrNotFound
+	}
+	if k.Status != domain.APIKeyStatusActive {
+		return storage.ErrAlreadyDeleted
+	}
+	k.Status = domain.APIKeyStatusRevoked
+	return nil
+}
+
+func (m *mockAPIKeyRepo) RotateKey(_ context.Context, _ uuid.UUID, id uuid.UUID, newKeyHash string, gracePeriodEnds time.Time) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	k, ok := m.keys[id]
+	if !ok {
+		return storage.ErrNotFound
+	}
+	k.PreviousKeyHash = k.KeyHash
+	grace := gracePeriodEnds
+	k.PreviousKeyExpiresAt = &grace
+	k.KeyHash = newKeyHash
+	return nil
+}
+
+func (m *mockAPIKeyRepo) UpdateLastUsed(_ context.Context, _ uuid.UUID, id uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	k, ok := m.keys[id]
+	if !ok {
+		return storage.ErrNotFound
+	}
+	now := time.Now().UTC()
+	k.LastUsedAt = &now
+	return nil
+}
+
+// --- helpers ---
+
+func newTestAPIKeyService(repo storage.APIKeyRepository) *APIKeyService {
+	return NewAPIKeyService(repo, zap.NewNop(), audit.NopLogger{})
+}
+
+func testAPIKey(id uuid.UUID, rawKey string) *domain.APIKey {
+	now := time.Now().UTC()
+	return &domain.APIKey{
+		ID:        id,
+		TenantID:  uuid.New(),
+		ClientID:  uuid.New(),
+		Name:      "test-key",
+		KeyHash:   hashAPIKey(rawKey),
+		KeyPrefix: rawKey[:len(apiKeyPrefix)+8],
+		Scopes:    []string{"read:users"},
+		RateLimit: defaultRateLimit,
+		Status:    domain.APIKeyStatusActive,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+// --- ValidateAPIKey (table-driven) ---
+
+func TestAPIKeyService_ValidateAPIKey(t *testing.T) {
+	now := time.Now().UTC()
+	repo := newMockAPIKeyRepo()
+
+	activeID := uuid.New()
+	repo.put(testAPIKey(activeID, "qf_ak_activekeyvalue"))
+
+	expiredID := uuid.New()
+	expired := testAPIKey(expiredID, "qf_ak_expiredkeyvalue")
+	expiredAt := now.Add(-time.Hour)
+	expired.ExpiresAt = &expiredAt
+	repo.put(expired)
+
+	revokedID := uuid.New()
+	revoked := testAPIKey(revokedID, "qf_ak_revokedkeyvalue")
+	revoked.Status = domain.APIKeyStatusRevoked
+	repo.put(revoked)
+
+	// A rotated key: current key is "new", previous key still valid within
+	// the grace window.
+	rotatedID := uuid.New()
+	rotated := testAPIKey(rotatedID, "qf_ak_rotatednewvalue")
+	rotated.PreviousKeyHash = hashAPIKey("qf_ak_rotatedoldvalue")
+	graceEnd := now.Add(time.Hour)
+	rotated.PreviousKeyExpiresAt = &graceEnd
+	repo.put(rotated)
+
+	// A rotated key whose grace window has already elapsed.
+	staleID := uuid.New()
+	stale := testAPIKey(staleID, "qf_ak_stalenewvalue")
+	stale.PreviousKeyHash = hashAPIKey("qf_ak_staleoldvalue")
+	gracePast := now.Add(-time.Hour)
+	stale.PreviousKeyExpiresAt = &gracePast
+	repo.put(stale)
+
+	svc := newTestAPIKeyService(repo)
+
+	tests := []struct {
+		name    string
+		rawKey  string
+		wantErr bool
+	}{
+		{name: "valid active key", rawKey: "qf_ak_activekeyvalue", wantErr: false},
+		{name: "unknown key", rawKey: "qf_ak_neverissuedvalue", wantErr: true},
+		{name: "revoked key rejected", rawKey: "qf_ak_revokedkeyvalue", wantErr: true},
+		{name: "expired key rejected", rawKey: "qf_ak_expiredkeyvalue", wantErr: true},
+		{name: "rotated: old key valid within grace window", rawKey: "qf_ak_rotatedoldvalue", wantErr: false},
+		{name: "rotated: new key valid immediately", rawKey: "qf_ak_rotatednewvalue", wantErr: false},
+		{name: "rotated: old key rejected after grace window", rawKey: "qf_ak_staleoldvalue", wantErr: true},
+		{name: "rotated: new key still valid after old key's grace expired", rawKey: "qf_ak_stalenewvalue", wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, err := svc.ValidateAPIKey(context.Background(), tt.rawKey)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, info)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, info)
+			assert.NotEmpty(t, info.ClientID)
+		})
+	}
+}
+
+// --- Full lifecycle: create -> validate -> rotate -> validate (old+new) -> revoke -> rejected ---
+
+func TestAPIKeyService_FullLifecycle(t *testing.T) {
+	repo := newMockAPIKeyRepo()
+	svc := newTestAPIKeyService(repo)
+	ctx := domain.WithTenantID(context.Background(), uuid.New())
+
+	created, err := svc.CreateAPIKey(ctx, &api.CreateAPIKeyRequest{
+		ClientID: uuid.New().String(),
+		Name:     "lifecycle-key",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, created.Key)
+	firstKey := created.Key
+
+	// Validate the freshly created key succeeds.
+	info, err := svc.ValidateAPIKey(ctx, firstKey)
+	require.NoError(t, err)
+	assert.Equal(t, created.ClientID, info.ClientID)
+
+	// Rotate: a new key is issued, old key still works within the grace period.
+	rotated, err := svc.RotateAPIKey(ctx, created.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, rotated.Key)
+	require.NotEqual(t, firstKey, rotated.Key)
+	require.NotNil(t, rotated.GracePeriodEnds)
+	secondKey := rotated.Key
+
+	_, err = svc.ValidateAPIKey(ctx, firstKey)
+	assert.NoError(t, err, "old key should still validate within the grace period")
+
+	_, err = svc.ValidateAPIKey(ctx, secondKey)
+	assert.NoError(t, err, "new key should validate immediately")
+
+	// Revoke: both old and new keys must be rejected afterward.
+	err = svc.RevokeAPIKey(ctx, created.ID)
+	require.NoError(t, err)
+
+	_, err = svc.ValidateAPIKey(ctx, secondKey)
+	assert.Error(t, err, "new key should be rejected after revoke")
+
+	_, err = svc.ValidateAPIKey(ctx, firstKey)
+	assert.Error(t, err, "old key should be rejected after revoke")
+}

--- a/internal/storage/repository_integration_test.go
+++ b/internal/storage/repository_integration_test.go
@@ -165,11 +165,31 @@ func createTables(t *testing.T, pool *pgxpool.Pool) {
 			created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
 			PRIMARY KEY (client_id, resource_type_id)
 		);
+
+		CREATE TABLE IF NOT EXISTS api_keys (
+			id                        UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+			tenant_id                 UUID        NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001' REFERENCES tenants (id),
+			client_id                 UUID        NOT NULL REFERENCES clients (id),
+			name                      TEXT        NOT NULL,
+			key_hash                  TEXT        NOT NULL,
+			previous_key_hash         TEXT        NOT NULL DEFAULT '',
+			previous_key_expires_at   TIMESTAMPTZ,
+			key_prefix                TEXT        NOT NULL,
+			scopes                    TEXT[]      NOT NULL DEFAULT '{}',
+			rate_limit                INTEGER     NOT NULL DEFAULT 0,
+			status                    TEXT        NOT NULL DEFAULT 'active',
+			expires_at                TIMESTAMPTZ,
+			last_used_at              TIMESTAMPTZ,
+			created_at                TIMESTAMPTZ NOT NULL DEFAULT now(),
+			updated_at                TIMESTAMPTZ NOT NULL DEFAULT now()
+		);
+
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_key_hash ON api_keys (key_hash);
 	`)
 	require.NoError(t, err)
 
 	// Clean tables before each test file run.
-	_, err = pool.Exec(ctx, `TRUNCATE users, refresh_tokens, clients, mfa_secrets, mfa_backup_codes, rar_resource_types, client_rar_allowed_types, tenants CASCADE`)
+	_, err = pool.Exec(ctx, `TRUNCATE users, refresh_tokens, clients, mfa_secrets, mfa_backup_codes, rar_resource_types, client_rar_allowed_types, api_keys, tenants CASCADE`)
 	require.NoError(t, err)
 
 	// Re-insert default tenant after truncation.
@@ -1461,3 +1481,198 @@ func TestPostgresTenantRepository_Create_WithConfig(t *testing.T) {
 	assert.Equal(t, 20, *created.Config.PasswordPolicy.MinLength)
 }
 
+// ────────────────────────────────────────────────────────────────────────────
+// APIKeyRepository tests
+//
+// GH-485: the api_keys table had no migration at all (every query 500'd
+// with "relation does not exist"). These tests run against a real api_keys
+// table (see createTables above, which mirrors
+// migrations/000019_create_api_keys_table.up.sql) to prove the schema and
+// the FindByKeyHash grace-window lookup
+// (key_hash = $1 OR (previous_key_hash = $1 AND previous_key_expires_at > NOW()))
+// actually work against Postgres, not just against the in-memory mock used
+// by internal/admin's service-level tests.
+// ────────────────────────────────────────────────────────────────────────────
+
+func newTestAPIKeyClient(t *testing.T, pool *pgxpool.Pool) *domain.Client {
+	t.Helper()
+	repo := storage.NewPostgresClientRepository(pool)
+	created, err := repo.Create(context.Background(), newTestClient())
+	require.NoError(t, err)
+	return created
+}
+
+func newTestAPIKey(clientID uuid.UUID, keyHash string) *domain.APIKey {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	return &domain.APIKey{
+		ID:        uuid.New(),
+		TenantID:  domain.DefaultTenantID,
+		ClientID:  clientID,
+		Name:      "test-api-key",
+		KeyHash:   keyHash,
+		KeyPrefix: "qf_ak_" + keyHash[:8],
+		Scopes:    []string{"read:users"},
+		RateLimit: 1000,
+		Status:    domain.APIKeyStatusActive,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+func TestPostgresAPIKeyRepository_Create(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAPIKeyRepository(pool)
+	client := newTestAPIKeyClient(t, pool)
+	ctx := context.Background()
+
+	key := newTestAPIKey(client.ID, "hash-"+uuid.New().String())
+	created, err := repo.Create(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, key.ID, created.ID)
+	assert.Equal(t, key.KeyHash, created.KeyHash)
+	assert.Equal(t, domain.APIKeyStatusActive, created.Status)
+}
+
+func TestPostgresAPIKeyRepository_FindByID(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAPIKeyRepository(pool)
+	client := newTestAPIKeyClient(t, pool)
+	ctx := context.Background()
+
+	key := newTestAPIKey(client.ID, "hash-"+uuid.New().String())
+	_, err := repo.Create(ctx, key)
+	require.NoError(t, err)
+
+	found, err := repo.FindByID(ctx, domain.DefaultTenantID, key.ID)
+	require.NoError(t, err)
+	assert.Equal(t, key.KeyHash, found.KeyHash)
+}
+
+func TestPostgresAPIKeyRepository_FindByID_NotFound(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAPIKeyRepository(pool)
+	ctx := context.Background()
+
+	_, err := repo.FindByID(ctx, domain.DefaultTenantID, uuid.New())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestPostgresAPIKeyRepository_FindByKeyHash(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAPIKeyRepository(pool)
+	client := newTestAPIKeyClient(t, pool)
+	ctx := context.Background()
+
+	hash := "hash-" + uuid.New().String()
+	key := newTestAPIKey(client.ID, hash)
+	_, err := repo.Create(ctx, key)
+	require.NoError(t, err)
+
+	found, err := repo.FindByKeyHash(ctx, domain.DefaultTenantID, hash)
+	require.NoError(t, err)
+	assert.Equal(t, key.ID, found.ID)
+}
+
+func TestPostgresAPIKeyRepository_FindByKeyHash_NotFound(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAPIKeyRepository(pool)
+	ctx := context.Background()
+
+	_, err := repo.FindByKeyHash(ctx, domain.DefaultTenantID, "nonexistent-hash")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+// TestPostgresAPIKeyRepository_RotateAndFullLifecycle proves the full
+// create -> validate(by hash) -> rotate -> validate(old within grace,
+// rejected after) -> revoke -> rejected lifecycle against real Postgres,
+// exercising the exact SQL grace-window OR clause in FindByKeyHash.
+func TestPostgresAPIKeyRepository_RotateAndFullLifecycle(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAPIKeyRepository(pool)
+	client := newTestAPIKeyClient(t, pool)
+	ctx := context.Background()
+
+	originalHash := "hash-original-" + uuid.New().String()
+	key := newTestAPIKey(client.ID, originalHash)
+	_, err := repo.Create(ctx, key)
+	require.NoError(t, err)
+
+	// Validate by original hash succeeds.
+	found, err := repo.FindByKeyHash(ctx, domain.DefaultTenantID, originalHash)
+	require.NoError(t, err)
+	assert.True(t, found.IsActive())
+
+	// Rotate: new hash becomes current, old hash becomes previous with a
+	// future grace deadline.
+	newHash := "hash-rotated-" + uuid.New().String()
+	graceEnd := time.Now().UTC().Add(time.Hour)
+	err = repo.RotateKey(ctx, domain.DefaultTenantID, key.ID, newHash, graceEnd)
+	require.NoError(t, err)
+
+	// Old key still resolves within the grace window.
+	found, err = repo.FindByKeyHash(ctx, domain.DefaultTenantID, originalHash)
+	require.NoError(t, err, "old key hash should still resolve within grace window")
+	assert.Equal(t, key.ID, found.ID)
+
+	// New key resolves immediately.
+	found, err = repo.FindByKeyHash(ctx, domain.DefaultTenantID, newHash)
+	require.NoError(t, err)
+	assert.Equal(t, key.ID, found.ID)
+
+	// Rotate again with an already-expired grace deadline to simulate the
+	// old key's grace window having elapsed.
+	newerHash := "hash-rotated-again-" + uuid.New().String()
+	pastGrace := time.Now().UTC().Add(-time.Hour)
+	err = repo.RotateKey(ctx, domain.DefaultTenantID, key.ID, newerHash, pastGrace)
+	require.NoError(t, err)
+
+	_, err = repo.FindByKeyHash(ctx, domain.DefaultTenantID, newHash)
+	require.Error(t, err, "previous key hash should be rejected once its grace window has elapsed")
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+
+	// Revoke: the current key must be rejected (IsActive false) going forward.
+	err = repo.Revoke(ctx, domain.DefaultTenantID, key.ID)
+	require.NoError(t, err)
+
+	found, err = repo.FindByKeyHash(ctx, domain.DefaultTenantID, newerHash)
+	require.NoError(t, err, "revoked key row is still findable by hash")
+	assert.False(t, found.IsActive(), "revoked key must report inactive")
+}
+
+func TestPostgresAPIKeyRepository_Revoke_AlreadyRevoked(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAPIKeyRepository(pool)
+	client := newTestAPIKeyClient(t, pool)
+	ctx := context.Background()
+
+	key := newTestAPIKey(client.ID, "hash-"+uuid.New().String())
+	_, err := repo.Create(ctx, key)
+	require.NoError(t, err)
+
+	err = repo.Revoke(ctx, domain.DefaultTenantID, key.ID)
+	require.NoError(t, err)
+
+	err = repo.Revoke(ctx, domain.DefaultTenantID, key.ID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrAlreadyDeleted)
+}
+
+func TestPostgresAPIKeyRepository_UpdateLastUsed(t *testing.T) {
+	pool := testPool(t)
+	repo := storage.NewPostgresAPIKeyRepository(pool)
+	client := newTestAPIKeyClient(t, pool)
+	ctx := context.Background()
+
+	key := newTestAPIKey(client.ID, "hash-"+uuid.New().String())
+	_, err := repo.Create(ctx, key)
+	require.NoError(t, err)
+
+	err = repo.UpdateLastUsed(ctx, domain.DefaultTenantID, key.ID)
+	require.NoError(t, err)
+
+	found, err := repo.FindByID(ctx, domain.DefaultTenantID, key.ID)
+	require.NoError(t, err)
+	require.NotNil(t, found.LastUsedAt)
+}

--- a/migrations/000019_create_api_keys_table.down.sql
+++ b/migrations/000019_create_api_keys_table.down.sql
@@ -1,0 +1,2 @@
+-- 000019_create_api_keys_table.down.sql
+DROP TABLE IF EXISTS api_keys;

--- a/migrations/000019_create_api_keys_table.up.sql
+++ b/migrations/000019_create_api_keys_table.up.sql
@@ -1,0 +1,37 @@
+-- 000019_create_api_keys_table.up.sql
+-- API keys for service/agent authentication (see GH-485). The table was
+-- never created despite internal/storage/apikey_repository.go targeting it
+-- since its introduction — every query against api_keys 500'd with
+-- "relation does not exist". Columns match apiKeyColumns in
+-- apikey_repository.go and domain.APIKey exactly.
+--
+-- key_hash stores a SHA-256 hex digest of the raw key (deterministic,
+-- indexed lookup), not an Argon2id hash: API keys are 256-bit random
+-- secrets, not human passwords, so salted slow hashing both defeats
+-- indexed lookup and adds needless per-request latency. See
+-- ValidateAPIKey in internal/admin/apikey_service.go.
+
+CREATE TABLE api_keys (
+    id                        UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id                 UUID        NOT NULL REFERENCES tenants (id),
+    client_id                 UUID        NOT NULL REFERENCES clients (id),
+    name                      TEXT        NOT NULL,
+    key_hash                  TEXT        NOT NULL,
+    previous_key_hash         TEXT        NOT NULL DEFAULT '',
+    previous_key_expires_at   TIMESTAMPTZ,
+    key_prefix                TEXT        NOT NULL,
+    scopes                    TEXT[]      NOT NULL DEFAULT '{}',
+    rate_limit                INTEGER     NOT NULL DEFAULT 0,
+    status                    TEXT        NOT NULL DEFAULT 'active',
+    expires_at                TIMESTAMPTZ,
+    last_used_at              TIMESTAMPTZ,
+    created_at                TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at                TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX idx_api_keys_key_hash ON api_keys (key_hash);
+CREATE INDEX idx_api_keys_tenant_id ON api_keys (tenant_id);
+
+ALTER TABLE api_keys ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_api_keys ON api_keys
+    USING (tenant_id = current_setting('app.current_tenant_id', true)::uuid);

--- a/migrations/consent_grants_migration_test.go
+++ b/migrations/consent_grants_migration_test.go
@@ -57,11 +57,13 @@ func tableExists(t *testing.T, dsn, table string) bool {
 	return exists
 }
 
-// TestMigration_ConsentGrantsUpDown proves 000018_consent_grants applies and
-// reverts cleanly: after `up` the table exists, after reverting exactly this
-// one migration (`steps -1`) it is dropped, matching the down migration's
-// contract. Restores the schema to head afterward so other integration
-// tests sharing TEST_DATABASE_URL see a fully-migrated database.
+// TestMigration_ConsentGrantsUpDown proves 000018_consent_grants and
+// 000019_create_api_keys_table apply and revert cleanly: after `up` both
+// tables exist, after reverting exactly the newest migration (`steps -1`,
+// which undoes 000019) api_keys is dropped while consent_grants — applied
+// by the earlier, non-reverted 000018 — is untouched. Restores the schema
+// to head afterward so other integration tests sharing TEST_DATABASE_URL
+// see a fully-migrated database.
 func TestMigration_ConsentGrantsUpDown(t *testing.T) {
 	m, dsn := testMigrate(t)
 
@@ -78,15 +80,17 @@ func TestMigration_ConsentGrantsUpDown(t *testing.T) {
 	version, dirty, err := m.Version()
 	require.NoError(t, err)
 	require.False(t, dirty, "schema should not be dirty after a clean up")
-	require.Equal(t, uint(18), version, "expected embedded migrations to be at head version 18")
+	require.Equal(t, uint(19), version, "expected embedded migrations to be at head version 19")
 
 	require.True(t, tableExists(t, dsn, "consent_grants"), "consent_grants table should exist after migrate up")
+	require.True(t, tableExists(t, dsn, "api_keys"), "api_keys table should exist after migrate up")
 
-	require.NoError(t, m.Steps(-1), "migrate down one step (000018 down)")
-	require.False(t, tableExists(t, dsn, "consent_grants"), "consent_grants table should be dropped after reverting 000018")
+	require.NoError(t, m.Steps(-1), "migrate down one step (000019 down)")
+	require.False(t, tableExists(t, dsn, "api_keys"), "api_keys table should be dropped after reverting 000019")
+	require.True(t, tableExists(t, dsn, "consent_grants"), "consent_grants table should be unaffected by reverting 000019")
 
 	version, dirty, err = m.Version()
 	require.NoError(t, err)
 	require.False(t, dirty)
-	require.Equal(t, uint(17), version, "expected version 17 after reverting 000018")
+	require.Equal(t, uint(18), version, "expected version 18 after reverting 000019")
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-485.

Closes #485

## Changes

GitHub Issue GH-485: fix(admin): API-key auth structurally broken — no api_keys migration + salted-hash equality lookup always 401s

# GH-TBD

**Created:** 2026-08-30
**Status:** 🚀 Dispatched to Pilot

## Problem

API-key auth is structurally broken twice over: the `api_keys` table has no migration (every repository call 500s with `relation "api_keys" does not exist`), and even with the table present, `ValidateAPIKey` re-hashes the presented key with a fresh random salt and exact-matches the result against the stored hash — which can never succeed with salted Argon2id. Every API-key request returns 401.

## Context

- **No migration**: `grep -rln "api_keys" migrations/*.sql` → zero hits across `000001`–`000018`. All queries in `internal/storage/apikey_repository.go` target a table that was never created.
- **Validation bug** (`internal/admin/apikey_service.go:295-320`): `ValidateAPIKey` calls `s.hasher.Hash(rawKey)` (Argon2id, fresh 16-byte salt per call — `internal/password/hasher.go:73-76`) then `FindByKeyHash` does exact `key_hash = $1 OR previous_key_hash = $1` (`internal/storage/apikey_repository.go:119-126`). Two `Hash()` calls on identical input produce different strings, so lookup always misses → 401.
- Creation (`apikey_service.go:105-146`) stores the Argon2id hash of the full raw key in `key_hash` and a 14-char display prefix (`qf_ak_` + 8 hex) in `key_prefix`. No deterministic lookup column exists.
- Repository column list (`apikey_repository.go:28`): `id, tenant_id, client_id, name, key_hash, previous_key_hash, previous_key_expires_at, key_prefix, scopes, rate_limit, status, expires_at, last_used_at, created_at, updated_at`. Domain struct: `internal/domain/apikey.go:16-32`.
- `migrations/consent_grants_migration_test.go:81` asserts embedded head version `uint(18)` — adding `000019` breaks it.

## Task

1. **Migration `000019_create_api_keys_table`** (up + down): create `api_keys` matching the repository's column list exactly (types per `domain.APIKey`: uuid PKs/FKs, `scopes text[]`, timestamptz for time fields, `status text NOT NULL DEFAULT 'active'`). `tenant_id uuid NOT NULL REFERENCES tenants(id)`, `client_id uuid NOT NULL REFERENCES clients(id)`. Unique index on `key_hash`; index on `tenant_id`. Add the (unarmed) RLS policy following the `000018_consent_grants` pattern for consistency. Down drops the table.
2. **Deterministic key hashing**: switch API-key hashing from Argon2id to SHA-256 hex digest of the raw key, in `CreateAPIKey`, `RotateAPIKey`, and `ValidateAPIKey`. Validation becomes: digest the presented key → `FindByKeyHash` → check `IsActive()`, expiry, and previous-key grace (`previous_key_expires_at`). No data migration needed — the table never existed, so no rows exist in any environment.
3. Update `consent_grants_migration_test.go:81` head assertion `18` → `19` (the `Steps(-1)` assertion at `:91` follows accordingly).

## Technical Decisions

- **SHA-256 instead of Argon2id for API keys**: keys are 256-bit random secrets, not human passwords — brute-forcing the digest is infeasible, and slow salted hashing adds latency per request while making indexed lookup impossible. Deterministic digest = O(1) indexed lookup + constant-time compare semantics via unique index. This mirrors the service's existing "store only token signatures" pattern (refresh tokens, `qf_rt_` HMAC). Keep Argon2id for passwords and client secrets (unchanged).
- `key_prefix` stays display-only.

## Acceptance criteria

- Migration up/down clean on fresh Postgres; embedded-migration test green at head 19.
- Table-driven tests for `ValidateAPIKey`: valid key → key info returned; unknown key → error; revoked/expired key → rejected; rotated key: old key valid within grace window, rejected after; new key valid immediately.
- Full lifecycle integration test: create → validate → rotate → validate (old+new) → revoke → 401.
- `golangci-lint run` and `go test ./...` green.

## Non-goals

Wiring API-key middleware onto additional routes; rate-limit enforcement (`rate_limit` stays stored-only); `last_used_at` tracking semantics beyond what exists.

## Refs

Found via external review 003 (mads feature inventory, verified 2026-08-30 against `f9494e2`).