### PR TITLE
GH-486: fix(token): refresh-token introspection inverted — full token stored as signature, rotation never updates Postgres

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -96,6 +96,9 @@ func run(log *zap.Logger, cfg *config.Config) error {
 	}
 	// Enrich refresh-minted access tokens with the user's current roles (GH-432).
 	tokenSvc.SetUserLookup(userRepo)
+	// Keep Postgres refresh-token bookkeeping (used for introspection) truthful
+	// across rotation (GH-486).
+	tokenSvc.SetRefreshTokenStore(refreshTokenRepo)
 	hibpClient := hibp.NewClient(http.DefaultClient)
 
 	// ── Email ────────────────────────────────────────────────────────────
@@ -107,17 +110,18 @@ func run(log *zap.Logger, cfg *config.Config) error {
 	}
 
 	authSvc := auth.NewService(auth.ServiceDeps{
-		Redis:         redisClient,
-		Logger:        log,
-		Auditor:       auditSvc,
-		Users:         userRepo,
-		Tokens:        refreshTokenRepo,
-		Issuer:        tokenSvc,
-		Hasher:        hasher,
-		Breaches:      hibpClient,
-		Email:         emailSender,
-		ResetURLBase:  cfg.Email.PasswordResetURLBase,
-		VerifyURLBase: cfg.Email.EmailVerifyURLBase,
+		Redis:           redisClient,
+		Logger:          log,
+		Auditor:         auditSvc,
+		Users:           userRepo,
+		Tokens:          refreshTokenRepo,
+		Issuer:          tokenSvc,
+		Hasher:          hasher,
+		Breaches:        hibpClient,
+		Email:           emailSender,
+		ResetURLBase:    cfg.Email.PasswordResetURLBase,
+		VerifyURLBase:   cfg.Email.EmailVerifyURLBase,
+		RefreshTokenTTL: cfg.JWT.RefreshTokenTTL,
 	})
 
 	// ── Session ──────────────────────────────────────────────────────────

--- a/internal/admin/refresh_token_flow_test.go
+++ b/internal/admin/refresh_token_flow_test.go
@@ -1,0 +1,214 @@
+package admin_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/qf-studio/auth-service/internal/admin"
+	"github.com/qf-studio/auth-service/internal/audit"
+	"github.com/qf-studio/auth-service/internal/config"
+	"github.com/qf-studio/auth-service/internal/domain"
+	"github.com/qf-studio/auth-service/internal/password"
+	"github.com/qf-studio/auth-service/internal/storage/mocks"
+	"github.com/qf-studio/auth-service/internal/token"
+
+	authpkg "github.com/qf-studio/auth-service/internal/auth"
+)
+
+// fakeRefreshTokenRepository is a thread-safe, map-backed implementation of
+// storage.RefreshTokenRepository (via mocks.MockRefreshTokenRepository) used
+// to wire token.Service, auth.Service, and admin.TokenService together in
+// this test so they observe the same Postgres-side state, the way they do
+// through the real repository in production.
+type fakeRefreshTokenRepository struct {
+	mu      sync.Mutex
+	records map[string]*domain.RefreshTokenRecord
+}
+
+func newFakeRefreshTokenRepository() *mocks.MockRefreshTokenRepository {
+	f := &fakeRefreshTokenRepository{records: make(map[string]*domain.RefreshTokenRecord)}
+
+	return &mocks.MockRefreshTokenRepository{
+		StoreFn: func(_ context.Context, tenantID uuid.UUID, signature, userID string, expiresAt time.Time) error {
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			f.records[signature] = &domain.RefreshTokenRecord{
+				Signature: signature,
+				TenantID:  tenantID,
+				UserID:    userID,
+				ExpiresAt: expiresAt,
+				CreatedAt: time.Now(),
+			}
+			return nil
+		},
+		FindBySignatureFn: func(_ context.Context, _ uuid.UUID, signature string) (*domain.RefreshTokenRecord, error) {
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			rec, ok := f.records[signature]
+			if !ok {
+				return nil, assertNotFoundErr
+			}
+			return rec, nil
+		},
+		RevokeFn: func(_ context.Context, _ uuid.UUID, signature string) error {
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			rec, ok := f.records[signature]
+			if !ok {
+				return nil
+			}
+			now := time.Now()
+			rec.RevokedAt = &now
+			return nil
+		},
+		RevokeAllForUserFn: func(_ context.Context, _ uuid.UUID, userID string) error {
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			now := time.Now()
+			for _, rec := range f.records {
+				if rec.UserID == userID {
+					rec.RevokedAt = &now
+				}
+			}
+			return nil
+		},
+	}
+}
+
+var assertNotFoundErr = errNotFound{}
+
+type errNotFound struct{}
+
+func (errNotFound) Error() string { return "refresh token record not found" }
+
+// TestRefreshTokenIntrospectionFlow is the GH-486 end-to-end acceptance test:
+// login mints a refresh token whose signature is correctly persisted to
+// Postgres (not the full token), introspection reflects it as active with the
+// right sub/exp/iat, rotation revokes the old signature's row and persists
+// the new one so introspection tracks the rotation immediately, and logout
+// revokes the current refresh token's row so introspection reflects it too.
+func TestRefreshTokenIntrospectionFlow(t *testing.T) {
+	ctx := context.Background()
+
+	// ── Redis (shared by token.Service for its hot-path state) ──
+	mr := miniredis.RunT(t)
+	rc := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rc.Close() })
+
+	// ── Signing key + token.Service ──
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	jwtCfg := config.JWTConfig{
+		Algorithm:       "ES256",
+		AccessTokenTTL:  15 * time.Minute,
+		RefreshTokenTTL: 7 * 24 * time.Hour,
+		SystemSecrets:   []string{"test-secret"},
+	}
+	oidcCfg := config.OIDCConfig{
+		IssuerURL:  "https://auth.qf.studio",
+		IDTokenTTL: time.Hour,
+	}
+
+	tokenSvc, err := token.NewServiceFromKey(jwtCfg, oidcCfg, key, rc, zap.NewNop(), audit.NopLogger{})
+	require.NoError(t, err)
+
+	// ── Shared fake Postgres-backed refresh token repository ──
+	refreshRepo := newFakeRefreshTokenRepository()
+	tokenSvc.SetRefreshTokenStore(refreshRepo)
+
+	// ── auth.Service ──
+	hasher := password.New(nil)
+	passwordHash, err := hasher.Hash("correct horse battery staple")
+	require.NoError(t, err)
+
+	user := &domain.User{
+		ID:           "user-1",
+		TenantID:     domain.DefaultTenantID,
+		Email:        "test@example.com",
+		PasswordHash: passwordHash,
+		Roles:        []string{"user"},
+	}
+
+	userRepo := &mocks.MockUserRepository{
+		FindByEmailFn: func(_ context.Context, _ uuid.UUID, email string) (*domain.User, error) {
+			if email == user.Email {
+				return user, nil
+			}
+			return nil, assertNotFoundErr
+		},
+		UpdateLastLoginFn: func(_ context.Context, _ uuid.UUID, _ string, _ time.Time) error {
+			return nil
+		},
+	}
+
+	authSvc := authpkg.NewService(authpkg.ServiceDeps{
+		Redis:           rc,
+		Logger:          zap.NewNop(),
+		Auditor:         audit.NopLogger{},
+		Users:           userRepo,
+		Tokens:          refreshRepo,
+		Issuer:          tokenSvc,
+		Hasher:          hasher,
+		RefreshTokenTTL: jwtCfg.RefreshTokenTTL,
+	})
+
+	// ── admin.TokenService (introspection) ──
+	adminTokenSvc := admin.NewTokenService(tokenSvc, refreshRepo, oidcCfg.IssuerURL, zap.NewNop(), audit.NopLogger{})
+
+	// ── Step 1: login ──
+	loginResult, err := authSvc.Login(ctx, user.Email, "correct horse battery staple")
+	require.NoError(t, err)
+	require.NotEmpty(t, loginResult.RefreshToken)
+	require.NotEmpty(t, loginResult.AccessToken)
+
+	// ── Step 2: introspect the freshly minted refresh token ──
+	introspectResp, err := adminTokenSvc.Introspect(ctx, loginResult.RefreshToken)
+	require.NoError(t, err)
+	assert.True(t, introspectResp.Active, "freshly issued refresh token should introspect active")
+	assert.Equal(t, user.ID, introspectResp.Sub)
+	assert.NotZero(t, introspectResp.Exp)
+	assert.NotZero(t, introspectResp.Iat)
+	assert.Greater(t, introspectResp.Exp, introspectResp.Iat)
+
+	oldRefreshToken := loginResult.RefreshToken
+
+	// ── Step 3: refresh (rotate) ──
+	refreshResult, err := tokenSvc.Refresh(ctx, oldRefreshToken)
+	require.NoError(t, err)
+	require.NotEmpty(t, refreshResult.RefreshToken)
+	assert.NotEqual(t, oldRefreshToken, refreshResult.RefreshToken, "rotation should mint a new refresh token")
+
+	// Old refresh token must no longer introspect as active.
+	oldIntrospectResp, err := adminTokenSvc.Introspect(ctx, oldRefreshToken)
+	require.NoError(t, err)
+	assert.False(t, oldIntrospectResp.Active, "rotated-away refresh token should introspect inactive immediately")
+
+	// New refresh token must introspect as active.
+	newIntrospectResp, err := adminTokenSvc.Introspect(ctx, refreshResult.RefreshToken)
+	require.NoError(t, err)
+	assert.True(t, newIntrospectResp.Active, "newly rotated refresh token should introspect active")
+	assert.Equal(t, user.ID, newIntrospectResp.Sub)
+	assert.NotZero(t, newIntrospectResp.Exp)
+	assert.NotZero(t, newIntrospectResp.Iat)
+
+	// ── Step 4: logout ──
+	err = authSvc.Logout(ctx, user.ID, refreshResult.AccessToken, refreshResult.RefreshToken)
+	require.NoError(t, err)
+
+	loggedOutIntrospectResp, err := adminTokenSvc.Introspect(ctx, refreshResult.RefreshToken)
+	require.NoError(t, err)
+	assert.False(t, loggedOutIntrospectResp.Active, "refresh token should introspect inactive after logout")
+}

--- a/internal/admin/token_service.go
+++ b/internal/admin/token_service.go
@@ -121,13 +121,10 @@ func (s *TokenService) introspectRefreshToken(ctx context.Context, token string)
 		return &api.IntrospectionResponse{Active: false}, nil
 	}
 
-	// Strip prefix and split into key + signature parts.
-	raw := strings.TrimPrefix(token, "qf_rt_")
-	parts := strings.SplitN(raw, ".", 2)
-	if len(parts) != 2 || parts[1] == "" {
+	signature, ok := domain.RefreshTokenSignature(token)
+	if !ok {
 		return &api.IntrospectionResponse{Active: false}, nil
 	}
-	signature := parts[1]
 
 	tenantID := domain.TenantIDFromContext(ctx)
 	rec, err := s.refreshTokens.FindBySignature(ctx, tenantID, signature)

--- a/internal/api/auth_handlers.go
+++ b/internal/api/auth_handlers.go
@@ -144,7 +144,13 @@ func (h *AuthHandlers) Logout(c *gin.Context) {
 
 	token := extractBearerToken(c)
 
-	if err := h.auth.Logout(c.Request.Context(), userID, token); err != nil {
+	// The refresh token is optional and not validated via the shared
+	// middleware (an absent/empty body is valid here); ignore bind errors
+	// and fall back to the zero value.
+	var req domain.LogoutRequest
+	_ = c.ShouldBindJSON(&req)
+
+	if err := h.auth.Logout(c.Request.Context(), userID, token, req.RefreshToken); err != nil {
 		handleServiceError(c, err)
 		return
 	}

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -32,7 +32,7 @@ type mockAuthService struct {
 	verifyEmailFn          func(ctx context.Context, token string) error
 	getMeFn                func(ctx context.Context, userID string) (*api.UserInfo, error)
 	changePasswordFn       func(ctx context.Context, userID, oldPassword, newPassword string) error
-	logoutFn               func(ctx context.Context, userID, token string) error
+	logoutFn               func(ctx context.Context, userID, token, refreshToken string) error
 	logoutAllFn            func(ctx context.Context, userID string) error
 }
 
@@ -90,9 +90,9 @@ func (m *mockAuthService) ChangePassword(ctx context.Context, userID, oldPasswor
 	return nil
 }
 
-func (m *mockAuthService) Logout(ctx context.Context, userID, token string) error {
+func (m *mockAuthService) Logout(ctx context.Context, userID, token, refreshToken string) error {
 	if m.logoutFn != nil {
-		return m.logoutFn(ctx, userID, token)
+		return m.logoutFn(ctx, userID, token, refreshToken)
 	}
 	return nil
 }

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -44,7 +44,7 @@ type AuthService interface {
 	VerifyEmail(ctx context.Context, token string) error
 	GetMe(ctx context.Context, userID string) (*UserInfo, error)
 	ChangePassword(ctx context.Context, userID, oldPassword, newPassword string) error
-	Logout(ctx context.Context, userID, token string) error
+	Logout(ctx context.Context, userID, token, refreshToken string) error
 	LogoutAll(ctx context.Context, userID string) error
 }
 

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -67,7 +67,15 @@ type Service struct {
 	email         email.EmailSender
 	resetURLBase  string
 	verifyURLBase string
+
+	// refreshTokenTTL is the configured lifetime for newly stored refresh
+	// token DB rows. Falls back to defaultRefreshTokenTTL when unset (e.g.
+	// tests that don't configure it), matching the previous hardcoded value.
+	refreshTokenTTL time.Duration
 }
+
+// defaultRefreshTokenTTL is used when ServiceDeps.RefreshTokenTTL is unset.
+const defaultRefreshTokenTTL = 24 * time.Hour
 
 // ServiceDeps groups the dependencies needed to construct a Service. Using a
 // struct here keeps NewService's call sites readable now that email delivery
@@ -84,23 +92,30 @@ type ServiceDeps struct {
 	Email         email.EmailSender
 	ResetURLBase  string // base URL password-reset links are built from: "<ResetURLBase>?token=<token>"
 	VerifyURLBase string // base URL email-verification links are built from: "<VerifyURLBase>?token=<token>"
+
+	// RefreshTokenTTL is the lifetime used for refresh token DB rows stored
+	// at login. Should match the token service's configured refresh TTL
+	// (cfg.JWT.RefreshTokenTTL) so the DB row doesn't outlive or expire
+	// before the Redis-backed token it introspects for.
+	RefreshTokenTTL time.Duration
 }
 
 // NewService creates a new auth Service.
 func NewService(deps ServiceDeps) *Service {
 	return &Service{
-		redis:         deps.Redis,
-		logger:        deps.Logger,
-		audit:         deps.Auditor,
-		users:         deps.Users,
-		tokens:        deps.Tokens,
-		issuer:        deps.Issuer,
-		hasher:        deps.Hasher,
-		breaches:      deps.Breaches,
-		email:         deps.Email,
-		resetURLBase:  deps.ResetURLBase,
-		verifyURLBase: deps.VerifyURLBase,
-		policy:        password.NewPolicyValidator(password.DefaultPolicy(), deps.Hasher),
+		redis:           deps.Redis,
+		logger:          deps.Logger,
+		audit:           deps.Auditor,
+		users:           deps.Users,
+		tokens:          deps.Tokens,
+		issuer:          deps.Issuer,
+		hasher:          deps.Hasher,
+		breaches:        deps.Breaches,
+		email:           deps.Email,
+		resetURLBase:    deps.ResetURLBase,
+		verifyURLBase:   deps.VerifyURLBase,
+		refreshTokenTTL: deps.RefreshTokenTTL,
+		policy:          password.NewPolicyValidator(password.DefaultPolicy(), deps.Hasher),
 	}
 }
 
@@ -373,8 +388,19 @@ func (s *Service) Login(ctx context.Context, email, pwd string) (*api.AuthResult
 	result.UserID = user.ID
 
 	// Store refresh token signature in DB (best-effort — don't fail login).
-	if err := s.tokens.Store(ctx, tenantID, result.RefreshToken, user.ID, time.Now().Add(24*time.Hour)); err != nil {
-		s.logger.Error("failed to store refresh token signature", zap.String("user_id", user.ID), zap.Error(err))
+	// Only the signature segment is persisted, never the full token
+	// (GH-486): storing the full token broke introspection lookups, which
+	// key on FindBySignature(parts[1]) alone.
+	if sig, ok := domain.RefreshTokenSignature(result.RefreshToken); ok {
+		ttl := s.refreshTokenTTL
+		if ttl <= 0 {
+			ttl = defaultRefreshTokenTTL
+		}
+		if err := s.tokens.Store(ctx, tenantID, sig, user.ID, time.Now().Add(ttl)); err != nil {
+			s.logger.Error("failed to store refresh token signature", zap.String("user_id", user.ID), zap.Error(err))
+		}
+	} else {
+		s.logger.Error("failed to parse refresh token signature, skipping DB store", zap.String("user_id", user.ID))
 	}
 
 	// Update last_login_at (best-effort — don't fail login).
@@ -613,8 +639,12 @@ func (s *Service) ChangePassword(ctx context.Context, userID, oldPassword, newPa
 }
 
 // Logout terminates a single session by revoking the access token via Redis
-// blocklist and revoking the refresh token in the database.
-func (s *Service) Logout(ctx context.Context, userID, token string) error {
+// blocklist and, when a refresh token is supplied, marking its DB row
+// revoked so introspection reflects the logout (GH-486). The refresh token
+// is optional and best-effort: its absence or a DB failure must not fail
+// the logout, since the Redis blocklist entry is the primary revocation
+// signal for the access token itself.
+func (s *Service) Logout(ctx context.Context, userID, token, refreshToken string) error {
 	// Revoke the access token via Redis blocklist.
 	if err := s.issuer.Revoke(ctx, token); err != nil {
 		s.logger.Error("failed to revoke access token",
@@ -622,6 +652,21 @@ func (s *Service) Logout(ctx context.Context, userID, token string) error {
 			zap.Error(err),
 		)
 		return fmt.Errorf("revoke access token: %w", err)
+	}
+
+	if refreshToken != "" {
+		if sig, ok := domain.RefreshTokenSignature(refreshToken); ok {
+			tenantID := domain.TenantIDFromContext(ctx)
+			if err := s.tokens.Revoke(ctx, tenantID, sig); err != nil {
+				s.logger.Warn("failed to revoke refresh token on logout",
+					zap.String("user_id", userID),
+					zap.Error(err),
+				)
+			}
+		} else {
+			s.logger.Warn("logout: malformed refresh token, skipping DB revoke",
+				zap.String("user_id", userID))
+		}
 	}
 
 	s.audit.LogEvent(ctx, audit.Event{

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -103,6 +103,7 @@ func (m *mockUserRepository) AddPasswordHistory(ctx context.Context, _ uuid.UUID
 
 type mockRefreshTokenRepository struct {
 	storeFn          func(ctx context.Context, sig, userID string, exp time.Time) error
+	revokeFn         func(ctx context.Context, sig string) error
 	revokeAllForUser func(ctx context.Context, userID string) error
 }
 
@@ -117,7 +118,10 @@ func (m *mockRefreshTokenRepository) FindBySignature(_ context.Context, _ uuid.U
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (m *mockRefreshTokenRepository) Revoke(_ context.Context, _ uuid.UUID, _ string) error {
+func (m *mockRefreshTokenRepository) Revoke(ctx context.Context, _ uuid.UUID, sig string) error {
+	if m.revokeFn != nil {
+		return m.revokeFn(ctx, sig)
+	}
 	return nil
 }
 
@@ -139,7 +143,7 @@ func (m *mockTokenIssuer) IssueTokenPair(ctx context.Context, subject string, ro
 	}
 	return &api.AuthResult{
 		AccessToken:  "qf_at_test-access",
-		RefreshToken: "qf_rt_test-refresh",
+		RefreshToken: "qf_rt_test-key.test-refresh-sig",
 		TokenType:    "Bearer",
 		ExpiresIn:    900,
 	}, nil
@@ -448,7 +452,7 @@ func TestLogin(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, result)
 				assert.Equal(t, "qf_at_test-access", result.AccessToken)
-				assert.Equal(t, "qf_rt_test-refresh", result.RefreshToken)
+				assert.Equal(t, "qf_rt_test-key.test-refresh-sig", result.RefreshToken)
 				assert.Equal(t, "Bearer", result.TokenType)
 				assert.Equal(t, 900, result.ExpiresIn)
 			}
@@ -639,11 +643,15 @@ func TestLogin_UpdatesLastLogin(t *testing.T) {
 
 func TestLogin_StoresRefreshTokenSignature(t *testing.T) {
 	var stored bool
+	var storedExpiry time.Time
 	tokens := &mockRefreshTokenRepository{
-		storeFn: func(_ context.Context, sig, userID string, _ time.Time) error {
+		storeFn: func(_ context.Context, sig, userID string, exp time.Time) error {
 			stored = true
-			assert.Equal(t, "qf_rt_test-refresh", sig)
+			// Only the signature segment (after the dot) should be stored,
+			// never the full "qf_rt_<key>.<sig>" token (GH-486).
+			assert.Equal(t, "test-refresh-sig", sig)
 			assert.Equal(t, "user-1", userID)
+			storedExpiry = exp
 			return nil
 		},
 	}
@@ -662,6 +670,80 @@ func TestLogin_StoresRefreshTokenSignature(t *testing.T) {
 	_, err := svc.Login(context.Background(), "alice@example.com", "password")
 	require.NoError(t, err)
 	assert.True(t, stored, "expected refresh token signature to be stored")
+	// newUnitService doesn't configure RefreshTokenTTL, so the default fallback applies.
+	assert.WithinDuration(t, time.Now().Add(defaultRefreshTokenTTL), storedExpiry, 5*time.Second)
+}
+
+func TestLogin_StoresRefreshTokenSignature_UsesConfiguredTTL(t *testing.T) {
+	var storedExpiry time.Time
+	tokens := &mockRefreshTokenRepository{
+		storeFn: func(_ context.Context, _, _ string, exp time.Time) error {
+			storedExpiry = exp
+			return nil
+		},
+	}
+	users := &mockUserRepository{
+		findByEmailFn: func(_ context.Context, _ string) (*domain.User, error) {
+			return &domain.User{
+				ID:           "user-1",
+				Email:        "alice@example.com",
+				PasswordHash: "hash",
+				Roles:        []string{"user"},
+			}, nil
+		},
+	}
+
+	logger, _ := zap.NewDevelopment()
+	svc := NewService(ServiceDeps{
+		Logger:          logger,
+		Auditor:         audit.NopLogger{},
+		Users:           users,
+		Tokens:          tokens,
+		Issuer:          &mockTokenIssuer{},
+		Hasher:          &mockHasher{},
+		Breaches:        &mockBreachChecker{},
+		Email:           &mockEmailSender{},
+		RefreshTokenTTL: 7 * 24 * time.Hour,
+	})
+
+	_, err := svc.Login(context.Background(), "alice@example.com", "password")
+	require.NoError(t, err)
+	assert.WithinDuration(t, time.Now().Add(7*24*time.Hour), storedExpiry, 5*time.Second)
+}
+
+func TestLogin_MalformedRefreshTokenSkipsStore(t *testing.T) {
+	var stored bool
+	tokens := &mockRefreshTokenRepository{
+		storeFn: func(_ context.Context, _, _ string, _ time.Time) error {
+			stored = true
+			return nil
+		},
+	}
+	users := &mockUserRepository{
+		findByEmailFn: func(_ context.Context, _ string) (*domain.User, error) {
+			return &domain.User{
+				ID:           "user-1",
+				Email:        "alice@example.com",
+				PasswordHash: "hash",
+				Roles:        []string{"user"},
+			}, nil
+		},
+	}
+	issuer := &mockTokenIssuer{
+		issueTokenPairFn: func(_ context.Context, _ string, _, _ []string, _ domain.ClientType) (*api.AuthResult, error) {
+			return &api.AuthResult{
+				AccessToken:  "qf_at_test-access",
+				RefreshToken: "qf_rt_no-dot-here",
+				TokenType:    "Bearer",
+				ExpiresIn:    900,
+			}, nil
+		},
+	}
+
+	svc := newUnitService(t, users, tokens, issuer, &mockHasher{})
+	_, err := svc.Login(context.Background(), "alice@example.com", "password")
+	require.NoError(t, err, "login must succeed even when the signature parse fails (best-effort store)")
+	assert.False(t, stored, "malformed refresh token must not be stored")
 }
 
 // ── Logout Tests ─────────────────────────────────────────────────────────────
@@ -691,7 +773,7 @@ func TestLogout(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := newUnitService(t, &mockUserRepository{}, &mockRefreshTokenRepository{}, tt.issuer, &mockHasher{})
-			err := svc.Logout(context.Background(), "user-1", "qf_at_some-token")
+			err := svc.Logout(context.Background(), "user-1", "qf_at_some-token", "")
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -711,9 +793,79 @@ func TestLogout_RevokesAccessToken(t *testing.T) {
 	}
 
 	svc := newUnitService(t, &mockUserRepository{}, &mockRefreshTokenRepository{}, issuer, &mockHasher{})
-	err := svc.Logout(context.Background(), "user-1", "qf_at_my-access-token")
+	err := svc.Logout(context.Background(), "user-1", "qf_at_my-access-token", "")
 	require.NoError(t, err)
 	assert.Equal(t, "qf_at_my-access-token", revokedToken)
+}
+
+// TestLogout_RevokesRefreshTokenSignature is a regression test for GH-486:
+// Logout's doc comment claimed the refresh token's DB row was revoked, but
+// the implementation never touched it, so a rotated-away token stayed
+// introspectable as active until its row's original TTL expired. When the
+// caller supplies the refresh token, its signature must be revoked too.
+func TestLogout_RevokesRefreshTokenSignature(t *testing.T) {
+	var revokedSig string
+	tokens := &mockRefreshTokenRepository{
+		revokeFn: func(_ context.Context, sig string) error {
+			revokedSig = sig
+			return nil
+		},
+	}
+
+	svc := newUnitService(t, &mockUserRepository{}, tokens, &mockTokenIssuer{}, &mockHasher{})
+	err := svc.Logout(context.Background(), "user-1", "qf_at_my-access-token", "qf_rt_key123.sig456")
+	require.NoError(t, err)
+	assert.Equal(t, "sig456", revokedSig)
+}
+
+// TestLogout_NoRefreshTokenSkipsRevoke confirms logout stays functional
+// (access-token-only) when the caller doesn't supply a refresh token — the
+// common case for /auth/logout callers that don't send a body.
+func TestLogout_NoRefreshTokenSkipsRevoke(t *testing.T) {
+	var revokeCalled bool
+	tokens := &mockRefreshTokenRepository{
+		revokeFn: func(_ context.Context, _ string) error {
+			revokeCalled = true
+			return nil
+		},
+	}
+
+	svc := newUnitService(t, &mockUserRepository{}, tokens, &mockTokenIssuer{}, &mockHasher{})
+	err := svc.Logout(context.Background(), "user-1", "qf_at_my-access-token", "")
+	require.NoError(t, err)
+	assert.False(t, revokeCalled)
+}
+
+// TestLogout_MalformedRefreshTokenSkipsRevoke confirms a malformed refresh
+// token doesn't fail logout or reach the DB revoke call.
+func TestLogout_MalformedRefreshTokenSkipsRevoke(t *testing.T) {
+	var revokeCalled bool
+	tokens := &mockRefreshTokenRepository{
+		revokeFn: func(_ context.Context, _ string) error {
+			revokeCalled = true
+			return nil
+		},
+	}
+
+	svc := newUnitService(t, &mockUserRepository{}, tokens, &mockTokenIssuer{}, &mockHasher{})
+	err := svc.Logout(context.Background(), "user-1", "qf_at_my-access-token", "qf_rt_no-dot-here")
+	require.NoError(t, err)
+	assert.False(t, revokeCalled)
+}
+
+// TestLogout_RefreshTokenRevokeFailureDoesNotFailLogout confirms the DB
+// revoke is best-effort: a failure there must not fail the overall logout,
+// since the access-token Redis blocklist entry is the primary signal.
+func TestLogout_RefreshTokenRevokeFailureDoesNotFailLogout(t *testing.T) {
+	tokens := &mockRefreshTokenRepository{
+		revokeFn: func(_ context.Context, _ string) error {
+			return fmt.Errorf("db down")
+		},
+	}
+
+	svc := newUnitService(t, &mockUserRepository{}, tokens, &mockTokenIssuer{}, &mockHasher{})
+	err := svc.Logout(context.Background(), "user-1", "qf_at_my-access-token", "qf_rt_key123.sig456")
+	require.NoError(t, err)
 }
 
 // ── LogoutAll Tests ──────────────────────────────────────────────────────────

--- a/internal/domain/refresh_token.go
+++ b/internal/domain/refresh_token.go
@@ -1,0 +1,31 @@
+package domain
+
+import "strings"
+
+// refreshTokenPrefix is the leak-detection prefix prepended to refresh
+// tokens (mirrors token.refreshTokenPrefix, duplicated here since domain
+// must not import the token package).
+const refreshTokenPrefix = "qf_rt_"
+
+// RefreshTokenSignature extracts the signature segment from a refresh token
+// string of the form "qf_rt_<keyEncoded>.<sigEncoded>". The signature is the
+// only part ever persisted to the refresh_tokens table (never the full
+// token) — this helper centralizes that parse so the login-time store
+// (internal/auth/service.go) and introspection lookup
+// (internal/admin/token_service.go) can't drift apart (GH-486).
+//
+// Returns ok=false if the token doesn't carry the qf_rt_ prefix, has no "."
+// separator, or the signature segment is empty.
+func RefreshTokenSignature(token string) (string, bool) {
+	if !strings.HasPrefix(token, refreshTokenPrefix) {
+		return "", false
+	}
+
+	raw := strings.TrimPrefix(token, refreshTokenPrefix)
+	parts := strings.SplitN(raw, ".", 2)
+	if len(parts) != 2 || parts[1] == "" {
+		return "", false
+	}
+
+	return parts[1], true
+}

--- a/internal/domain/refresh_token_test.go
+++ b/internal/domain/refresh_token_test.go
@@ -1,0 +1,58 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/qf-studio/auth-service/internal/domain"
+)
+
+func TestRefreshTokenSignature(t *testing.T) {
+	tests := []struct {
+		name      string
+		token     string
+		wantSig   string
+		wantOK    bool
+		wantEmpty bool
+	}{
+		{
+			name:    "well-formed",
+			token:   "qf_rt_abc123.sig456",
+			wantSig: "sig456",
+			wantOK:  true,
+		},
+		{
+			name:   "missing dot",
+			token:  "qf_rt_abc123sig456",
+			wantOK: false,
+		},
+		{
+			name:   "empty signature",
+			token:  "qf_rt_abc123.",
+			wantOK: false,
+		},
+		{
+			name:   "wrong prefix",
+			token:  "qf_at_abc123.sig456",
+			wantOK: false,
+		},
+		{
+			name:   "empty token",
+			token:  "",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sig, ok := domain.RefreshTokenSignature(tt.token)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantSig, sig)
+			} else {
+				assert.Empty(t, sig)
+			}
+		})
+	}
+}

--- a/internal/domain/validation.go
+++ b/internal/domain/validation.go
@@ -73,6 +73,16 @@ type RevokeRequest struct {
 	Token string `json:"token" validate:"required"`
 }
 
+// LogoutRequest is the optional request body for POST /auth/logout. The
+// refresh token isn't required — logout always revokes the access token via
+// the Redis blocklist — but if the caller supplies the refresh token issued
+// alongside it, its DB row is also marked revoked so introspection reflects
+// the logout (GH-486). Not run through the shared validator middleware since
+// the field is optional and an empty/absent body is valid.
+type LogoutRequest struct {
+	RefreshToken string `json:"refresh_token,omitempty"`
+}
+
 // PasswordChangeRequest is the validated request body for changing a password (authenticated).
 type PasswordChangeRequest struct {
 	OldPassword string `json:"old_password" validate:"required"`

--- a/internal/token/service.go
+++ b/internal/token/service.go
@@ -56,6 +56,14 @@ type UserLookup interface {
 	FindByID(ctx context.Context, tenantID uuid.UUID, id string) (*domain.User, error)
 }
 
+// RefreshTokenStore abstracts the Postgres bookkeeping for refresh token
+// signatures performed during rotation. This is a narrow interface satisfied
+// by storage.RefreshTokenRepository.
+type RefreshTokenStore interface {
+	Store(ctx context.Context, tenantID uuid.UUID, signature, userID string, expiresAt time.Time) error
+	Revoke(ctx context.Context, tenantID uuid.UUID, signature string) error
+}
+
 // Service implements api.TokenService and middleware.TokenValidator.
 type Service struct {
 	logger        *zap.Logger
@@ -67,6 +75,7 @@ type Service struct {
 	publicKey     crypto.PublicKey
 	signingMethod jwt.SigningMethod
 	users         UserLookup
+	refreshTokens RefreshTokenStore
 	kid           string
 }
 
@@ -139,6 +148,16 @@ func (s *Service) SetUserLookup(users UserLookup) {
 	s.users = users
 }
 
+// SetRefreshTokenStore injects the Postgres refresh-token repository used to
+// keep introspection state truthful across rotation: on refresh, the old
+// signature's row is marked revoked and the new signature's row is inserted
+// (GH-486). Optional: if unset, rotation stays Redis-only and Postgres
+// introspection state goes stale until the old row's original TTL expires.
+// Injected post-construction, mirroring SetUserLookup.
+func (s *Service) SetRefreshTokenStore(store RefreshTokenStore) {
+	s.refreshTokens = store
+}
+
 // IssueTokenPair generates an access/refresh token pair for the given subject.
 func (s *Service) IssueTokenPair(ctx context.Context, subject string, roles, scopes []string, clientType domain.ClientType) (*api.AuthResult, error) {
 	return s.issueTokenPair(ctx, subject, roles, scopes, clientType, "")
@@ -193,13 +212,28 @@ func (s *Service) refreshInternal(ctx context.Context, rawRefreshToken, jktThumb
 	// Revoke the old refresh token (rotate).
 	s.deleteRefreshToken(ctx, rawRefreshToken)
 
+	tenantID := domain.TenantIDFromContext(ctx)
+
+	// Mark the old signature's Postgres row revoked so introspection reflects
+	// the rotation immediately rather than waiting out the row's original
+	// TTL (GH-486). Best-effort: Postgres bookkeeping must not fail the
+	// refresh — Redis (above) is already the authoritative hot-path
+	// revocation signal.
+	if s.refreshTokens != nil {
+		if oldSig, ok := domain.RefreshTokenSignature(rawRefreshToken); ok {
+			if revokeErr := s.refreshTokens.Revoke(ctx, tenantID, oldSig); revokeErr != nil {
+				s.logger.Warn("failed to revoke old refresh token signature in db",
+					zap.String("subject", subject), zap.Error(revokeErr))
+			}
+		}
+	}
+
 	// Refresh tokens carry no roles/scopes of their own, so look up the user's
 	// current roles (as of refresh time) and mirror what the login path does,
 	// otherwise refresh-minted access tokens would silently drop the roles
 	// claim and demote the user until they re-login (GH-432).
 	var roles []string
 	if s.users != nil {
-		tenantID := domain.TenantIDFromContext(ctx)
 		user, lookupErr := s.users.FindByID(ctx, tenantID, subject)
 		if lookupErr != nil {
 			s.logger.Error("failed to look up user for refresh role enrichment",
@@ -212,6 +246,17 @@ func (s *Service) refreshInternal(ctx context.Context, rawRefreshToken, jktThumb
 	result, err := s.issueTokenPair(ctx, subject, roles, nil, domain.ClientTypeUser, jktThumbprint)
 	if err != nil {
 		return nil, err
+	}
+
+	// Insert the new signature's Postgres row (best-effort, same rationale
+	// as above — mirrors the login-time store in auth.Service.Login).
+	if s.refreshTokens != nil {
+		if newSig, ok := domain.RefreshTokenSignature(result.RefreshToken); ok {
+			if storeErr := s.refreshTokens.Store(ctx, tenantID, newSig, subject, time.Now().Add(s.cfg.RefreshTokenTTL)); storeErr != nil {
+				s.logger.Warn("failed to store new refresh token signature in db",
+					zap.String("subject", subject), zap.Error(storeErr))
+			}
+		}
 	}
 
 	s.audit.LogEvent(ctx, audit.Event{

--- a/internal/token/service_test.go
+++ b/internal/token/service_test.go
@@ -827,6 +827,94 @@ func TestRefresh_UserLookupErrorFailsOpenWithNoRoles(t *testing.T) {
 	assert.Empty(t, refreshClaims.Roles)
 }
 
+// ── Refresh Token Postgres Bookkeeping (GH-486) ─────────────────────────────
+
+// TestRefresh_UpdatesPostgresBookkeeping verifies that rotation revokes the
+// old signature's Postgres row and inserts the new signature's row, using
+// the configured refresh TTL. Previously refreshInternal was Redis-only, so
+// a rotated-away token stayed introspectable as active until its original
+// row's TTL expired, and the new token was never introspectable at all.
+func TestRefresh_UpdatesPostgresBookkeeping(t *testing.T) {
+	svc, _ := newES256Service(t)
+	ctx := context.Background()
+
+	var revokedSig string
+	var storedSig, storedUserID string
+	var storedExpiry time.Time
+
+	store := &mocks.MockRefreshTokenRepository{
+		RevokeFn: func(_ context.Context, _ uuid.UUID, sig string) error {
+			revokedSig = sig
+			return nil
+		},
+		StoreFn: func(_ context.Context, _ uuid.UUID, sig, userID string, expiresAt time.Time) error {
+			storedSig = sig
+			storedUserID = userID
+			storedExpiry = expiresAt
+			return nil
+		},
+	}
+	svc.SetRefreshTokenStore(store)
+
+	result, err := svc.IssueTokenPair(ctx, "user-486", nil, nil, domain.ClientTypeUser)
+	require.NoError(t, err)
+
+	oldSig, ok := domain.RefreshTokenSignature(result.RefreshToken)
+	require.True(t, ok)
+
+	refreshResult, err := svc.Refresh(ctx, result.RefreshToken)
+	require.NoError(t, err)
+
+	newSig, ok := domain.RefreshTokenSignature(refreshResult.RefreshToken)
+	require.True(t, ok)
+
+	assert.Equal(t, oldSig, revokedSig, "old signature's row should be revoked")
+	assert.Equal(t, newSig, storedSig, "new signature's row should be stored")
+	assert.Equal(t, "user-486", storedUserID)
+	assert.WithinDuration(t, time.Now().Add(defaultCfg().RefreshTokenTTL), storedExpiry, 5*time.Second)
+}
+
+// TestRefresh_PostgresFailureDoesNotFailRefresh fault-injects both the
+// revoke and store calls to confirm Postgres bookkeeping stays best-effort:
+// the refresh grant itself must still succeed since Redis remains the
+// authoritative hot-path source.
+func TestRefresh_PostgresFailureDoesNotFailRefresh(t *testing.T) {
+	svc, _ := newES256Service(t)
+	ctx := context.Background()
+
+	store := &mocks.MockRefreshTokenRepository{
+		RevokeFn: func(_ context.Context, _ uuid.UUID, _ string) error {
+			return errors.New("db down")
+		},
+		StoreFn: func(_ context.Context, _ uuid.UUID, _, _ string, _ time.Time) error {
+			return errors.New("db down")
+		},
+	}
+	svc.SetRefreshTokenStore(store)
+
+	result, err := svc.IssueTokenPair(ctx, "user-486", nil, nil, domain.ClientTypeUser)
+	require.NoError(t, err)
+
+	refreshResult, err := svc.Refresh(ctx, result.RefreshToken)
+	require.NoError(t, err, "refresh must succeed even when Postgres bookkeeping fails")
+	require.NotNil(t, refreshResult)
+}
+
+// TestRefresh_NoPostgresStoreConfiguredStillWorks preserves refresh behavior
+// when SetRefreshTokenStore is never called (e.g. most existing tests in
+// this file): rotation stays Redis-only, same as before GH-486.
+func TestRefresh_NoPostgresStoreConfiguredStillWorks(t *testing.T) {
+	svc, _ := newES256Service(t)
+	ctx := context.Background()
+
+	result, err := svc.IssueTokenPair(ctx, "user-486", nil, nil, domain.ClientTypeUser)
+	require.NoError(t, err)
+
+	refreshResult, err := svc.Refresh(ctx, result.RefreshToken)
+	require.NoError(t, err)
+	require.NotNil(t, refreshResult)
+}
+
 // ── JWKS ─────────────────────────────────────────────────────────────────────
 
 func TestJWKS_ES256(t *testing.T) {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-486.

Closes #486

## Changes

GitHub Issue GH-486: fix(token): refresh-token introspection inverted — full token stored as signature, rotation never updates Postgres

# GH-486

**Created:** 2026-08-30
**Status:** 🚀 Dispatched to Pilot
**Pilot issue:** https://github.com/qf-studio/auth-service/issues/486

## Problem

Refresh-token introspection reports inverted state. The valid, current refresh token always introspects `active:false`; a rotated-away (dead) token introspects `active:true` until its original 24h row expires. Two root causes: the login path stores the **full** token where the schema expects only the signature segment, and the rotation path never touches Postgres at all.

## Context

- **Storage bug**: `internal/auth/service.go:365-367` calls `s.tokens.Store(ctx, tenantID, result.RefreshToken, user.ID, time.Now().Add(24*time.Hour))` — passing the whole `qf_rt_<key>.<sig>` string as the `signature` param. `PostgresRefreshTokenRepository.Store` (`internal/storage/refresh_token_repository.go:44-47`) inserts it verbatim.
- **Lookup**: `internal/admin/token_service.go:119-152` (`introspectRefreshToken`) strips `qf_rt_`, splits on `.`, and looks up **only** `parts[1]` via `FindBySignature` → never matches the stored full token → `active:false` for every live token.
- **Rotation gap**: `refreshInternal` (`internal/token/service.go:187-224`) is Redis-only (`rt_sig:` keys). It deletes the old Redis entry and mints a new pair without inserting the new signature into Postgres or revoking/deleting the old row. The `internal/auth/service.go:366` login-time insert is the **only** production writer. `revoked_at` is never set by anything.
- Table (`000004` + `000015`): `signature` (PK), `tenant_id`, `user_id`, `expires_at`, `created_at`, `revoked_at`.
- The hardcoded `24*time.Hour` at the Store call also ignores the configured refresh TTL.

## Task

1. **Login path** (`internal/auth/service.go`): store only the signature segment (strip `qf_rt_`, split on `.`, take `parts[1]`) — add a small shared helper (e.g. `domain.RefreshTokenSignature(token string) (string, bool)`) rather than duplicating the split logic, since `internal/admin/token_service.go:125-130` already does the same parse. Use the configured refresh-token TTL for `expiresAt` instead of hardcoded 24h.
2. **Rotation path** (`internal/token/service.go`): give `token.Service` an optional refresh-token store (setter-injection mirroring `SetUserLookup`, wired from `cmd/server/main.go` with the existing `storage.NewPostgresRefreshTokenRepository`). In `refreshInternal`: mark the old signature's row revoked (or delete it) and insert the new signature's row. Best-effort with logged errors — Postgres bookkeeping must not fail the refresh itself (matches the login path's best-effort comment).
3. **Logout** (`/auth/logout`, `/auth/logout/all` paths in `internal/auth/service.go`): mark the corresponding row(s) revoked (add `Revoke(ctx, tenantID, signature)` / `RevokeAllForUser(ctx, tenantID, userID)` to the repository as needed) so introspection reflects logout.

## Technical Decisions

- Postgres stays the introspection/audit source; Redis stays the hot-path validation source. This issue only makes the Postgres bookkeeping truthful — it does NOT add Postgres checks to the token validation hot path (reuse detection is a separate, unissued gap).
- Prefer `revoked_at` marking over row deletion for old/rotated/logged-out tokens: keeps an audit trail and `IsRevoked()` already exists on the domain type.

## Acceptance criteria

- Integration test: login → introspect current refresh token → `active:true` with correct `sub`/`exp`/`iat`; refresh → old token introspects `active:false`, new token `active:true`; logout → `active:false`.
- Unit tests for the signature-parse helper (well-formed, missing dot, empty sig, wrong prefix).
- Refresh still succeeds when the Postgres write fails (fault-injected repo mock) — error logged, not returned.
- Existing token/auth tests stay green; `go test ./...` and `golangci-lint run` clean.

## Non-goals

Refresh-token reuse detection / family revocation; consulting Postgres revocation during `validateRefreshToken` (Redis remains authoritative for the hot path); RFC 7009 revocation endpoint; retention/cleanup of expired rows.

## Refs

Found via external review 003 (mads feature inventory, verified 2026-08-30 against `f9494e2`).