### PR TITLE
GH-488: fix(mfa): post-MFA tokens drop roles, MFA status check fails open, 8-digit TOTP can never verify

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -144,7 +144,10 @@ func run(log *zap.Logger, cfg *config.Config) error {
 		Period:          uint(cfg.MFA.Period), //nolint:gosec // non-negative from config
 		BackupCodeCount: cfg.MFA.BackupCodeCount,
 	}
-	mfaSvc := mfa.NewService(mfaCfg, mfaRepo, mfaStore, tokenSvc, log, auditSvc)
+	mfaSvc, err := mfa.NewService(mfaCfg, mfaRepo, mfaStore, tokenSvc, userRepo, log, auditSvc)
+	if err != nil {
+		return fmt.Errorf("mfa service init failed: %w", err)
+	}
 
 	// Inject MFA checker into auth service to enable MFA challenge on login.
 	authSvc.SetMFAChecker(mfaSvc)

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -333,7 +333,17 @@ func (s *Service) Login(ctx context.Context, email, pwd string) (*api.AuthResult
 		mfaEnabled, mfaErr := s.mfa.IsMFAEnabled(ctx, user.ID)
 		if mfaErr != nil {
 			s.logger.Error("failed to check mfa status", zap.String("user_id", user.ID), zap.Error(mfaErr))
-			// Continue with normal login on MFA check failure (fail-open for availability).
+			// Fail closed (NIST SP 800-63-4 AAL2): an MFA-status lookup error
+			// must not silently downgrade an MFA-enrolled user to a
+			// password-only (AAL1) login. An MFA-store outage blocks login
+			// for MFA-enrolled users rather than letting the second factor
+			// be bypassed by degrading the store (GH-488).
+			s.audit.LogEvent(ctx, audit.Event{
+				Type:     "mfa_status_check_failed",
+				ActorID:  user.ID,
+				TargetID: user.ID,
+			})
+			return nil, fmt.Errorf("check mfa status: %w", api.ErrInternalError)
 		} else if mfaEnabled {
 			mfaToken, tokenErr := s.mfa.GenerateMFAToken(ctx, user.ID)
 			if tokenErr != nil {

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -477,6 +477,15 @@ func (m *mockMFAChecker) GenerateMFAToken(ctx context.Context, userID string) (s
 	return "mfa-token-123", nil
 }
 
+// spyAuditor records emitted audit events for assertions.
+type spyAuditor struct {
+	events []audit.Event
+}
+
+func (s *spyAuditor) LogEvent(_ context.Context, event audit.Event) {
+	s.events = append(s.events, event)
+}
+
 func TestLogin_MFAChallenge(t *testing.T) {
 	activeUser := &domain.User{
 		ID:           "user-1",
@@ -540,6 +549,69 @@ func TestLogin_MFANotEnabled_ReturnsTokens(t *testing.T) {
 	require.NotNil(t, result)
 	assert.False(t, result.MFARequired)
 	assert.Equal(t, "qf_at_test-access", result.AccessToken)
+}
+
+// TestLogin_MFAStatusCheckError_FailsClosed is a regression test for GH-488:
+// an error checking MFA status must reject the login (NIST SP 800-63-4 AAL2)
+// instead of silently falling back to a password-only login. Previously this
+// path "failed open" and issued tokens anyway.
+func TestLogin_MFAStatusCheckError_FailsClosed(t *testing.T) {
+	activeUser := &domain.User{
+		ID:           "user-1",
+		Email:        "alice@example.com",
+		PasswordHash: "$argon2id$v=19$m=19456,t=2,p=1$dGVzdHNhbHQ$dGVzdGhhc2g",
+		Roles:        []string{"user"},
+	}
+
+	users := &mockUserRepository{
+		findByEmailFn: func(_ context.Context, _ string) (*domain.User, error) {
+			return activeUser, nil
+		},
+	}
+
+	mfaChecker := &mockMFAChecker{
+		isMFAEnabledFn: func(_ context.Context, _ string) (bool, error) {
+			return false, fmt.Errorf("mfa store unavailable")
+		},
+	}
+
+	var issued bool
+	issuer := &mockTokenIssuer{
+		issueTokenPairFn: func(_ context.Context, _ string, _, _ []string, _ domain.ClientType) (*api.AuthResult, error) {
+			issued = true
+			return &api.AuthResult{}, nil
+		},
+	}
+
+	auditor := &spyAuditor{}
+	logger, _ := zap.NewDevelopment()
+	svc := NewService(ServiceDeps{
+		Redis:    nil,
+		Logger:   logger,
+		Auditor:  auditor,
+		Users:    users,
+		Tokens:   &mockRefreshTokenRepository{},
+		Issuer:   issuer,
+		Hasher:   &mockHasher{},
+		Breaches: &mockBreachChecker{},
+		Email:    &mockEmailSender{},
+	})
+	svc.SetMFAChecker(mfaChecker)
+
+	result, err := svc.Login(context.Background(), "alice@example.com", "correct-password")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrInternalError)
+	assert.Nil(t, result)
+	assert.False(t, issued, "no tokens should be issued when the mfa status check fails")
+
+	var sawEvent bool
+	for _, e := range auditor.events {
+		if e.Type == "mfa_status_check_failed" {
+			sawEvent = true
+			assert.Equal(t, "user-1", e.ActorID)
+		}
+	}
+	assert.True(t, sawEvent, "expected mfa_status_check_failed audit event")
 }
 
 func TestLogin_UpdatesLastLogin(t *testing.T) {

--- a/internal/mfa/mfa.go
+++ b/internal/mfa/mfa.go
@@ -41,6 +41,13 @@ type TokenIssuer interface {
 	IssueTokenPair(ctx context.Context, subject string, roles, scopes []string, clientType domain.ClientType) (*api.AuthResult, error)
 }
 
+// UserLookup abstracts user retrieval for role enrichment when completing
+// MFA login (GH-488). This is a narrow interface satisfied by
+// storage.UserRepository, mirroring token.UserLookup.
+type UserLookup interface {
+	FindByID(ctx context.Context, tenantID uuid.UUID, id string) (*domain.User, error)
+}
+
 // Config holds MFA-specific settings.
 type Config struct {
 	Issuer          string // TOTP issuer name shown in authenticator apps
@@ -65,27 +72,36 @@ type Service struct {
 	repo   storage.MFARepository
 	tokens MFATokenStore
 	issuer TokenIssuer
+	users  UserLookup
 	logger *zap.Logger
 	audit  audit.EventLogger
 }
 
-// NewService creates a new MFA service.
+// NewService creates a new MFA service. Returns an error if cfg is invalid
+// (e.g. an unsupported TOTP digit count), so misconfiguration is caught at
+// startup rather than producing accounts that can never verify (GH-488).
 func NewService(
 	cfg Config,
 	repo storage.MFARepository,
 	tokens MFATokenStore,
 	issuer TokenIssuer,
+	users UserLookup,
 	logger *zap.Logger,
 	auditor audit.EventLogger,
-) *Service {
+) (*Service, error) {
+	if cfg.Digits != 6 && cfg.Digits != 8 {
+		return nil, fmt.Errorf("mfa: invalid digits %d: must be 6 or 8", cfg.Digits)
+	}
+
 	return &Service{
 		cfg:    cfg,
 		repo:   repo,
 		tokens: tokens,
 		issuer: issuer,
+		users:  users,
 		logger: logger,
 		audit:  auditor,
-	}
+	}, nil
 }
 
 // InitiateEnrollment generates a new TOTP secret for the user.
@@ -93,16 +109,11 @@ func NewService(
 func (s *Service) InitiateEnrollment(ctx context.Context, userID, email string) (*api.MFAEnrollmentResult, error) {
 	tenantID := domain.TenantIDFromContext(ctx)
 
-	otpDigits := otp.DigitsSix
-	if s.cfg.Digits == 8 {
-		otpDigits = otp.DigitsEight
-	}
-
 	key, err := totp.Generate(totp.GenerateOpts{
 		Issuer:      s.cfg.Issuer,
 		AccountName: email,
 		Period:      s.cfg.Period,
-		Digits:      otpDigits,
+		Digits:      s.totpDigits(),
 		Algorithm:   otp.AlgorithmSHA1,
 	})
 	if err != nil {
@@ -270,8 +281,20 @@ func (s *Service) CompleteMFALogin(ctx context.Context, mfaToken, code, codeType
 		return nil, fmt.Errorf("unsupported code type %q: %w", codeType, api.ErrUnauthorized)
 	}
 
+	// Re-read the user's current roles before issuance (rather than carrying
+	// roles captured at the password step) so role changes between the
+	// password and MFA steps are honored, consistent with the refresh-path
+	// behavior (GH-432). A lookup failure must not mint a role-less token
+	// (GH-488), so it fails the MFA completion instead of falling back.
+	tenantID := domain.TenantIDFromContext(ctx)
+	user, err := s.users.FindByID(ctx, tenantID, userID)
+	if err != nil {
+		s.logger.Error("failed to look up user for mfa role enrichment", zap.String("user_id", userID), zap.Error(err))
+		return nil, fmt.Errorf("look up user after mfa: %w", api.ErrInternalError)
+	}
+
 	// Issue full token pair now that MFA is verified.
-	result, err := s.issuer.IssueTokenPair(ctx, userID, nil, nil, domain.ClientTypeUser)
+	result, err := s.issuer.IssueTokenPair(ctx, userID, user.Roles, nil, domain.ClientTypeUser)
 	if err != nil {
 		return nil, fmt.Errorf("issue tokens after mfa: %w", err)
 	}
@@ -352,7 +375,7 @@ func (s *Service) IsMFAEnabled(ctx context.Context, userID string) (bool, error)
 func (s *Service) validateTOTP(secret, code string) bool {
 	valid, err := totp.ValidateCustom(code, secret, time.Now().UTC(), totp.ValidateOpts{
 		Period:    s.cfg.Period,
-		Digits:    otp.DigitsSix,
+		Digits:    s.totpDigits(),
 		Algorithm: otp.AlgorithmSHA1,
 	})
 	if err != nil {
@@ -360,6 +383,18 @@ func (s *Service) validateTOTP(secret, code string) bool {
 		return false
 	}
 	return valid
+}
+
+// totpDigits returns the configured TOTP digit count as an otp.Digits value.
+// NewService rejects any Digits value other than 6 or 8, so any value other
+// than 8 here is the 6-digit default (GH-488: this must match the digit
+// count used at enrollment time in InitiateEnrollment, or codes can never
+// verify).
+func (s *Service) totpDigits() otp.Digits {
+	if s.cfg.Digits == 8 {
+		return otp.DigitsEight
+	}
+	return otp.DigitsSix
 }
 
 // generateBackupCodes creates the configured number of random backup codes.

--- a/internal/mfa/mfa_test.go
+++ b/internal/mfa/mfa_test.go
@@ -2,20 +2,30 @@ package mfa
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/google/uuid"
+	"github.com/pquerna/otp"
 	"github.com/pquerna/otp/totp"
+	redisv9 "github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/qf-studio/auth-service/internal/api"
 	"github.com/qf-studio/auth-service/internal/audit"
+	"github.com/qf-studio/auth-service/internal/config"
 	"github.com/qf-studio/auth-service/internal/domain"
 	"github.com/qf-studio/auth-service/internal/storage"
+	tokensvc "github.com/qf-studio/auth-service/internal/token"
 )
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
@@ -138,18 +148,74 @@ func (m *mockTokenIssuer) IssueTokenPair(ctx context.Context, subject string, ro
 	}, nil
 }
 
+type mockUserLookup struct {
+	findByIDFn func(ctx context.Context, tenantID uuid.UUID, id string) (*domain.User, error)
+}
+
+func (m *mockUserLookup) FindByID(ctx context.Context, tenantID uuid.UUID, id string) (*domain.User, error) {
+	if m.findByIDFn != nil {
+		return m.findByIDFn(ctx, tenantID, id)
+	}
+	return &domain.User{ID: id}, nil
+}
+
 // ── Test helpers ─────────────────────────────────────────────────────────────
 
 func newTestService(repo *mockMFARepository, tokens *mockMFATokenStore, issuer *mockTokenIssuer) *Service {
+	return newTestServiceWithUsers(repo, tokens, issuer, &mockUserLookup{})
+}
+
+func newTestServiceWithUsers(repo *mockMFARepository, tokens *mockMFATokenStore, issuer *mockTokenIssuer, users *mockUserLookup) *Service {
+	return newTestServiceWithConfig(DefaultConfig(), repo, tokens, issuer, users)
+}
+
+func newTestServiceWithConfig(cfg Config, repo *mockMFARepository, tokens *mockMFATokenStore, issuer *mockTokenIssuer, users *mockUserLookup) *Service {
 	logger, _ := zap.NewDevelopment()
-	return NewService(
-		DefaultConfig(),
+	svc, err := NewService(
+		cfg,
 		repo,
 		tokens,
 		issuer,
+		users,
 		logger,
 		audit.NopLogger{},
 	)
+	if err != nil {
+		// Only reachable if a test passes an invalid Digits value directly;
+		// callers exercising that path should call NewService themselves.
+		panic(err)
+	}
+	return svc
+}
+
+// newRealTokenIssuer builds a real token.Service (real ES256 key + miniredis)
+// so tests can parse the actual JWT claims minted by CompleteMFALogin,
+// rather than a mockTokenIssuer that echoes back a static token (GH-488).
+func newRealTokenIssuer(t *testing.T) *tokensvc.Service {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(mr.Close)
+	rc := redisv9.NewClient(&redisv9.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rc.Close() })
+
+	cfg := config.JWTConfig{
+		Algorithm:       "ES256",
+		AccessTokenTTL:  15 * time.Minute,
+		RefreshTokenTTL: 7 * 24 * time.Hour,
+		SystemSecrets:   []string{"test-secret-1"},
+	}
+	oidcCfg := config.OIDCConfig{
+		IssuerURL:  "https://auth.qf.studio",
+		IDTokenTTL: 1 * time.Hour,
+	}
+
+	svc, err := tokensvc.NewServiceFromKey(cfg, oidcCfg, key, rc, zap.NewNop(), audit.NopLogger{})
+	require.NoError(t, err)
+	return svc
 }
 
 // ── Enrollment Tests ─────────────────────────────────────────────────────────
@@ -466,6 +532,101 @@ func TestCompleteMFALogin_BackupCode(t *testing.T) {
 	assert.Equal(t, "user-1", result.UserID)
 }
 
+// TestCompleteMFALogin_RolesInAccessTokenClaims is a regression test for
+// GH-488: CompleteMFALogin previously hardcoded nil roles when issuing
+// tokens, so a successful MFA login always demoted the user to a role-less
+// access token. This uses a real token.Service (not a mock) so it can parse
+// the minted JWT and assert on its actual roles claim, per the table-driven
+// cases below.
+func TestCompleteMFALogin_RolesInAccessTokenClaims(t *testing.T) {
+	tests := []struct {
+		name  string
+		roles []string
+	}{
+		{name: "single role", roles: []string{"user"}},
+		{name: "multiple roles", roles: []string{"user", "admin"}},
+		{name: "no roles", roles: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, err := totp.Generate(totp.GenerateOpts{Issuer: "Test", AccountName: "alice@test.com"})
+			require.NoError(t, err)
+			code, err := totp.GenerateCode(key.Secret(), time.Now())
+			require.NoError(t, err)
+
+			repo := &mockMFARepository{
+				getSecretFn: func(_ context.Context, _ string) (*domain.MFASecret, error) {
+					return &domain.MFASecret{Secret: key.Secret(), Confirmed: true}, nil
+				},
+			}
+			tokenStore := &mockMFATokenStore{
+				consumeFn: func(_ context.Context, _ string) (string, error) {
+					return "user-roles-test", nil
+				},
+			}
+			users := &mockUserLookup{
+				findByIDFn: func(_ context.Context, _ uuid.UUID, id string) (*domain.User, error) {
+					return &domain.User{ID: id, Roles: tt.roles}, nil
+				},
+			}
+			issuer := newRealTokenIssuer(t)
+
+			svc, err := NewService(DefaultConfig(), repo, tokenStore, issuer, users, zap.NewNop(), audit.NopLogger{})
+			require.NoError(t, err)
+
+			result, err := svc.CompleteMFALogin(context.Background(), "mfa-token", code, "totp")
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			claims, err := issuer.ValidateToken(context.Background(), strings.TrimPrefix(result.AccessToken, "qf_at_"))
+			require.NoError(t, err)
+			assert.Equal(t, tt.roles, claims.Roles)
+		})
+	}
+}
+
+// TestCompleteMFALogin_UserLookupErrorFailsClosed is a regression test for
+// GH-488: a UserLookup failure during MFA completion must fail the login
+// rather than minting a role-less token.
+func TestCompleteMFALogin_UserLookupErrorFailsClosed(t *testing.T) {
+	key, err := totp.Generate(totp.GenerateOpts{Issuer: "Test", AccountName: "alice@test.com"})
+	require.NoError(t, err)
+	code, err := totp.GenerateCode(key.Secret(), time.Now())
+	require.NoError(t, err)
+
+	repo := &mockMFARepository{
+		getSecretFn: func(_ context.Context, _ string) (*domain.MFASecret, error) {
+			return &domain.MFASecret{Secret: key.Secret(), Confirmed: true}, nil
+		},
+	}
+	tokenStore := &mockMFATokenStore{
+		consumeFn: func(_ context.Context, _ string) (string, error) {
+			return "user-1", nil
+		},
+	}
+	users := &mockUserLookup{
+		findByIDFn: func(_ context.Context, _ uuid.UUID, _ string) (*domain.User, error) {
+			return nil, errors.New("db unavailable")
+		},
+	}
+	var issued bool
+	issuer := &mockTokenIssuer{
+		issueTokenPairFn: func(_ context.Context, _ string, _, _ []string, _ domain.ClientType) (*api.AuthResult, error) {
+			issued = true
+			return &api.AuthResult{}, nil
+		},
+	}
+
+	svc := newTestServiceWithUsers(repo, tokenStore, issuer, users)
+
+	result, err := svc.CompleteMFALogin(context.Background(), "mfa-token", code, "totp")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrInternalError)
+	assert.Nil(t, result)
+	assert.False(t, issued, "no tokens should be issued when user lookup fails")
+}
+
 // ── Disable Tests ────────────────────────────────────────────────────────────
 
 func TestDisable_Success(t *testing.T) {
@@ -590,6 +751,115 @@ func TestGenerateMFAToken_StoreError(t *testing.T) {
 	svc := newTestService(&mockMFARepository{}, tokens, &mockTokenIssuer{})
 	_, err := svc.GenerateMFAToken(context.Background(), "user-1")
 	require.Error(t, err)
+}
+
+// ── Digit Configuration Tests (GH-488) ──────────────────────────────────────
+
+// TestNewService_RejectsInvalidDigits is a regression test for GH-488:
+// misconfigured digit counts must be rejected at construction time rather
+// than silently producing accounts that can never verify.
+func TestNewService_RejectsInvalidDigits(t *testing.T) {
+	tests := []struct {
+		name    string
+		digits  int
+		wantErr bool
+	}{
+		{name: "6 digits valid", digits: 6, wantErr: false},
+		{name: "8 digits valid", digits: 8, wantErr: false},
+		{name: "7 digits invalid", digits: 7, wantErr: true},
+		{name: "0 digits invalid", digits: 0, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Digits = tt.digits
+
+			logger, _ := zap.NewDevelopment()
+			svc, err := NewService(cfg, &mockMFARepository{}, &mockMFATokenStore{}, &mockTokenIssuer{}, &mockUserLookup{}, logger, audit.NopLogger{})
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, svc)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, svc)
+			}
+		})
+	}
+}
+
+// TestEnrollConfirmVerify_EightDigitRoundtrip is a regression test for
+// GH-488: configuring 8-digit TOTP previously created accounts that could
+// never verify, because validateTOTP hardcoded otp.DigitsSix regardless of
+// config. This exercises the full enroll -> confirm -> verify flow with an
+// 8-digit configuration.
+func TestEnrollConfirmVerify_EightDigitRoundtrip(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Digits = 8
+
+	var savedSecret *domain.MFASecret
+	var confirmed bool
+	repo := &mockMFARepository{
+		saveSecretFn: func(_ context.Context, secret *domain.MFASecret) (*domain.MFASecret, error) {
+			savedSecret = secret
+			return secret, nil
+		},
+		getSecretFn: func(_ context.Context, _ string) (*domain.MFASecret, error) {
+			return &domain.MFASecret{Secret: savedSecret.Secret, Confirmed: confirmed}, nil
+		},
+		confirmSecretFn: func(_ context.Context, _ string) error {
+			confirmed = true
+			return nil
+		},
+	}
+
+	svc := newTestServiceWithConfig(cfg, repo, &mockMFATokenStore{}, &mockTokenIssuer{}, &mockUserLookup{})
+
+	enrollment, err := svc.InitiateEnrollment(context.Background(), "user-1", "alice@example.com")
+	require.NoError(t, err)
+	require.NotNil(t, savedSecret)
+
+	code, err := totp.GenerateCodeCustom(enrollment.Secret, time.Now(), totp.ValidateOpts{
+		Period:    cfg.Period,
+		Digits:    otp.DigitsEight,
+		Algorithm: otp.AlgorithmSHA1,
+	})
+	require.NoError(t, err)
+	require.Len(t, code, 8, "expected an 8-digit code")
+
+	_, err = svc.ConfirmEnrollment(context.Background(), "user-1", code)
+	require.NoError(t, err, "8-digit code must verify against 8-digit config")
+	assert.True(t, confirmed)
+
+	// A subsequent 8-digit code must also verify via VerifyTOTP.
+	verifyCode, err := totp.GenerateCodeCustom(enrollment.Secret, time.Now(), totp.ValidateOpts{
+		Period:    cfg.Period,
+		Digits:    otp.DigitsEight,
+		Algorithm: otp.AlgorithmSHA1,
+	})
+	require.NoError(t, err)
+	err = svc.VerifyTOTP(context.Background(), "user-1", verifyCode)
+	require.NoError(t, err)
+}
+
+// TestValidateTOTP_SixDigitDefaultUnchanged ensures the default 6-digit
+// configuration still validates 6-digit codes (no regression from the
+// GH-488 digit-count fix).
+func TestValidateTOTP_SixDigitDefaultUnchanged(t *testing.T) {
+	key, err := totp.Generate(totp.GenerateOpts{Issuer: "Test", AccountName: "alice@test.com"})
+	require.NoError(t, err)
+	code, err := totp.GenerateCode(key.Secret(), time.Now())
+	require.NoError(t, err)
+	require.Len(t, code, 6)
+
+	repo := &mockMFARepository{
+		getSecretFn: func(_ context.Context, _ string) (*domain.MFASecret, error) {
+			return &domain.MFASecret{Secret: key.Secret(), Confirmed: true}, nil
+		},
+	}
+	svc := newTestService(repo, &mockMFATokenStore{}, &mockTokenIssuer{})
+	err = svc.VerifyTOTP(context.Background(), "user-1", code)
+	require.NoError(t, err)
 }
 
 // ── Backup Code Format Tests ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-488.

Closes #488

## Changes

GitHub Issue GH-488: fix(mfa): post-MFA tokens drop roles, MFA status check fails open, 8-digit TOTP can never verify

# GH-TBD

**Created:** 2026-08-30
**Status:** 🚀 Dispatched to Pilot

## Problem

Three MFA defects that together undermine the AAL2 target:
1. Tokens minted after a successful MFA login carry **no roles** — `CompleteMFALogin` hardcodes `nil`.
2. Login **fails open**: if the MFA-status lookup errors, the user gets a password-only login even with MFA enrolled (silent AAL2→AAL1 downgrade on any MFA-repo outage).
3. Configuring 8-digit TOTP creates accounts that can **never verify** — validation hardcodes 6 digits.

## Context

- **Roles dropped**: `internal/mfa/mfa.go:274` — `s.issuer.IssueTokenPair(ctx, userID, nil, nil, domain.ClientTypeUser)`. `mfa.Service` (`mfa.go:63-70`) has no user-repository dependency, so it has nothing to read roles from. `token.Service` already solved this exact problem with setter-injected `UserLookup` (`tokenSvc.SetUserLookup(userRepo)` at `cmd/server/main.go:98`, used for role re-read at `internal/token/service.go:200-209`); `userRepo` is constructed at `main.go:83` and available. (Storing roles in the Redis MFA pending token is NOT viable without an interface change — `StoreMFAToken` stores a bare userID string, `internal/storage/redis_mfa_store.go:84-94`.)
- **Fail-open**: `internal/auth/service.go:331-338` — on `s.mfa.IsMFAEnabled` error, logs and continues to normal token issuance with an explicit "fail-open for availability" comment.
- **8-digit dead end**: `InitiateEnrollment` respects `cfg.Digits==8` when generating the secret/QR (`mfa.go:96-99`), but `validateTOTP` hardcodes `otp.DigitsSix` (`mfa.go:355`), used by both `ConfirmEnrollment` (`:159`) and `VerifyTOTP` (`:202`).

## Task

1. **Roles**: add a `UserLookup` dependency to `mfa.Service` mirroring the `token.Service` pattern (setter or constructor param — match existing style), wire `userRepo` in `cmd/server/main.go`, and in `CompleteMFALogin` read the user's roles before issuance: `IssueTokenPair(ctx, userID, user.Roles, nil, domain.ClientTypeUser)`. If the lookup fails, fail the MFA completion (do not mint role-less tokens).
2. **Fail closed**: in `internal/auth/service.go:331-338`, an error from `IsMFAEnabled` must reject the login (map to `api.ErrInternalError` → 500), with an audit event. Update the comment to state the AAL2 rationale.
3. **Digits**: `validateTOTP` must use the configured digit count (`otp.Digits` from `s.cfg.Digits`) instead of hardcoded `DigitsSix`; validate `Digits ∈ {6, 8}` at config/construction time.

## Technical Decisions

- **Availability vs. AAL2**: fail-closed is the NIST SP 800-63-4 AAL2-consistent choice — an attacker must not be able to bypass the second factor by degrading the MFA store. An MFA-repo outage now blocks logins for MFA-enrolled users; that is the intended trade.
- Roles are re-read at MFA completion time (not captured at password step) so role changes between password and MFA steps are honored — consistent with refresh-path behavior.

## Acceptance criteria

- Table-driven test: MFA login completion produces an access token whose claims include the user's roles (parse the JWT in-test).
- `UserLookup` error during completion → login fails, no tokens issued.
- Fault-injected `IsMFAEnabled` error → login rejected (500), audit event emitted; MFA-disabled and MFA-enabled happy paths unchanged.
- 8-digit config: enrollment → confirm → verify roundtrip passes with 8-digit codes; 6-digit default unchanged; invalid digit config rejected at startup.
- Existing MFA/auth tests stay green; `go test ./...` and `golangci-lint run` clean.

## Non-goals

WebAuthn wiring; MFA rate-limit changes (Redis lockout already exists); step-up/AAL2 session semantics; changing the MFA pending-token storage shape.

## Refs

Found via external review 003 (mads feature inventory, verified 2026-08-30 against `f9494e2`).