### PR TITLE
GH-487: fix(deploy): deploy.sh runs nonexistent migrate command and swallows failure — deploys skip migrations

### DIFF
--- a/deployments/README.md
+++ b/deployments/README.md
@@ -195,10 +195,11 @@ cp .env.staging.example .env.staging
 2. Sources the environment file
 3. Saves current container image tag to `.deploy-state/previous-image.staging` (for rollback)
 4. Builds the auth-service image from source (`docker compose build`)
-5. Starts all services (`docker compose up -d`)
-6. Runs database migrations (`docker compose exec auth-service /app/auth-service migrate up`)
-7. Polls `http://localhost:4000/health` with exponential backoff (up to 8 retries, ~2 min max)
-8. Exits non-zero if health check fails
+5. Starts the postgres and redis dependencies (`docker compose up -d postgres redis`)
+6. Runs database migrations (`docker compose run --rm --entrypoint /auth-migrate auth-service up`), aborting before the restart step on failure
+7. Restarts all services, including auth-service (`docker compose up -d`)
+8. Polls `http://localhost:4000/health` with exponential backoff (up to 8 retries, ~2 min max)
+9. Exits non-zero if health check fails
 
 #### Staging Compose Services
 
@@ -501,7 +502,7 @@ If a migration caused the issue:
 
 ```bash
 # Run migration rollback (down)
-docker compose -f deployments/docker-compose.<env>.yml exec auth-service /app/auth-service migrate down
+docker compose -f deployments/docker-compose.<env>.yml exec auth-service /auth-migrate down
 
 # Verify database state
 docker compose -f deployments/docker-compose.<env>.yml exec postgres psql -U <user> -d <db> -c '\dt'

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,7 +7,7 @@
 # Steps:
 #   1. Sources the appropriate .env.<environment> file
 #   2. Pulls latest image (production) or rebuilds (staging)
-#   3. Runs database migrations via docker compose exec
+#   3. Runs database migrations via a one-off `docker compose run` container
 #   4. Restarts services
 #   5. Health-check polling with exponential backoff
 #
@@ -109,15 +109,25 @@ fi
 
 # Step 3: Run database migrations
 info "Step 3/5: Running database migrations..."
-# Start all services so auth-service container is running for exec
-$COMPOSE_CMD up -d
-info "Waiting for database to be ready..."
-sleep 5
+# Bring up only the DB/cache dependencies here, not auth-service. The server
+# itself queries schema (e.g. casbin_policies) during startup, so on a fresh
+# database it crash-loops until migrations are applied — which would leave
+# no running auth-service container for `exec` to target. Use a one-off
+# `run --rm` container instead, decoupled from the long-running service.
+$COMPOSE_CMD up -d postgres redis
 
-# Run migrations via docker compose exec as specified
-$COMPOSE_CMD exec auth-service /app/auth-service migrate up 2>&1 || {
-    info "Migration command not available, skipping (migrate binary may not be built yet)"
-}
+# Migrations live in the separate /auth-migrate binary, not the server
+# binary (docker/Dockerfile). `run` reuses the auth-service image/env
+# (DATABASE_URL / POSTGRES_*) but overrides the entrypoint, and a failure
+# here must abort the deploy before Step 4 restarts services — the
+# rollback state saved in Step 1 is only useful if we stop before
+# replacing the running version.
+if ! $COMPOSE_CMD run --rm --entrypoint /auth-migrate auth-service up; then
+    die "Database migration failed. Aborting before restart; previous version is still running."
+fi
+
+info "Applied schema version:"
+$COMPOSE_CMD run --rm --entrypoint /auth-migrate auth-service version
 
 # Step 4: Restart services
 info "Step 4/5: Restarting services..."


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-487.

Closes #487

## Changes

GitHub Issue GH-487: fix(deploy): deploy.sh runs nonexistent migrate command and swallows failure — deploys skip migrations

# GH-TBD

**Created:** 2026-08-30
**Status:** 🚀 Dispatched to Pilot

## Problem

`scripts/deploy.sh` never runs database migrations: its Step 3 executes a command that does not exist in the image and swallows the failure with an `|| { info "skipping..." }`, so every deploy through this script silently proceeds without migrating.

## Context

- `scripts/deploy.sh:118-120`:
  ```bash
  $COMPOSE_CMD exec auth-service /app/auth-service migrate up 2>&1 || {
      info "Migration command not available, skipping (migrate binary may not be built yet)"
  }
  ```
  Wrong on two counts: (a) the server binary lives at `/auth-service`, not `/app/auth-service` (`docker/Dockerfile:33`, `ENTRYPOINT ["/auth-service"]`); (b) the server has no `migrate` subcommand — migrations live in the separate `/auth-migrate` binary (`docker/Dockerfile:34`, `cmd/migrate/main.go`), invoked as `/auth-migrate <up|down|version|force N>`, reading `DATABASE_URL` or the `POSTGRES_*` env fallbacks (`cmd/migrate/main.go:42-75`).
- Known-good reference: the release CI dry-run job (`.github/workflows/release.yml:103-109`) runs `docker run --rm --entrypoint /auth-migrate -e DATABASE_URL "$IMAGE" up`.

## Task

1. Replace Step 3's exec line with the correct in-image invocation:
   `$COMPOSE_CMD exec auth-service /auth-migrate up` (the running container already carries the DB env vars; `exec` inherits them). If the service container may not be up yet at that point, use `$COMPOSE_CMD run --rm --entrypoint /auth-migrate auth-service up` instead — pick one, verify it works against the compose file, and delete the other.
2. **Fail hard**: remove the `|| { info ... }` swallow. A migration failure must abort the deploy (non-zero exit) *before* Step 4 (restart) — leaving the previous version running is the correct failure mode given Step 1 saved rollback state.
3. Echo the applied version afterwards (`/auth-migrate version`) so deploy logs show the schema version.

## Acceptance criteria

- Local end-to-end check documented in the PR: `docker compose build && ./scripts/deploy.sh` (dev mode) applies migrations on a fresh Postgres and prints the head version.
- Simulated failure (e.g. unreachable Postgres) exits non-zero and never reaches the restart step.
- `shellcheck scripts/deploy.sh` introduces no new warnings.

## Non-goals

Changing the CI release pipeline (its dry-run is already correct); rollback automation for failed migrations; touching `deploy-pointer-aws.yml` (Pointer's consumer deploy path is tracked separately in #447).

## Refs

Found via external review 003 (mads feature inventory, verified 2026-08-30 against `f9494e2`). #447 (Pointer deploy workflow relocation).